### PR TITLE
Create an initial db actor

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use scylla::client::session::Session;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::debug_span;
+use tracing::Instrument;
+
+pub(crate) enum Db {
+    #[allow(dead_code)]
+    DummyTemp,
+}
+
+#[allow(dead_code)]
+pub(crate) trait DbExt {}
+
+impl DbExt for mpsc::Sender<Db> {}
+
+pub(crate) async fn new(db_session: Arc<Session>) -> anyhow::Result<mpsc::Sender<Db>> {
+    let statements = Arc::new(Statements::new(db_session).await?);
+    let (tx, mut rx) = mpsc::channel(10);
+    tokio::spawn(
+        async move {
+            while let Some(msg) = rx.recv().await {
+                tokio::spawn(process(Arc::clone(&statements), msg));
+            }
+        }
+        .instrument(debug_span!("db")),
+    );
+    Ok(tx)
+}
+
+async fn process(_statements: Arc<Statements>, msg: Db) {
+    match msg {
+        Db::DummyTemp => unreachable!(),
+    }
+}
+
+#[allow(dead_code)]
+struct Statements {
+    session: Arc<Session>,
+}
+
+impl Statements {
+    async fn new(session: Arc<Session>) -> anyhow::Result<Self> {
+        Ok(Self { session })
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::db::Db;
 use crate::modify_indexes::ModifyIndexes;
 use crate::modify_indexes::ModifyIndexesExt;
 use crate::Connectivity;
@@ -89,6 +90,7 @@ impl IndexExt for mpsc::Sender<Index> {
 pub(crate) fn new(
     id: IndexId,
     modify_actor: mpsc::Sender<ModifyIndexes>,
+    _db: mpsc::Sender<Db>,
     dimensions: Dimensions,
     connectivity: Connectivity,
     expansion_add: ExpansionAdd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Proprietary
  */
 
+mod db;
 mod engine;
 mod httproutes;
 mod httpserver;
@@ -313,7 +314,8 @@ pub async fn run(
             .build_global()?;
     }
     let db_session = new_db_session(scylladb_uri).await?;
-    let engine_actor = engine::new(db_session).await?;
+    let db_actor = db::new(Arc::clone(&db_session)).await?;
+    let engine_actor = engine::new(db_session, db_actor).await?;
     httpserver::new(addr, engine_actor).await
 }
 

--- a/src/modify_indexes.rs
+++ b/src/modify_indexes.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::db;
 use crate::IndexId;
 use crate::IndexItemsCount;
 use anyhow::Context;
@@ -44,7 +45,10 @@ impl ModifyIndexesExt for Sender<ModifyIndexes> {
     }
 }
 
-pub(crate) async fn new(db_session: Arc<Session>) -> anyhow::Result<Sender<ModifyIndexes>> {
+pub(crate) async fn new(
+    db_session: Arc<Session>,
+    _db_actor: Sender<db::Db>,
+) -> anyhow::Result<Sender<ModifyIndexes>> {
     let db = Db::new(db_session).await?;
 
     // The value was taken from initial benchmarks

--- a/src/monitor_indexes.rs
+++ b/src/monitor_indexes.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::db;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::ColumnName;
@@ -37,6 +38,7 @@ pub(crate) enum MonitorIndexes {}
 
 pub(crate) async fn new(
     db_session: Arc<Session>,
+    _db_actor: Sender<db::Db>,
     engine: Sender<Engine>,
 ) -> anyhow::Result<Sender<MonitorIndexes>> {
     let db = Db::new(db_session).await?;

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::db;
 use crate::index::Index;
 use crate::index::IndexExt;
 use crate::Embeddings;
@@ -30,6 +31,7 @@ pub(crate) enum MonitorItems {}
 
 pub(crate) async fn new(
     db_session: Arc<Session>,
+    _db_actor: Sender<db::Db>,
     metadata: IndexMetadata,
     index: Sender<Index>,
 ) -> anyhow::Result<Sender<MonitorItems>> {


### PR DESCRIPTION
The change is the start of moving db functionality into separate actors, so that it will be easy to mockup db api for integration test. See #3. It implements an initial actor for general db queries.