### PR TITLE
gh-24: read timestamps for embeddings from a db

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
+use time::OffsetDateTime;
 use tokio::signal;
 use tokio::sync::mpsc::Sender;
 use utoipa::PartialSchema;
@@ -350,10 +351,14 @@ impl DbCustomIndex {
     }
 }
 
+#[derive(Clone, Copy, Debug, derive_more::From, derive_more::AsRef)]
+pub struct Timestamp(OffsetDateTime);
+
 #[derive(Debug)]
 pub struct DbEmbeddings {
     pub primary_key: PrimaryKey,
     pub embeddings: Embeddings,
+    pub timestamp: Timestamp,
 }
 
 #[derive(derive_more::From)]

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -5,8 +5,11 @@
 
 use crate::DbEmbeddings;
 use crate::IndexId;
+use crate::PrimaryKey;
+use crate::Timestamp;
 use crate::index::Index;
 use crate::index::IndexExt;
+use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
@@ -29,13 +32,15 @@ pub(crate) async fn new(
         async move {
             debug!("starting");
 
+            let mut timestamps: HashMap<PrimaryKey, Timestamp> = HashMap::new();
+
             while !rx.is_closed() {
                 tokio::select! {
                     embeddings = embeddings.recv() => {
                         let Some(embeddings) = embeddings else {
                             break;
                         };
-                        index.add_or_replace(embeddings.primary_key, embeddings.embeddings).await;
+                        add(&mut timestamps, & index, embeddings).await;
                     }
                     _ = rx.recv() => { }
                 }
@@ -48,10 +53,34 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
+async fn add(
+    timestamps: &mut HashMap<PrimaryKey, Timestamp>,
+    index: &Sender<Index>,
+    embeddings: DbEmbeddings,
+) {
+    let mut add = true;
+    timestamps
+        .entry(embeddings.primary_key.clone())
+        .and_modify(|timestamp| {
+            if timestamp.0 < embeddings.timestamp.0 {
+                *timestamp = embeddings.timestamp;
+            } else {
+                add = false;
+            }
+        })
+        .or_insert(embeddings.timestamp);
+    if add {
+        index
+            .add_or_replace(embeddings.primary_key, embeddings.embeddings)
+            .await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use scylla::value::CqlValue;
+    use time::OffsetDateTime;
 
     #[tokio::test]
     async fn flow() {
@@ -69,6 +98,7 @@ mod tests {
             .send(DbEmbeddings {
                 primary_key: vec![CqlValue::Int(1)].into(),
                 embeddings: vec![1.].into(),
+                timestamp: OffsetDateTime::from_unix_timestamp(10).unwrap().into(),
             })
             .await
             .unwrap();
@@ -76,6 +106,25 @@ mod tests {
             .send(DbEmbeddings {
                 primary_key: vec![CqlValue::Int(2)].into(),
                 embeddings: vec![2.].into(),
+                timestamp: OffsetDateTime::from_unix_timestamp(11).unwrap().into(),
+            })
+            .await
+            .unwrap();
+        tx_embeddings
+            .send(DbEmbeddings {
+                // should be dropped
+                primary_key: vec![CqlValue::Int(1)].into(),
+                embeddings: vec![3.].into(),
+                timestamp: OffsetDateTime::from_unix_timestamp(5).unwrap().into(),
+            })
+            .await
+            .unwrap();
+        tx_embeddings
+            .send(DbEmbeddings {
+                // should be accepted
+                primary_key: vec![CqlValue::Int(2)].into(),
+                embeddings: vec![4.].into(),
+                timestamp: OffsetDateTime::from_unix_timestamp(15).unwrap().into(),
             })
             .await
             .unwrap();
@@ -99,6 +148,16 @@ mod tests {
         };
         assert_eq!(primary_key, vec![CqlValue::Int(2)].into());
         assert_eq!(embeddings, vec![2.].into());
+
+        let Some(Index::AddOrReplace {
+            primary_key,
+            embeddings,
+        }) = rx_index.recv().await
+        else {
+            unreachable!();
+        };
+        assert_eq!(primary_key, vec![CqlValue::Int(2)].into());
+        assert_eq!(embeddings, vec![4.].into());
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());

--- a/tests/integration/usearch.rs
+++ b/tests/integration/usearch.rs
@@ -7,6 +7,7 @@ use crate::db_basic;
 use crate::db_basic::Index;
 use crate::db_basic::Table;
 use crate::httpclient::HttpClient;
+use ::time::OffsetDateTime;
 use scylla::value::CqlValue;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
@@ -74,14 +75,17 @@ async fn simple_create_search_delete_index() {
             (
                 vec![CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
                 vec![1., 1., 1.].into(),
+                OffsetDateTime::from_unix_timestamp(10).unwrap().into(),
             ),
             (
                 vec![CqlValue::Int(2), CqlValue::Text("two".to_string())].into(),
                 vec![2., -2., 2.].into(),
+                OffsetDateTime::from_unix_timestamp(20).unwrap().into(),
             ),
             (
                 vec![CqlValue::Int(3), CqlValue::Text("three".to_string())].into(),
                 vec![3., 3., 3.].into(),
+                OffsetDateTime::from_unix_timestamp(30).unwrap().into(),
             ),
         ],
     )


### PR DESCRIPTION
The ScyllaDB uses cells timestamps to resolve merging data problem -
only a modification with the latest timestamp is stored in a db. The
vector-store needs to deal with the same problem - data from the
ScyllaDB will flow concurrently, so there is a need for coordinating
them with timestamps - data with the latest timestamp should be stored
in the index.

This patch implements using same timestamps for embeddings as the
ScyllaDB. It uses `SELECT id, embedding, writetime(embedding)` for a
retrieval of embeddings with timestamps. Timestamps in the ScyllaDB
writetime are in microseconds since a unix epoch. Internally this patch
introduces a newtype Timestamp with time::OffsetDateTime.

As support for Deserializing Vector type within Row has been implemented
in a rust driver there is a removal of a custom serialization
functionality.

---

### List of PRs for #24
- #117
- #118
- #119
- #120
- #121
- -> read timestamps for embeddings from a db
- #123
- #124
