### PR TITLE
Implement retrieval of a size of an index

### DIFF
--- a/src/index/actor.rs
+++ b/src/index/actor.rs
@@ -12,6 +12,7 @@ use tokio::sync::oneshot;
 use tracing::warn;
 
 pub(crate) type AnnR = anyhow::Result<(Vec<PrimaryKey>, Vec<Distance>)>;
+pub(crate) type CountR = anyhow::Result<usize>;
 
 pub(crate) enum Index {
     Add {
@@ -23,11 +24,15 @@ pub(crate) enum Index {
         limit: Limit,
         tx: oneshot::Sender<AnnR>,
     },
+    Count {
+        tx: oneshot::Sender<CountR>,
+    },
 }
 
 pub(crate) trait IndexExt {
     async fn add(&self, primary_key: PrimaryKey, embeddings: Embeddings);
     async fn ann(&self, embeddings: Embeddings, limit: Limit) -> AnnR;
+    async fn count(&self) -> CountR;
 }
 
 impl IndexExt for mpsc::Sender<Index> {
@@ -48,6 +53,12 @@ impl IndexExt for mpsc::Sender<Index> {
             tx,
         })
         .await?;
+        rx.await?
+    }
+
+    async fn count(&self) -> CountR {
+        let (tx, rx) = oneshot::channel();
+        self.send(Index::Count { tx }).await?;
         rx.await?
     }
 }

--- a/src/index/usearch.rs
+++ b/src/index/usearch.rs
@@ -15,6 +15,7 @@ use crate::PrimaryKey;
 use crate::db::Db;
 use crate::db::DbExt;
 use crate::index::actor::AnnR;
+use crate::index::actor::CountR;
 use crate::index::actor::Index;
 use anyhow::anyhow;
 use bimap::BiMap;
@@ -158,6 +159,10 @@ async fn process(
         } => {
             ann(idx, tx, keys, embeddings, dimensions, limit).await;
         }
+
+        Index::Count { tx } => {
+            count(idx, tx);
+        }
     }
 }
 
@@ -289,4 +294,9 @@ async fn ann(
                 }),
         )
         .unwrap_or_else(|_| warn!("index::ann: unable to send response"));
+}
+
+fn count(idx: Arc<RwLock<usearch::Index>>, tx: oneshot::Sender<CountR>) {
+    tx.send(Ok(idx.read().unwrap().size()))
+        .unwrap_or_else(|_| warn!("index::count: unable to send response"));
 }

--- a/tests/integration/httpclient.rs
+++ b/tests/integration/httpclient.rs
@@ -61,4 +61,18 @@ impl HttpClient {
             .unwrap();
         (resp.primary_keys, resp.distances)
     }
+
+    pub(crate) async fn count(&self, index: &IndexMetadata) -> Option<usize> {
+        self.client
+            .get(format!(
+                "{}/indexes/{}/{}/count",
+                self.url_api, index.keyspace_name, index.index_name
+            ))
+            .send()
+            .await
+            .unwrap()
+            .json::<usize>()
+            .await
+            .ok()
+    }
 }

--- a/tests/integration/usearch.rs
+++ b/tests/integration/usearch.rs
@@ -99,6 +99,7 @@ async fn simple_create_search_delete_index() {
     })
     .await
     .unwrap();
+    assert_eq!(client.count(&index).await, Some(3));
 
     let indexes = client.indexes().await;
     assert_eq!(indexes.len(), 1);


### PR DESCRIPTION
This is a part of #54.

There is a need for knowledge about a specific index size, how many embeddings are stored in an index. There is a workaround for that functionality which uses a specific table/field. This patch adds HTTP API endpoint to retrieve this information from an index. It introduces an additional index actor API - an index actor is responsible for provided size of an index.
