### PR TITLE
gh-24: refactor index add into add_or_replace

### DIFF
--- a/src/index/actor.rs
+++ b/src/index/actor.rs
@@ -14,7 +14,7 @@ pub(crate) type AnnR = anyhow::Result<(Vec<PrimaryKey>, Vec<Distance>)>;
 pub(crate) type CountR = anyhow::Result<usize>;
 
 pub(crate) enum Index {
-    Add {
+    AddOrReplace {
         primary_key: PrimaryKey,
         embeddings: Embeddings,
     },
@@ -29,14 +29,14 @@ pub(crate) enum Index {
 }
 
 pub(crate) trait IndexExt {
-    async fn add(&self, primary_key: PrimaryKey, embeddings: Embeddings);
+    async fn add_or_replace(&self, primary_key: PrimaryKey, embeddings: Embeddings);
     async fn ann(&self, embeddings: Embeddings, limit: Limit) -> AnnR;
     async fn count(&self) -> CountR;
 }
 
 impl IndexExt for mpsc::Sender<Index> {
-    async fn add(&self, primary_key: PrimaryKey, embeddings: Embeddings) {
-        self.send(Index::Add {
+    async fn add_or_replace(&self, primary_key: PrimaryKey, embeddings: Embeddings) {
+        self.send(Index::AddOrReplace {
             primary_key,
             embeddings,
         })

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -35,7 +35,7 @@ pub(crate) async fn new(
                         let Some(embeddings) = embeddings else {
                             break;
                         };
-                        index.add(embeddings.primary_key, embeddings.embeddings).await;
+                        index.add_or_replace(embeddings.primary_key, embeddings.embeddings).await;
                     }
                     _ = rx.recv() => { }
                 }


### PR DESCRIPTION
The embeddings data in ScyllaDB could be modified, so there is a need to
modify data in an usearch index. This patch modifies functionality of
simply adding a new embedding with add or replace embedding for a
specific primary key.

---

### List of PRs for #24
- #117
- #118
- -> refactor index add into add_or_replace
- #120
- #121
- #122
- #123
- #124
