### PR TITLE
Move a monitor_items::Db::update_items into a db index actor

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -11,9 +11,7 @@ use crate::index;
 use crate::index::Index;
 use crate::monitor_indexes;
 use crate::monitor_items;
-use scylla::client::session::Session;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tracing::error;
@@ -74,10 +72,7 @@ impl EngineExt for mpsc::Sender<Engine> {
     }
 }
 
-pub(crate) async fn new(
-    db_session: Arc<Session>,
-    db: mpsc::Sender<Db>,
-) -> anyhow::Result<mpsc::Sender<Engine>> {
+pub(crate) async fn new(db: mpsc::Sender<Db>) -> anyhow::Result<mpsc::Sender<Engine>> {
     let (tx, mut rx) = mpsc::channel(10);
 
     let monitor_actor = monitor_indexes::new(db.clone(), tx.clone()).await?;
@@ -122,9 +117,7 @@ pub(crate) async fn new(
                     };
 
                     let Ok(monitor_actor) = monitor_items::new(
-                        Arc::clone(&db_session),
                         db_index.clone(),
-                        metadata.clone(),
                         index_actor.clone(),
                     )
                     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,8 +314,8 @@ pub async fn run(
             .build_global()?;
     }
     let db_session = new_db_session(scylladb_uri).await?;
-    let db_actor = db::new(Arc::clone(&db_session)).await?;
-    let engine_actor = engine::new(db_session, db_actor).await?;
+    let db_actor = db::new(db_session).await?;
+    let engine_actor = engine::new(db_actor).await?;
     httpserver::new(addr, engine_actor).await
 }
 

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -3,18 +3,12 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::IndexMetadata;
-use crate::Key;
 use crate::db_index::DbIndex;
 use crate::db_index::DbIndexExt;
 use crate::index::Index;
 use crate::index::IndexExt;
-use anyhow::Context;
 use futures::TryStreamExt;
-use scylla::client::session::Session;
-use scylla::statement::prepared::PreparedStatement;
 use std::mem;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
@@ -28,13 +22,9 @@ use tracing::warn;
 pub(crate) enum MonitorItems {}
 
 pub(crate) async fn new(
-    db_session: Arc<Session>,
     db_index: Sender<DbIndex>,
-    metadata: IndexMetadata,
     index: Sender<Index>,
 ) -> anyhow::Result<Sender<MonitorItems>> {
-    let db = Arc::new(Db::new(db_session, metadata).await?);
-
     // The value was taken from initial benchmarks
     const CHANNEL_SIZE: usize = 10;
     let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
@@ -65,7 +55,7 @@ pub(crate) async fn new(
                             }
                         }
                         State::Copy => {
-                            if table_to_index(&db, &db_index, &index)
+                            if table_to_index(&db_index, &index)
                                 .await
                                 .unwrap_or_else(|err| {
                                     warn!("monitor_items: unable to copy data from table to index: {err}");
@@ -90,40 +80,6 @@ enum State {
     Copy,
 }
 
-struct Db {
-    session: Arc<Session>,
-    st_update_items: PreparedStatement,
-}
-
-impl Db {
-    async fn new(session: Arc<Session>, metadata: IndexMetadata) -> anyhow::Result<Self> {
-        Ok(Self {
-            st_update_items: session
-                .prepare(Self::update_items_query(&metadata))
-                .await
-                .context("update_items_query")?,
-            session,
-        })
-    }
-
-    fn update_items_query(metadata: &IndexMetadata) -> String {
-        format!(
-            "
-            UPDATE {}.{}
-                SET processed = True
-                WHERE id IN ?
-            ",
-            metadata.keyspace_name.0, metadata.table_name.0
-        )
-    }
-    async fn update_items(&self, keys: &[Key]) -> anyhow::Result<()> {
-        self.session
-            .execute_unpaged(&self.st_update_items, (keys,))
-            .await?;
-        Ok(())
-    }
-}
-
 async fn reset_items(db_index: &Sender<DbIndex>) -> anyhow::Result<bool> {
     // The value was taken from initial benchmarks
     const CHUNK_SIZE: usize = 100;
@@ -139,11 +95,7 @@ async fn reset_items(db_index: &Sender<DbIndex>) -> anyhow::Result<bool> {
 }
 
 /// Get new embeddings from db and add to the index. Then mark embeddings in db as processed
-async fn table_to_index(
-    db: &Arc<Db>,
-    db_index: &Sender<DbIndex>,
-    index: &Sender<Index>,
-) -> anyhow::Result<bool> {
+async fn table_to_index(db_index: &Sender<DbIndex>, index: &Sender<Index>) -> anyhow::Result<bool> {
     let mut rows = db_index.get_items().await?;
 
     // The value was taken from initial benchmarks
@@ -162,12 +114,12 @@ async fn table_to_index(
             // A new chunk of processed keys is prepared. Mark them as processed in db in the
             // background.
             let processed: Vec<_> = mem::take(&mut processed);
-            let db = Arc::clone(db);
-            tokio::spawn(async move {
-                db.update_items(&processed).await.unwrap_or_else(|err| {
+            db_index
+                .update_items(processed)
+                .await
+                .unwrap_or_else(|err| {
                     warn!("monitor_items::table_to_index: unable to update items: {err}")
                 });
-            });
         }
 
         // Add the embeddings in the background
@@ -180,7 +132,7 @@ async fn table_to_index(
     }
 
     if !processed.is_empty() {
-        db.update_items(&processed).await?;
+        db_index.update_items(processed).await?;
     }
 
     if count > 0 {


### PR DESCRIPTION
This is a part of #3.

The change moves update_items method from monitor_tems into a db index actor. Db struct in monitor_items is not needed anymore, so remove it. Next patches will refactor & cleanup sources before integration tests.