### PR TITLE
Enable merge_group trigger for github rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,8 @@ on:
     branches:
     - 'master'
 
+  merge_group:
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings


### PR DESCRIPTION
Introducing GitHub merge queues needs support from workflows to be triggered by merge_group tirgger.

Fixes: #27