### PR TITLE
Improve logging levels and messages

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -30,7 +30,7 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tracing::Instrument;
 use tracing::debug_span;
-use tracing::warn;
+use tracing::trace;
 use uuid::Uuid;
 
 type GetDbIndexR = anyhow::Result<mpsc::Sender<DbIndex>>;
@@ -175,17 +175,17 @@ async fn process(statements: Arc<Statements>, msg: Db) {
     match msg {
         Db::GetDbIndex { metadata, tx } => tx
             .send(statements.get_db_index(metadata).await)
-            .unwrap_or_else(|_| warn!("db::process: Db::GetDbIndex: unable to send response")),
+            .unwrap_or_else(|_| trace!("process: Db::GetDbIndex: unable to send response")),
 
         Db::LatestSchemaVersion { tx } => tx
             .send(statements.latest_schema_version().await)
             .unwrap_or_else(|_| {
-                warn!("db::process: Db::LatestSchemaVersion: unable to send response")
+                trace!("process: Db::LatestSchemaVersion: unable to send response")
             }),
 
         Db::GetIndexes { tx } => tx
             .send(statements.get_indexes().await)
-            .unwrap_or_else(|_| warn!("db::process: Db::GetIndexes: unable to send response")),
+            .unwrap_or_else(|_| trace!("process: Db::GetIndexes: unable to send response")),
 
         Db::GetIndexVersion {
             keyspace,
@@ -193,7 +193,7 @@ async fn process(statements: Arc<Statements>, msg: Db) {
             tx,
         } => tx
             .send(statements.get_index_version(keyspace, index).await)
-            .unwrap_or_else(|_| warn!("db::process: Db::GetIndexVersion: unable to send response")),
+            .unwrap_or_else(|_| trace!("process: Db::GetIndexVersion: unable to send response")),
 
         Db::GetIndexTargetType {
             keyspace,
@@ -206,7 +206,7 @@ async fn process(statements: Arc<Statements>, msg: Db) {
                     .get_index_target_type(keyspace, table, target_column)
                     .await,
             )
-            .unwrap_or_else(|_| warn!("db::process: Db::GetIndexVersion: unable to send response")),
+            .unwrap_or_else(|_| trace!("process: Db::GetIndexVersion: unable to send response")),
 
         Db::GetIndexParams {
             keyspace,
@@ -214,7 +214,7 @@ async fn process(statements: Arc<Statements>, msg: Db) {
             tx,
         } => tx
             .send(statements.get_index_params(keyspace, index).await)
-            .unwrap_or_else(|_| warn!("db::process: Db::GetIndexParams: unable to send response")),
+            .unwrap_or_else(|_| trace!("process: Db::GetIndexParams: unable to send response")),
     }
 }
 

--- a/src/index/actor.rs
+++ b/src/index/actor.rs
@@ -9,7 +9,6 @@ use crate::Limit;
 use crate::PrimaryKey;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
-use tracing::warn;
 
 pub(crate) type AnnR = anyhow::Result<(Vec<PrimaryKey>, Vec<Distance>)>;
 pub(crate) type CountR = anyhow::Result<usize>;
@@ -42,7 +41,7 @@ impl IndexExt for mpsc::Sender<Index> {
             embeddings,
         })
         .await
-        .unwrap_or_else(|err| warn!("IndexExt::add: unable to send request: {err}"));
+        .expect("internal actor should receive request");
     }
 
     async fn ann(&self, embeddings: Embeddings, limit: Limit) -> AnnR {


### PR DESCRIPTION
This is a part of #54.

This patch cleans up logging levels - error, warn & info should be used with messages meaningful for administrators, debug & trace could store more debugging information, useful rather for developers.