### PR TITLE
Move a monitor_indexes::Db::get_index_target_type into a db index actor

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -82,8 +82,7 @@ pub(crate) async fn new(
 ) -> anyhow::Result<mpsc::Sender<Engine>> {
     let (tx, mut rx) = mpsc::channel(10);
 
-    let monitor_actor =
-        monitor_indexes::new(Arc::clone(&db_session), db.clone(), tx.clone()).await?;
+    let monitor_actor = monitor_indexes::new(db.clone(), tx.clone()).await?;
     let modify_actor = modify_indexes::new(Arc::clone(&db_session), db.clone()).await?;
 
     tokio::spawn(async move {


### PR DESCRIPTION
This is a part of #3.

The change moves get_index_target_type method from monitor_indexes into a db actor. This will also remove monitor_indexes empty Db struct. Next paches will move other methods into a db actor.