### PR TITLE
Do not trigger CI on push to any branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - 'master'
-    - '**'
 
   pull_request:
     branches:


### PR DESCRIPTION
After added trigger for merge queue CI trigger twice rust workflow - once for push on branch and second for merge queue. Removing CI for every branch is not needed generally. If someone wants to run it for specific branch, he will enable it temporary for this specific branch.