### PR TITLE
Refactor usearch index using task per message

### DIFF
--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -122,13 +122,7 @@ async fn table_to_index(db_index: &Sender<DbIndex>, index: &Sender<Index>) -> an
                 });
         }
 
-        // Add the embeddings in the background
-        tokio::spawn({
-            let index = index.clone();
-            async move {
-                index.add(key, embeddings).await;
-            }
-        });
+        index.add(key, embeddings).await;
     }
 
     if !processed.is_empty() {


### PR DESCRIPTION
This is a part of #23.

This patch introduce internal task per each message received by usearch actor to simplify usage on consumer side.
