### PR TITLE
Introduce vector of i64s as a base for multicolumn primary keys

### DIFF
--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::Distance;
 use crate::Embeddings;
 use crate::IndexId;
@@ -10,9 +11,11 @@ use crate::Key;
 use crate::KeyspaceName;
 use crate::Limit;
 use crate::TableName;
+use crate::db_index::DbIndexExt;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::index::IndexExt;
+use anyhow::bail;
 use axum::Router;
 use axum::extract;
 use axum::extract::Path;
@@ -21,8 +24,11 @@ use axum::http::StatusCode;
 use axum::response;
 use axum::response::IntoResponse;
 use axum::response::Response;
+use itertools::Itertools;
+use std::collections::HashMap;
 use tokio::sync::mpsc::Sender;
 use tower_http::trace::TraceLayer;
+use tracing::error;
 use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
@@ -72,13 +78,13 @@ pub struct PostIndexAnnRequest {
 
 #[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 pub struct PostIndexAnnResponse {
-    pub keys: Vec<Key>,
+    pub primary_keys: HashMap<ColumnName, Vec<Key>>,
     pub distances: Vec<Distance>,
 }
 
 #[utoipa::path(
     post,
-    path = "/api/v1/indexes/{keyspace}/{table}/ann",
+    path = "/api/v1/indexes/{keyspace}/{index}/ann",
     description = "Ann search in the index",
     params(
         ("keyspace" = KeyspaceName, Path, description = "Keyspace name for the table to search"),
@@ -95,15 +101,67 @@ async fn post_index_ann(
     Path((keyspace, index)): Path<(KeyspaceName, TableName)>,
     extract::Json(request): extract::Json<PostIndexAnnRequest>,
 ) -> Response {
-    let Some(index) = engine.get_index(IndexId::new(&keyspace, &index)).await else {
+    let Some((index, db_index)) = engine.get_index(IndexId::new(&keyspace, &index)).await else {
         return (StatusCode::NOT_FOUND, "").into_response();
     };
+
     match index.ann(request.embeddings, request.limit).await {
-        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
-        Ok((keys, distances)) => (
-            StatusCode::OK,
-            response::Json(PostIndexAnnResponse { keys, distances }),
-        )
-            .into_response(),
+        Err(err) => {
+            let msg = format!("index.ann request error: {err}");
+            error!("post_index_ann: {msg}");
+            (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+        }
+
+        Ok((primary_keys, distances)) => {
+            if primary_keys.len() != distances.len() {
+                let msg = format!(
+                    "wrong size of an ann response: number of primary_keys = {}, number of distances = {}",
+                    primary_keys.len(),
+                    distances.len()
+                );
+                error!("post_index_ann: {msg}");
+                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+            } else {
+                let primary_key_columns = db_index.get_primary_key_columns().await;
+                let primary_keys: anyhow::Result<_> = primary_key_columns
+                    .iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(idx_column, column)| {
+                        let primary_keys: anyhow::Result<_> = primary_keys
+                            .iter()
+                            .map(|primary_key| {
+                                if primary_key.0.len() != primary_key_columns.len() {
+                                    bail!(
+                                        "wrong size of a primary key: {}, {}",
+                                        primary_key_columns.len(),
+                                        primary_key.0.len()
+                                    );
+                                }
+                                Ok(primary_key)
+                            })
+                            .map_ok(|primary_key| primary_key.0[idx_column])
+                            .collect();
+                        primary_keys.map(|primary_keys| (column, primary_keys))
+                    })
+                    .collect();
+
+                match primary_keys {
+                    Err(err) => {
+                        error!("post_index_ann: {err}");
+                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                    }
+
+                    Ok(primary_keys) => (
+                        StatusCode::OK,
+                        response::Json(PostIndexAnnResponse {
+                            primary_keys,
+                            distances,
+                        }),
+                    )
+                        .into_response(),
+                }
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ impl SerializeValue for TableName {
     serde::Serialize,
     serde::Deserialize,
     derive_more::Display,
+    utoipa::ToSchema,
 )]
 /// Name of the column in a db table
 pub struct ColumnName(String);
@@ -177,6 +178,9 @@ impl SerializeValue for Key {
         <i64 as SerializeValue>::serialize(&(self.0 as i64), typ, writer)
     }
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::From)]
+pub struct PrimaryKey(Vec<Key>);
 
 #[derive(
     Clone, Debug, serde::Serialize, serde::Deserialize, derive_more::From, utoipa::ToSchema,

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -98,10 +98,10 @@ async fn table_to_index(db_index: &Sender<DbIndex>, index: &Sender<Index>) -> an
     // The accumulator for number of processed embeddings
     let mut count = 0;
 
-    while let Some((key, embeddings)) = rows.try_next().await? {
+    while let Some((primary_key, embeddings)) = rows.try_next().await? {
         count += 1;
-        db_index.update_item(key).await?;
-        index.add(key, embeddings).await;
+        db_index.update_item(primary_key.clone()).await?;
+        index.add(primary_key, embeddings).await;
     }
 
     if count > 0 {

--- a/tests/integration/httpclient.rs
+++ b/tests/integration/httpclient.rs
@@ -4,7 +4,9 @@
  */
 
 use reqwest::Client;
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use vector_store::ColumnName;
 use vector_store::Distance;
 use vector_store::Embeddings;
 use vector_store::IndexId;
@@ -43,7 +45,7 @@ impl HttpClient {
         index: &IndexMetadata,
         embeddings: Embeddings,
         limit: Limit,
-    ) -> (Vec<Key>, Vec<Distance>) {
+    ) -> (HashMap<ColumnName, Vec<Key>>, Vec<Distance>) {
         let resp = self
             .client
             .post(format!(
@@ -57,6 +59,6 @@ impl HttpClient {
             .json::<PostIndexAnnResponse>()
             .await
             .unwrap();
-        (resp.keys, resp.distances)
+        (resp.primary_keys, resp.distances)
     }
 }


### PR DESCRIPTION
This is a part of #23.

This is first step in introduction multicolumn primary keys. This change introduces a vector storage of i64s for a primary key as a collection of several columns. Currently it will use only first item in this vector (the size will be always 1) - the one which is retrieved from IndexMetadata. In the next patch there will be support more dimensions. It changes HTTP API according to this change also.
