### PR TITLE
Create an initial db-index actor

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -3,21 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::db_index;
+use crate::db_index::DbIndex;
+use crate::IndexMetadata;
 use scylla::client::session::Session;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tracing::debug_span;
+use tracing::warn;
 use tracing::Instrument;
 
 pub(crate) enum Db {
-    #[allow(dead_code)]
-    DummyTemp,
+    #[allow(clippy::enum_variant_names)]
+    GetIndexDb {
+        metadata: IndexMetadata,
+        tx: oneshot::Sender<anyhow::Result<mpsc::Sender<DbIndex>>>,
+    },
 }
 
-#[allow(dead_code)]
-pub(crate) trait DbExt {}
+pub(crate) trait DbExt {
+    async fn get_index_db(&self, metadata: IndexMetadata) -> anyhow::Result<mpsc::Sender<DbIndex>>;
+}
 
-impl DbExt for mpsc::Sender<Db> {}
+impl DbExt for mpsc::Sender<Db> {
+    async fn get_index_db(&self, metadata: IndexMetadata) -> anyhow::Result<mpsc::Sender<DbIndex>> {
+        let (tx, rx) = oneshot::channel();
+        self.send(Db::GetIndexDb { metadata, tx }).await?;
+        rx.await?
+    }
+}
 
 pub(crate) async fn new(db_session: Arc<Session>) -> anyhow::Result<mpsc::Sender<Db>> {
     let statements = Arc::new(Statements::new(db_session).await?);
@@ -33,9 +48,11 @@ pub(crate) async fn new(db_session: Arc<Session>) -> anyhow::Result<mpsc::Sender
     Ok(tx)
 }
 
-async fn process(_statements: Arc<Statements>, msg: Db) {
+async fn process(statements: Arc<Statements>, msg: Db) {
     match msg {
-        Db::DummyTemp => unreachable!(),
+        Db::GetIndexDb { metadata, tx } => tx
+            .send(statements.get_index_db(metadata).await)
+            .unwrap_or_else(|_| warn!("db::process: Db::GetIndexDb: unable to send response")),
     }
 }
 
@@ -47,5 +64,9 @@ struct Statements {
 impl Statements {
     async fn new(session: Arc<Session>) -> anyhow::Result<Self> {
         Ok(Self { session })
+    }
+
+    async fn get_index_db(&self, metadata: IndexMetadata) -> anyhow::Result<mpsc::Sender<DbIndex>> {
+        db_index::new(Arc::clone(&self.session), metadata).await
     }
 }

--- a/src/db_index.rs
+++ b/src/db_index.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::IndexMetadata;
+use scylla::client::session::Session;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::{debug_span, Instrument};
+
+pub(crate) enum DbIndex {}
+
+#[allow(dead_code)]
+pub(crate) trait DbIndexExt {}
+
+impl DbIndexExt for mpsc::Sender<DbIndex> {}
+
+pub(crate) async fn new(
+    db_session: Arc<Session>,
+    metadata: IndexMetadata,
+) -> anyhow::Result<mpsc::Sender<DbIndex>> {
+    let statements = Arc::new(Statements::new(db_session, metadata).await?);
+    let (tx, mut rx) = mpsc::channel(10);
+    tokio::spawn(
+        async move {
+            while let Some(msg) = rx.recv().await {
+                tokio::spawn(process(Arc::clone(&statements), msg));
+            }
+        }
+        .instrument(debug_span!("db_index")),
+    );
+    Ok(tx)
+}
+
+async fn process(_statements: Arc<Statements>, msg: DbIndex) {
+    match msg {}
+}
+
+#[allow(dead_code)]
+struct Statements {
+    session: Arc<Session>,
+}
+
+impl Statements {
+    async fn new(session: Arc<Session>, _metadata: IndexMetadata) -> anyhow::Result<Self> {
+        Ok(Self { session })
+    }
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::db::Db;
+use crate::db::DbExt;
 use crate::index;
 use crate::index::Index;
 use crate::modify_indexes;
@@ -119,9 +120,15 @@ pub(crate) async fn new(
                         continue;
                     };
 
+                    let Ok(db_index) = db.get_index_db(metadata.clone()).await.inspect_err(|err| {
+                        error!("unable to create db_index from {metadata:?}: {err}")
+                    }) else {
+                        continue;
+                    };
+
                     let Ok(monitor_actor) = monitor_items::new(
                         Arc::clone(&db_session),
-                        db.clone(),
+                        db_index.clone(),
                         metadata.clone(),
                         index_actor.clone(),
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
  */
 
 mod db;
+mod db_index;
 mod engine;
 mod httproutes;
 mod httpserver;

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::db;
+use crate::db_index::DbIndex;
 use crate::index::Index;
 use crate::index::IndexExt;
 use crate::Embeddings;
@@ -31,7 +31,7 @@ pub(crate) enum MonitorItems {}
 
 pub(crate) async fn new(
     db_session: Arc<Session>,
-    _db_actor: Sender<db::Db>,
+    _db_index: Sender<DbIndex>,
     metadata: IndexMetadata,
     index: Sender<Index>,
 ) -> anyhow::Result<Sender<MonitorItems>> {


### PR DESCRIPTION
The change implements an initial actor for db queries about a specific index and an associated table.