### PR TITLE
Move a monitor_items::Db::get_processed_ids into a db index actor

### DIFF
--- a/src/db_index.rs
+++ b/src/db_index.rs
@@ -3,18 +3,45 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::IndexMetadata;
+use crate::Key;
+use crate::TableName;
+use anyhow::Context;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use futures::stream::BoxStream;
 use scylla::client::session::Session;
+use scylla::errors::NextRowError;
+use scylla::statement::prepared::PreparedStatement;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{Instrument, debug_span};
+use tokio::sync::oneshot;
+use tracing::Instrument;
+use tracing::debug_span;
+use tracing::warn;
 
-pub(crate) enum DbIndex {}
+pub(crate) enum DbIndex {
+    GetProcessedIds {
+        tx: oneshot::Sender<anyhow::Result<BoxStream<'static, Result<Key, NextRowError>>>>,
+    },
+}
 
-#[allow(dead_code)]
-pub(crate) trait DbIndexExt {}
+pub(crate) trait DbIndexExt {
+    async fn get_processed_ids(
+        &self,
+    ) -> anyhow::Result<BoxStream<'static, Result<Key, NextRowError>>>;
+}
 
-impl DbIndexExt for mpsc::Sender<DbIndex> {}
+impl DbIndexExt for mpsc::Sender<DbIndex> {
+    async fn get_processed_ids(
+        &self,
+    ) -> anyhow::Result<BoxStream<'static, Result<Key, NextRowError>>> {
+        let (tx, rx) = oneshot::channel();
+        self.send(DbIndex::GetProcessedIds { tx }).await?;
+        rx.await?
+    }
+}
 
 pub(crate) async fn new(
     db_session: Arc<Session>,
@@ -33,17 +60,56 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
-async fn process(_statements: Arc<Statements>, msg: DbIndex) {
-    match msg {}
+async fn process(statements: Arc<Statements>, msg: DbIndex) {
+    match msg {
+        DbIndex::GetProcessedIds { tx } => tx
+            .send(statements.get_processed_ids().await)
+            .unwrap_or_else(|_| {
+                warn!("db_index::process: Db::GetProcessedIds: unable to send response")
+            }),
+    }
 }
 
-#[allow(dead_code)]
 struct Statements {
     session: Arc<Session>,
+    st_get_processed_ids: PreparedStatement,
 }
 
 impl Statements {
-    async fn new(session: Arc<Session>, _metadata: IndexMetadata) -> anyhow::Result<Self> {
-        Ok(Self { session })
+    async fn new(session: Arc<Session>, metadata: IndexMetadata) -> anyhow::Result<Self> {
+        Ok(Self {
+            st_get_processed_ids: session
+                .prepare(Self::get_processed_ids_query(
+                    &metadata.table_name,
+                    &metadata.key_name,
+                ))
+                .await
+                .context("get_processed_ids_query")?,
+
+            session,
+        })
+    }
+
+    fn get_processed_ids_query(table: &TableName, col_id: &ColumnName) -> String {
+        format!(
+            "
+            SELECT {col_id}
+            FROM {table}
+            WHERE processed = TRUE
+            LIMIT 1000
+            "
+        )
+    }
+
+    async fn get_processed_ids(
+        &self,
+    ) -> anyhow::Result<BoxStream<'static, Result<Key, NextRowError>>> {
+        Ok(self
+            .session
+            .execute_iter(self.st_get_processed_ids.clone(), ())
+            .await?
+            .rows_stream::<(i64,)>()?
+            .map_ok(|(key,)| (key as u64).into())
+            .boxed())
     }
 }


### PR DESCRIPTION
This is a part of #3.

The change moves get_processed_ids method from monitor_tems into a db index actor. Next paches will move other methods into a db index actor.