### PR TITLE
gh-24: add simple unit test for monitor_items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,7 @@ struct ParamM(usize);
 #[derive(
     Clone,
     Debug,
+    PartialEq,
     serde::Serialize,
     serde::Deserialize,
     derive_more::AsRef,


### PR DESCRIPTION
In the stack of commits there will be a need for adding or modyfing
a functionality of monitor_items and testing this functionality needs
unit tests. This patch implements a simple unit test for a current
monitor_items actor.

---

### List of PRs for #24
- #117
- #118
- #119
- -> add simple unit test for monitor_items
- #121
- #122
- #123
- #124
