### PR TITLE
Remove functionality of removing index from a db

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -134,9 +134,6 @@ pub(crate) async fn new(db: mpsc::Sender<Db>) -> anyhow::Result<mpsc::Sender<Eng
 
                 Engine::DelIndex { id } => {
                     indexes.remove(&id);
-                    db.remove_index(id).await.unwrap_or_else(|err| {
-                        warn!("engine::Engine::DelIndex: issue while removing index: {err}")
-                    });
                 }
 
                 Engine::GetIndex { id, tx } => {

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -306,12 +306,6 @@ fn process_db(db: &DbBasic, msg: Db) {
                 })))
             .map_err(|_| anyhow!("Db::GetIndexParams: unable to send response"))
             .unwrap(),
-
-        Db::RemoveIndex { id } => {
-            if let Some(keyspace) = db.0.write().unwrap().keyspaces.get_mut(&id.keyspace()) {
-                keyspace.indexes.remove(&id.index());
-            }
-        }
     }
 }
 


### PR DESCRIPTION
This is a part of #54.

Old workaround functionality for storing index metadata in the ScyllaDB has been removing, so this patch removes functionality of removing such index data from the ScyllaDB.