### PR TITLE
Refactor target name into target_column

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -261,7 +261,7 @@ pub(crate) struct GetIndexes {
     pub(crate) keyspace: KeyspaceName,
     pub(crate) index: TableName,
     pub(crate) table: TableName,
-    pub(crate) target: ColumnName,
+    pub(crate) target_column: ColumnName,
 }
 
 impl GetIndexes {
@@ -368,7 +368,7 @@ impl Statements {
                     keyspace: keyspace.into(),
                     index: index.into(),
                     table: table.into(),
-                    target: target.into(),
+                    target_column: target.into(),
                 }))
             })
             .try_collect()

--- a/src/db_index.rs
+++ b/src/db_index.rs
@@ -149,7 +149,7 @@ impl Statements {
                 .prepare(Self::get_items_query(
                     &metadata.table_name,
                     &metadata.key_name,
-                    &metadata.target_name,
+                    &metadata.target_column,
                 ))
                 .await
                 .context("get_items_query")?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ struct IndexMetadata {
     keyspace_name: KeyspaceName,
     index_name: TableName,
     table_name: TableName,
-    target_name: ColumnName,
+    target_column: ColumnName,
     key_name: ColumnName,
     dimensions: Dimensions,
     connectivity: Connectivity,

--- a/src/monitor_indexes.rs
+++ b/src/monitor_indexes.rs
@@ -93,7 +93,11 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
         };
 
         let Some(dimensions) = db
-            .get_index_target_type(idx.keyspace.clone(), idx.table.clone(), idx.target.clone())
+            .get_index_target_type(
+                idx.keyspace.clone(),
+                idx.table.clone(),
+                idx.target_column.clone(),
+            )
             .await
             .inspect_err(|err| {
                 warn!("monitor_indexes::get_indexes: unable to get index target type: {err}")
@@ -117,7 +121,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             keyspace_name: idx.keyspace,
             index_name: idx.index,
             table_name: idx.table,
-            target_name: idx.target,
+            target_column: idx.target_column,
             key_name: "id".to_string().into(),
             dimensions,
             connectivity,


### PR DESCRIPTION
This is a part of #3.

This change renames IndexMetadata::target_name into target_column_name and GetIndexes::target into target_column. The name target_column seems a better name for a column in a table with embeddings which contains embeddings vectors.