### PR TITLE
Remove temporary storage of index parameters

### DIFF
--- a/src/monitor_indexes.rs
+++ b/src/monitor_indexes.rs
@@ -107,8 +107,10 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             continue;
         };
 
-        let (connectivity, expansion_add, expansion_search) = if let Some(params) =
-            db.get_index_params(idx.id()).await.inspect_err(|err| {
+        let (connectivity, expansion_add, expansion_search) = if let Some(params) = db
+            .get_index_params(idx.keyspace.clone(), idx.index.clone())
+            .await
+            .inspect_err(|err| {
                 warn!("monitor_indexes::get_indexes: unable to get index params: {err}")
             })? {
             params

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -289,14 +289,18 @@ fn process_db(db: &DbBasic, msg: Db) {
             .map_err(|_| anyhow!("Db::GetIndexTargetType: unable to send response"))
             .unwrap(),
 
-        Db::GetIndexParams { id, tx } => tx
+        Db::GetIndexParams {
+            keyspace,
+            index,
+            tx,
+        } => tx
             .send(Ok(db
                 .0
                 .read()
                 .unwrap()
                 .keyspaces
-                .get(&id.keyspace())
-                .and_then(|keyspace| keyspace.indexes.get(&id.index()))
+                .get(&keyspace)
+                .and_then(|keyspace| keyspace.indexes.get(&index))
                 .map(|index| {
                     (
                         index.index.connectivity,


### PR DESCRIPTION
This is a part of #54.

The old workaround for storing metadata of an index in specific table in the ScyllaDB has been removing. This patch removes getting parameters of an index from specific table and replace them with default values. Setting index parameters from the custom index in CREATE INDEX will be a part of #57.