### PR TITLE
Remove update_item & reset_item from db index actor

### DIFF
--- a/src/db_index.rs
+++ b/src/db_index.rs
@@ -26,7 +26,6 @@ use scylla::errors::TypeCheckError;
 use scylla::frame::response::result::ColumnSpec;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
-use scylla::value::Row;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -34,15 +33,10 @@ use tracing::Instrument;
 use tracing::debug_span;
 use tracing::warn;
 
-type GetProcessedIdsR = anyhow::Result<BoxStream<'static, anyhow::Result<PrimaryKey>>>;
 type GetItemsR = anyhow::Result<BoxStream<'static, anyhow::Result<(PrimaryKey, Embeddings)>>>;
 type GetPrimaryKeyColumnsR = Vec<ColumnName>;
 
 pub enum DbIndex {
-    GetProcessedIds {
-        tx: oneshot::Sender<GetProcessedIdsR>,
-    },
-
     GetItems {
         tx: oneshot::Sender<GetItemsR>,
     },
@@ -50,35 +44,15 @@ pub enum DbIndex {
     GetPrimaryKeyColumns {
         tx: oneshot::Sender<GetPrimaryKeyColumnsR>,
     },
-
-    ResetItem {
-        primary_key: PrimaryKey,
-    },
-
-    UpdateItem {
-        primary_key: PrimaryKey,
-    },
 }
 
 pub(crate) trait DbIndexExt {
-    async fn get_processed_ids(&self) -> GetProcessedIdsR;
-
     async fn get_items(&self) -> GetItemsR;
 
     async fn get_primary_key_columns(&self) -> GetPrimaryKeyColumnsR;
-
-    async fn reset_item(&self, primary_key: PrimaryKey) -> anyhow::Result<()>;
-
-    async fn update_item(&self, primary_key: PrimaryKey) -> anyhow::Result<()>;
 }
 
 impl DbIndexExt for mpsc::Sender<DbIndex> {
-    async fn get_processed_ids(&self) -> GetProcessedIdsR {
-        let (tx, rx) = oneshot::channel();
-        self.send(DbIndex::GetProcessedIds { tx }).await?;
-        rx.await?
-    }
-
     async fn get_items(&self) -> GetItemsR {
         let (tx, rx) = oneshot::channel();
         self.send(DbIndex::GetItems { tx }).await?;
@@ -99,16 +73,6 @@ impl DbIndexExt for mpsc::Sender<DbIndex> {
             warn!("db_index::get_primary_key_columns: unable to recv internal message: {err}");
             Vec::new()
         })
-    }
-
-    async fn reset_item(&self, primary_key: PrimaryKey) -> anyhow::Result<()> {
-        self.send(DbIndex::ResetItem { primary_key }).await?;
-        Ok(())
-    }
-
-    async fn update_item(&self, primary_key: PrimaryKey) -> anyhow::Result<()> {
-        self.send(DbIndex::UpdateItem { primary_key }).await?;
-        Ok(())
     }
 }
 
@@ -131,12 +95,6 @@ pub(crate) async fn new(
 
 async fn process(statements: Arc<Statements>, msg: DbIndex) {
     match msg {
-        DbIndex::GetProcessedIds { tx } => tx
-            .send(statements.get_processed_ids().await)
-            .unwrap_or_else(|_| {
-                warn!("db_index::process: Db::GetProcessedIds: unable to send response")
-            }),
-
         DbIndex::GetItems { tx } => tx
             .send(statements.get_items().await)
             .unwrap_or_else(|_| warn!("db_index::process: Db::GetItems: unable to send response")),
@@ -146,16 +104,6 @@ async fn process(statements: Arc<Statements>, msg: DbIndex) {
             .unwrap_or_else(|_| {
                 warn!("db_index::process: Db::GetPrimaryKeyColumns: unable to send response")
             }),
-
-        DbIndex::ResetItem { primary_key } => statements
-            .reset_item(primary_key)
-            .await
-            .unwrap_or_else(|err| warn!("db_index::process: Db::ResetItem: {err}")),
-
-        DbIndex::UpdateItem { primary_key } => statements
-            .update_item(primary_key)
-            .await
-            .unwrap_or_else(|err| warn!("db_index::process: Db::UpdateItem: {err}")),
     }
 }
 
@@ -217,10 +165,7 @@ impl<'frame, 'metadata> DeserializeRow<'frame, 'metadata> for PrimaryKeyWithEmbe
 struct Statements {
     session: Arc<Session>,
     primary_key_columns: Vec<ColumnName>,
-    st_get_processed_ids: PreparedStatement,
     st_get_items: PreparedStatement,
-    st_reset_item: PreparedStatement,
-    st_update_item: PreparedStatement,
 }
 
 impl Statements {
@@ -243,22 +188,8 @@ impl Statements {
 
         let st_primary_key_select = primary_key_columns.iter().join(", ");
 
-        let st_primary_key_where = primary_key_columns
-            .iter()
-            .map(|column| format!("{column} = ?"))
-            .join(" AND ");
-
         Ok(Self {
             primary_key_columns,
-
-            st_get_processed_ids: session
-                .prepare(Self::get_processed_ids_query(
-                    &metadata.keyspace_name,
-                    &metadata.table_name,
-                    &st_primary_key_select,
-                ))
-                .await
-                .context("get_processed_ids_query")?,
 
             st_get_items: session
                 .prepare(Self::get_items_query(
@@ -270,62 +201,12 @@ impl Statements {
                 .await
                 .context("get_items_query")?,
 
-            st_reset_item: session
-                .prepare(Self::reset_item_query(
-                    &metadata.keyspace_name,
-                    &metadata.table_name,
-                    &st_primary_key_where,
-                ))
-                .await
-                .context("reset_items_query")?,
-
-            st_update_item: session
-                .prepare(Self::update_item_query(
-                    &metadata.keyspace_name,
-                    &metadata.table_name,
-                    &st_primary_key_where,
-                ))
-                .await
-                .context("update_item_query")?,
-
             session,
         })
     }
 
     fn get_primary_key_columns(&self) -> Vec<ColumnName> {
         self.primary_key_columns.clone()
-    }
-
-    fn get_processed_ids_query(
-        keyspace: &KeyspaceName,
-        table: &TableName,
-        st_primary_key_select: &str,
-    ) -> String {
-        format!(
-            "
-            SELECT {st_primary_key_select}
-            FROM {keyspace}.{table}
-            WHERE processed = TRUE
-            LIMIT 1000
-            "
-        )
-    }
-
-    async fn get_processed_ids(&self) -> GetProcessedIdsR {
-        Ok(self
-            .session
-            .execute_iter(self.st_get_processed_ids.clone(), ())
-            .await?
-            .rows_stream::<Row>()?
-            .map_err(|err| err.into())
-            .and_then(|row| async move {
-                row.columns
-                    .into_iter()
-                    .map(|col| col.ok_or_else(|| anyhow!("missing value for a primary key")))
-                    .collect::<anyhow::Result<Vec<_>>>()
-                    .map(PrimaryKey::from)
-            })
-            .boxed())
     }
 
     fn get_items_query(
@@ -338,7 +219,6 @@ impl Statements {
             "
             SELECT {st_primary_key_select}, {embeddings}
             FROM {keyspace}.{table}
-            WHERE processed = FALSE
             "
         )
     }
@@ -352,47 +232,5 @@ impl Statements {
             .map_err(|err| err.into())
             .map_ok(|row| (row.primary_key, row.embeddings))
             .boxed())
-    }
-
-    fn reset_item_query(
-        keyspace: &KeyspaceName,
-        table: &TableName,
-        st_primary_key_where: &str,
-    ) -> String {
-        format!(
-            "
-            UPDATE {keyspace}.{table}
-                SET processed = False
-                WHERE {st_primary_key_where}
-            "
-        )
-    }
-
-    async fn reset_item(&self, primary_key: PrimaryKey) -> anyhow::Result<()> {
-        self.session
-            .execute_unpaged(&self.st_reset_item, primary_key.0)
-            .await?;
-        Ok(())
-    }
-
-    fn update_item_query(
-        keyspace: &KeyspaceName,
-        table: &TableName,
-        st_primary_key_where: &str,
-    ) -> String {
-        format!(
-            "
-            UPDATE {keyspace}.{table}
-                SET processed = True
-                WHERE {st_primary_key_where}
-            "
-        )
-    }
-
-    async fn update_item(&self, primary_key: PrimaryKey) -> anyhow::Result<()> {
-        self.session
-            .execute_unpaged(&self.st_update_item, primary_key.0)
-            .await?;
-        Ok(())
     }
 }


### PR DESCRIPTION
This is a part of #54.

A read path from the ScyllaDB was implemented with a workaround using a special boolean field in a table with embeddings. This patch removes update & reset item functionalities (and other supporting functions) as they will be no longer in use when full scan & CDC support will be implemented.