### PR TITLE
gh-24: update scylla rust driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,12 +890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "histogram"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
-
-[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,34 +1635,13 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_chacha",
+ "rand_core",
  "zerocopy 0.8.23",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1678,16 +1651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.15",
+ "rand_core",
 ]
 
 [[package]]
@@ -1701,20 +1665,11 @@ dependencies = [
 
 [[package]]
 name = "rand_pcg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_pcg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1995,39 +1950,8 @@ checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
 
 [[package]]
 name = "scylla"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0408e59e11f589071d1cefc3928270aa8fe4d03f654cb118e0c24d16013ea82"
-dependencies = [
- "arc-swap",
- "async-trait",
- "byteorder",
- "bytes",
- "chrono",
- "dashmap",
- "futures",
- "hashbrown 0.14.5",
- "histogram",
- "itertools 0.13.0",
- "lazy_static",
- "lz4_flex",
- "rand 0.8.5",
- "rand_pcg 0.3.1",
- "scylla-cql 0.4.1",
- "scylla-macros 0.7.1",
- "smallvec",
- "snap",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "scylla"
-version = "1.0.0"
-source = "git+https://github.com/smoczy123/scylla-rust-driver.git?rev=b5721711df8e237d485a7a2bb9a925869e5a6941#b5721711df8e237d485a7a2bb9a925869e5a6941"
+version = "1.1.0"
+source = "git+https://github.com/ewienik/scylla-rust-driver.git?rev=5fef6ae#5fef6aedd595ae57b304a260b70e895cf868edb4"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2038,11 +1962,10 @@ dependencies = [
  "futures",
  "hashbrown 0.14.5",
  "itertools 0.14.0",
- "lazy_static",
  "lz4_flex",
- "rand 0.9.0",
- "rand_pcg 0.9.0",
- "scylla-cql 1.0.0",
+ "rand",
+ "rand_pcg",
+ "scylla-cql",
  "smallvec",
  "snap",
  "socket2",
@@ -2054,8 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "scylla-cdc"
-version = "0.3.0"
-source = "git+https://github.com/abastian/scylla-cdc-rust.git?rev=fdf53f3cab58855fc92ff052d8f95ff61c7764f9#fdf53f3cab58855fc92ff052d8f95ff61c7764f9"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef47312c2d9ab846dd5117773dd01df4122de8b36f54945970c4f25614f4f80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2064,7 +1988,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "num_enum",
- "scylla 0.15.1",
+ "scylla",
  "tokio",
  "tracing",
  "uuid",
@@ -2072,36 +1996,16 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cefd8b924bb8f67525937a811038d5662f9febc30c74c778a8205f63c4b365"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "lz4_flex",
- "scylla-macros 0.7.1",
- "snap",
- "stable_deref_trait",
- "thiserror",
- "tokio",
- "uuid",
- "yoke",
-]
-
-[[package]]
-name = "scylla-cql"
-version = "1.0.0"
-source = "git+https://github.com/smoczy123/scylla-rust-driver.git?rev=b5721711df8e237d485a7a2bb9a925869e5a6941#b5721711df8e237d485a7a2bb9a925869e5a6941"
+version = "1.1.0"
+source = "git+https://github.com/ewienik/scylla-rust-driver.git?rev=5fef6ae#5fef6aedd595ae57b304a260b70e895cf868edb4"
 dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
  "chrono",
- "either",
  "itertools 0.14.0",
  "lz4_flex",
- "scylla-macros 1.0.0",
+ "scylla-macros",
  "snap",
  "stable_deref_trait",
  "thiserror",
@@ -2113,20 +2017,8 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e878bfb8a235207864ac3fb0b51d7954c77fd38486e0e4fb4e037935ff7eb46c"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "scylla-macros"
-version = "1.0.0"
-source = "git+https://github.com/smoczy123/scylla-rust-driver.git?rev=b5721711df8e237d485a7a2bb9a925869e5a6941#b5721711df8e237d485a7a2bb9a925869e5a6941"
+version = "1.1.0"
+source = "git+https://github.com/ewienik/scylla-rust-driver.git?rev=5fef6ae#5fef6aedd595ae57b304a260b70e895cf868edb4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2860,6 +2752,7 @@ name = "vector-store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "bimap",
  "derive_more",
@@ -2870,7 +2763,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "scylla 1.0.0",
+ "scylla",
  "scylla-cdc",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ opensearch = ["dep:opensearch"]
 
 [dependencies]
 anyhow = "1.0.97"
+async-trait = "0.1.88"
 axum = { version = "0.8.1", features = ["macros"] }
 bimap = "0.6.3"
 derive_more = { version = "2.0.1", features = ["full"] }
@@ -23,8 +24,8 @@ itertools = "0.14.0"
 opensearch = { version = "2.3.0", optional = true }
 rayon = "1.10.0"
 regex = "1.11.1"
-scylla = { git = "https://github.com/smoczy123/scylla-rust-driver.git", rev = "b5721711df8e237d485a7a2bb9a925869e5a6941", features = ["time-03"] }
-scylla-cdc = { git = "https://github.com/abastian/scylla-cdc-rust.git", rev = "fdf53f3cab58855fc92ff052d8f95ff61c7764f9" }
+scylla = { version = "1.1.0", features = ["time-03"] }
+scylla-cdc = "0.4.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2.0.12"
@@ -38,6 +39,9 @@ utoipa = { version = "5.3.1", features = ["axum_extras"] }
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
 uuid = "1.16.0"
+
+[patch.crates-io]
+scylla = { git = "https://github.com/ewienik/scylla-rust-driver.git", rev = "5fef6ae" }
 
 [dev-dependencies]
 reqwest = { version = "0.12.15", features = ["json"] }


### PR DESCRIPTION
Using CDC ScyllaDB functionality needs scylla-cdc and async-trait
crates. As vector type support is not merged with scylla driver there is
a need for integration branch on a separate repository. This patch uses
ewienik for a scylla driver crate. Eventually vector support will be
merged and then scylla and scylla-cdc crates version should be updated.

---

### List of PRs for #24
- -> #117: update scylla rust driver
- add simple unit test for an usearch index
- refactor index add into add_or_replace
- add simple unit test for monitor_items
- implement a db index validation
- read timestamps for embeddings from a db
- implement removing embeddings from an index
- implement reading new embeddings from the CDC
