### PR TITLE
Refactor reading embeddings as a channel

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -6,6 +6,7 @@
 use crate::ColumnName;
 use crate::Connectivity;
 use crate::DbCustomIndex;
+use crate::DbEmbeddings;
 use crate::Dimensions;
 use crate::ExpansionAdd;
 use crate::ExpansionSearch;
@@ -33,7 +34,7 @@ use tracing::debug_span;
 use tracing::trace;
 use uuid::Uuid;
 
-type GetDbIndexR = anyhow::Result<mpsc::Sender<DbIndex>>;
+type GetDbIndexR = anyhow::Result<(mpsc::Sender<DbIndex>, mpsc::Receiver<DbEmbeddings>)>;
 type LatestSchemaVersionR = anyhow::Result<Option<CqlTimeuuid>>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;
 type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -119,7 +119,7 @@ pub(crate) async fn new(db: mpsc::Sender<Db>) -> anyhow::Result<mpsc::Sender<Eng
                             continue;
                         };
 
-                        let Ok(db_index) =
+                        let Ok((db_index, embeddings_stream)) =
                             db.get_db_index(metadata.clone()).await.inspect_err(|err| {
                                 error!("unable to create a db monitoring task for an index {id}: {err}")
                             })
@@ -128,7 +128,7 @@ pub(crate) async fn new(db: mpsc::Sender<Db>) -> anyhow::Result<mpsc::Sender<Eng
                         };
 
                         let Ok(monitor_actor) =
-                            monitor_items::new(db_index.clone(), id.clone(), index_actor.clone())
+                            monitor_items::new(id.clone(), embeddings_stream, index_actor.clone())
                                 .await
                                 .inspect_err(|err| {
                                     error!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,6 +349,12 @@ impl DbCustomIndex {
     }
 }
 
+#[derive(Debug)]
+pub struct DbEmbeddings {
+    pub primary_key: PrimaryKey,
+    pub embeddings: Embeddings,
+}
+
 #[derive(derive_more::From)]
 pub struct HttpServerAddr(SocketAddr);
 

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -3,25 +3,22 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::DbEmbeddings;
 use crate::IndexId;
-use crate::db_index::DbIndex;
-use crate::db_index::DbIndexExt;
 use crate::index::Index;
 use crate::index::IndexExt;
-use futures::TryStreamExt;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
-use tracing::warn;
 
 pub(crate) enum MonitorItems {}
 
 pub(crate) async fn new(
-    db_index: Sender<DbIndex>,
     id: IndexId,
+    mut embeddings: Receiver<DbEmbeddings>,
     index: Sender<Index>,
 ) -> anyhow::Result<Sender<MonitorItems>> {
     // The value was taken from initial benchmarks
@@ -29,47 +26,24 @@ pub(crate) async fn new(
     let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
 
     tokio::spawn(
-        {
-            let id = id.clone();
-            async move {
-                debug!("starting");
+        async move {
+            debug!("starting");
 
-                initial_read(&mut rx, &db_index, &index)
-                    .await
-                    .unwrap_or_else(|err| {
-                        warn!("unable to do initial read from db for {id}: {err}");
-                    });
-
-                while rx.recv().await.is_some() {}
-
-                debug!("finished");
+            while !rx.is_closed() {
+                tokio::select! {
+                    embeddings = embeddings.recv() => {
+                        let Some(embeddings) = embeddings else {
+                            break;
+                        };
+                        index.add(embeddings.primary_key, embeddings.embeddings).await;
+                    }
+                    _ = rx.recv() => { }
+                }
             }
+
+            debug!("finished");
         }
         .instrument(debug_span!("monitor items", "{id}")),
     );
     Ok(tx)
-}
-
-/// Get all current embeddings from the db table and add to the index
-async fn initial_read(
-    rx: &mut Receiver<MonitorItems>,
-    db_index: &Sender<DbIndex>,
-    index: &Sender<Index>,
-) -> anyhow::Result<()> {
-    let mut rows = db_index.get_items().await?;
-
-    while !rx.is_closed() {
-        tokio::select! {
-            row = rows.try_next() => {
-                let Some((primary_key, embeddings)) = row? else {
-                    break;
-                };
-                index.add(primary_key, embeddings).await;
-            }
-
-            _ = rx.recv() => { }
-        }
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
This is a part of #54.

This patch creates a channel of embeddings from db index while constructing its owner, instead of stream returned from API. There should be the only one channel/stream in the lifetime of db index, so it is better to create it during construction. A mpsc channel is better solution for concurrent scan ranges introduces in the next patch.

There should be also a limitation of concurrent requests by the index actor, so there is implemented a semaphore to limit that.