### PR TITLE
gh-24: implement a db index validation

### DIFF
--- a/src/db_index.rs
+++ b/src/db_index.rs
@@ -174,6 +174,8 @@ struct Statements {
 
 impl Statements {
     async fn new(session: Arc<Session>, metadata: IndexMetadata) -> anyhow::Result<Self> {
+        session.await_schema_agreement().await?;
+
         let cluster_state = session.get_cluster_state();
         let table = cluster_state
             .get_keyspace(metadata.keyspace_name.as_ref())

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -312,6 +312,11 @@ fn process_db(db: &DbBasic, msg: Db) {
                 })))
             .map_err(|_| anyhow!("Db::GetIndexParams: unable to send response"))
             .unwrap(),
+
+        Db::IsValidIndex { tx, .. } => tx
+            .send(true)
+            .map_err(|_| anyhow!("Db::IsValidIndex: unable to send response"))
+            .unwrap(),
     }
 }
 


### PR DESCRIPTION
Schema changes are concurrent processes without an atomic view from the
client/driver side. A process of retrieving an index metadata from the
vector-store could be faster than similar process in a driver itself.
The vector-store reads some schema metadata from system tables directly,
because they are not available from a rust driver, and it reads some
other schema metadata from the rust driver, so there must be an
agreement between data read directly from a db and a driver. This patch
checks if index metadata are correct and if there is an agreement of a
db schema in the rust driver.

---

### List of PRs for #24
- #117
- #118
- #119
- #120
- -> implement a db index validation
- #122
- #123
- #124
