### PR TITLE
Refactor db::GetIndex into DbCustomIndex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,20 @@ impl IndexMetadata {
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct DbCustomIndex {
+    pub(crate) keyspace: KeyspaceName,
+    pub(crate) index: TableName,
+    pub(crate) table: TableName,
+    pub(crate) target_column: ColumnName,
+}
+
+impl DbCustomIndex {
+    pub(crate) fn id(&self) -> IndexId {
+        IndexId::new(&self.keyspace, &self.index)
+    }
+}
+
 #[derive(derive_more::From)]
 pub struct HttpServerAddr(SocketAddr);
 


### PR DESCRIPTION
This is a part of #3.

This patch renames struct to show the purpose - it is a struct which holds information about a custom index. This patch moves the struct to the lib.rs as a preparation for exporting API for integration tests.