### PR TITLE
Export Db API for integration tests

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -42,7 +42,7 @@ type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;
 type GetIndexTargetTypeR = anyhow::Result<Option<Dimensions>>;
 type GetIndexParamsR = anyhow::Result<Option<(Connectivity, ExpansionAdd, ExpansionSearch)>>;
 
-pub(crate) enum Db {
+pub enum Db {
     GetDbIndex {
         metadata: IndexMetadata,
         tx: oneshot::Sender<GetDbIndexR>,

--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -63,17 +63,17 @@ async fn get_indexes(State(engine): State<Sender<Engine>>) -> response::Json<Vec
     response::Json(engine.get_index_ids().await)
 }
 
-#[derive(serde::Deserialize, utoipa::ToSchema)]
-struct PostIndexAnnRequest {
-    embeddings: Embeddings,
+#[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+pub struct PostIndexAnnRequest {
+    pub embeddings: Embeddings,
     #[serde(default)]
-    limit: Limit,
+    pub limit: Limit,
 }
 
-#[derive(serde::Serialize, utoipa::ToSchema)]
-struct PostIndexAnnResponse {
-    keys: Vec<Key>,
-    distances: Vec<Distance>,
+#[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+pub struct PostIndexAnnResponse {
+    pub keys: Vec<Key>,
+    pub distances: Vec<Distance>,
 }
 
 #[utoipa::path(

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -6,6 +6,7 @@
 use crate::HttpServerAddr;
 use crate::engine::Engine;
 use crate::httproutes;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
@@ -17,9 +18,9 @@ pub(crate) enum HttpServer {}
 pub(crate) async fn new(
     addr: HttpServerAddr,
     engine: Sender<Engine>,
-) -> anyhow::Result<Sender<HttpServer>> {
+) -> anyhow::Result<(Sender<HttpServer>, SocketAddr)> {
     let listener = TcpListener::bind(addr.0).await?;
-    tracing::info!("listening on {}", listener.local_addr()?);
+    let addr = listener.local_addr()?;
 
     // minimal size as channel is used as a lifetime guard
     const CHANNEL_SIZE: usize = 1;
@@ -44,5 +45,5 @@ pub(crate) async fn new(
             .expect("failed to run web server");
     });
 
-    Ok(tx)
+    Ok((tx, addr))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,10 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .and_then(|v| v.parse().ok());
 
-    let _server_actor =
-        vector_store::run(scylla_usearch_addr, background_threads, scylladb_uri).await?;
+    let db_actor = vector_store::new_db(scylladb_uri).await?;
+    let (_server_actor, addr) =
+        vector_store::run(scylla_usearch_addr, background_threads, db_actor).await?;
+    tracing::info!("listening on {addr}");
     vector_store::wait_for_shutdown().await;
 
     Ok(())


### PR DESCRIPTION
This is a part of #3.

This patch exports API for integration tests by adding pub visibility to them. It also adds needed interface for manipulating types and variables.

Additionally it adds a possibility to provide custom db actor - to be able to mock ScyllaDB functionality, so there is some small redesign in main.rs and lib.rs: main creates new db actor before running services.