### PR TITLE
Introduce a github rust worflow for CI tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,57 @@
+name: Rust
+
+on:
+  push:
+    branches:
+    - 'master'
+    - '**'
+
+  pull_request:
+    branches:
+    - 'master'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: full
+
+jobs:
+  static_checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: clippy, rustfmt
+
+    - name: Print rustc version
+      run: rustc --version
+
+    - name: Print rustfmt version
+      run: cargo fmt --version
+
+    - name: Print clippy version
+      run: cargo clippy --version
+
+    - name: Format check
+      run: cargo fmt --all -- --check
+
+    - name: Clippy check
+      run: cargo clippy --all-targets
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup rust toolchain
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+
+    - name: Print rustc version
+      run: rustc --version
+
+    - name: Run tests
+      run: cargo test --verbose
+

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::db_index;
-use crate::db_index::DbIndex;
 use crate::ColumnName;
 use crate::Connectivity;
 use crate::Dimensions;
@@ -15,6 +13,8 @@ use crate::IndexMetadata;
 use crate::IndexVersion;
 use crate::KeyspaceName;
 use crate::TableName;
+use crate::db_index;
+use crate::db_index::DbIndex;
 use anyhow::Context;
 use futures::TryStreamExt;
 use regex::Regex;
@@ -26,9 +26,9 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tracing::Instrument;
 use tracing::debug_span;
 use tracing::warn;
-use tracing::Instrument;
 use uuid::Uuid;
 
 pub(crate) enum Db {

--- a/src/db_index.rs
+++ b/src/db_index.rs
@@ -7,7 +7,7 @@ use crate::IndexMetadata;
 use scylla::client::session::Session;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{debug_span, Instrument};
+use tracing::{Instrument, debug_span};
 
 pub(crate) enum DbIndex {}
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::IndexId;
+use crate::IndexMetadata;
 use crate::db::Db;
 use crate::db::DbExt;
 use crate::index;
@@ -11,8 +13,6 @@ use crate::modify_indexes;
 use crate::modify_indexes::ModifyIndexesExt;
 use crate::monitor_indexes;
 use crate::monitor_items;
-use crate::IndexId;
-use crate::IndexMetadata;
 use scylla::client::session::Session;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::engine::Engine;
-use crate::engine::EngineExt;
-use crate::index::IndexExt;
 use crate::Distance;
 use crate::Embeddings;
 use crate::IndexId;
@@ -13,6 +10,10 @@ use crate::Key;
 use crate::KeyspaceName;
 use crate::Limit;
 use crate::TableName;
+use crate::engine::Engine;
+use crate::engine::EngineExt;
+use crate::index::IndexExt;
+use axum::Router;
 use axum::extract;
 use axum::extract::Path;
 use axum::extract::State;
@@ -20,7 +21,6 @@ use axum::http::StatusCode;
 use axum::response;
 use axum::response::IntoResponse;
 use axum::response::Response;
-use axum::Router;
 use tokio::sync::mpsc::Sender;
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::HttpServerAddr;
 use crate::engine::Engine;
 use crate::httproutes;
-use crate::HttpServerAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
-use tokio::sync::Notify;
 
 pub(crate) enum HttpServer {}
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::db::Db;
-use crate::modify_indexes::ModifyIndexes;
-use crate::modify_indexes::ModifyIndexesExt;
 use crate::Connectivity;
 use crate::Dimensions;
 use crate::Distance;
@@ -16,22 +13,25 @@ use crate::IndexId;
 use crate::IndexItemsCount;
 use crate::Key;
 use crate::Limit;
+use crate::db::Db;
+use crate::modify_indexes::ModifyIndexes;
+use crate::modify_indexes::ModifyIndexesExt;
 use anyhow::anyhow;
 use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::RwLock;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
-use std::sync::RwLock;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::time;
+use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
-use tracing::Instrument;
 use usearch::IndexOptions;
 use usearch::ScalarKind;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,23 +16,23 @@ mod monitor_items;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use scylla::cluster::metadata::ColumnType;
+use scylla::serialize::SerializationError;
 use scylla::serialize::value::SerializeValue;
 use scylla::serialize::writers::CellWriter;
 use scylla::serialize::writers::WrittenCellProof;
-use scylla::serialize::SerializationError;
 use std::borrow::Cow;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::signal;
-use utoipa::openapi::schema::Type;
+use utoipa::PartialSchema;
+use utoipa::ToSchema;
 use utoipa::openapi::KnownFormat;
 use utoipa::openapi::ObjectBuilder;
 use utoipa::openapi::RefOr;
 use utoipa::openapi::Schema;
 use utoipa::openapi::SchemaFormat;
-use utoipa::PartialSchema;
-use utoipa::ToSchema;
+use utoipa::openapi::schema::Type;
 use uuid::Uuid;
 
 #[derive(Clone, derive_more::From, derive_more::Display)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,9 @@
 
 use anyhow::anyhow;
 use std::net::ToSocketAddrs;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::EnvFilter;
 
 // Index creating/querying is CPU bound task, so that vector-store uses rayon ThreadPool for them.
 // From the start there was no need (network traffic seems to be not so high) to support more than

--- a/src/modify_indexes.rs
+++ b/src/modify_indexes.rs
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::db;
 use crate::IndexId;
 use crate::IndexItemsCount;
+use crate::db;
 use anyhow::Context;
 use scylla::client::session::Session;
 use scylla::statement::prepared::PreparedStatement;

--- a/src/monitor_indexes.rs
+++ b/src/monitor_indexes.rs
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::IndexMetadata;
 use crate::db::Db;
 use crate::db::DbExt;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
-use crate::IndexMetadata;
 use scylla::value::CqlTimeuuid;
 use std::collections::HashSet;
 use std::mem;

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::db_index::DbIndex;
-use crate::index::Index;
-use crate::index::IndexExt;
 use crate::Embeddings;
 use crate::IndexMetadata;
 use crate::Key;
+use crate::db_index::DbIndex;
+use crate::index::Index;
+use crate::index::IndexExt;
 use anyhow::Context;
 use futures::Stream;
 use futures::TryStreamExt;
@@ -21,11 +21,11 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::time;
+use tracing::Instrument;
 use tracing::debug;
 use tracing::info;
 use tracing::info_span;
 use tracing::warn;
-use tracing::Instrument;
 
 pub(crate) enum MonitorItems {}
 


### PR DESCRIPTION
CI should use github actions for static checks and for tests. This change introduces fmt, clippy and build checks as static_checks and running all tests as tests. It contains also all necessary fixes in formatting to pass these tests.

Fixes: #4