### PR TITLE
gh-105: add a newtype IndexName

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -11,6 +11,7 @@ use crate::Dimensions;
 use crate::ExpansionAdd;
 use crate::ExpansionSearch;
 use crate::IndexMetadata;
+use crate::IndexName;
 use crate::IndexVersion;
 use crate::KeyspaceName;
 use crate::ScyllaDbUri;
@@ -58,7 +59,7 @@ pub enum Db {
 
     GetIndexVersion {
         keyspace: KeyspaceName,
-        index: TableName,
+        index: IndexName,
         tx: oneshot::Sender<GetIndexVersionR>,
     },
 
@@ -71,7 +72,7 @@ pub enum Db {
 
     GetIndexParams {
         keyspace: KeyspaceName,
-        index: TableName,
+        index: IndexName,
         tx: oneshot::Sender<GetIndexParamsR>,
     },
 
@@ -95,7 +96,7 @@ pub(crate) trait DbExt {
 
     async fn get_indexes(&self) -> GetIndexesR;
 
-    async fn get_index_version(&self, keyspace: KeyspaceName, index: TableName)
+    async fn get_index_version(&self, keyspace: KeyspaceName, index: IndexName)
     -> GetIndexVersionR;
 
     async fn get_index_target_type(
@@ -105,7 +106,7 @@ pub(crate) trait DbExt {
         target_column: ColumnName,
     ) -> GetIndexTargetTypeR;
 
-    async fn get_index_params(&self, keyspace: KeyspaceName, index: TableName) -> GetIndexParamsR;
+    async fn get_index_params(&self, keyspace: KeyspaceName, index: IndexName) -> GetIndexParamsR;
 
     async fn is_valid_index(&self, metadata: IndexMetadata) -> IsValidIndexR;
 }
@@ -132,7 +133,7 @@ impl DbExt for mpsc::Sender<Db> {
     async fn get_index_version(
         &self,
         keyspace: KeyspaceName,
-        index: TableName,
+        index: IndexName,
     ) -> GetIndexVersionR {
         let (tx, rx) = oneshot::channel();
         self.send(Db::GetIndexVersion {
@@ -161,7 +162,7 @@ impl DbExt for mpsc::Sender<Db> {
         rx.await?
     }
 
-    async fn get_index_params(&self, keyspace: KeyspaceName, index: TableName) -> GetIndexParamsR {
+    async fn get_index_params(&self, keyspace: KeyspaceName, index: IndexName) -> GetIndexParamsR {
         let (tx, rx) = oneshot::channel();
         self.send(Db::GetIndexParams {
             keyspace,
@@ -348,7 +349,7 @@ impl Statements {
     async fn get_index_version(
         &self,
         keyspace: KeyspaceName,
-        index: TableName,
+        index: IndexName,
     ) -> GetIndexVersionR {
         Ok(self
             .session
@@ -399,7 +400,7 @@ impl Statements {
     async fn get_index_params(
         &self,
         _keyspace: KeyspaceName,
-        _index: TableName,
+        _index: IndexName,
     ) -> GetIndexParamsR {
         Ok(Some((
             Connectivity::default(),

--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -7,9 +7,9 @@ use crate::ColumnName;
 use crate::Distance;
 use crate::Embeddings;
 use crate::IndexId;
+use crate::IndexName;
 use crate::KeyspaceName;
 use crate::Limit;
-use crate::TableName;
 use crate::db_index::DbIndexExt;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
@@ -82,7 +82,7 @@ async fn get_indexes(State(engine): State<Sender<Engine>>) -> response::Json<Vec
     description = "Get a number of elements for a specific index",
     params(
         ("keyspace" = KeyspaceName, Path, description = "A keyspace name for the index"),
-        ("index" = TableName, Path, description = "An index name")
+        ("index" = IndexName, Path, description = "An index name")
     ),
     responses(
         (status = 200, description = "Index count", body = usize)
@@ -90,7 +90,7 @@ async fn get_indexes(State(engine): State<Sender<Engine>>) -> response::Json<Vec
 )]
 async fn get_index_count(
     State(engine): State<Sender<Engine>>,
-    Path((keyspace, index)): Path<(KeyspaceName, TableName)>,
+    Path((keyspace, index)): Path<(KeyspaceName, IndexName)>,
 ) -> Response {
     let Some((index, _)) = engine.get_index(IndexId::new(&keyspace, &index)).await else {
         debug!("get_index_size: missing index: {keyspace}/{index}");
@@ -126,7 +126,7 @@ pub struct PostIndexAnnResponse {
     description = "Ann search in the index",
     params(
         ("keyspace" = KeyspaceName, Path, description = "Keyspace name for the table to search"),
-        ("index" = TableName, Path, description = "Index to search")
+        ("index" = IndexName, Path, description = "Index to search")
     ),
     request_body = PostIndexAnnRequest,
     responses(
@@ -136,7 +136,7 @@ pub struct PostIndexAnnResponse {
 )]
 async fn post_index_ann(
     State(engine): State<Sender<Engine>>,
-    Path((keyspace, index)): Path<(KeyspaceName, TableName)>,
+    Path((keyspace, index)): Path<(KeyspaceName, IndexName)>,
     extract::Json(request): extract::Json<PostIndexAnnRequest>,
 ) -> Response {
     let Some((index, db_index)) = engine.get_index(IndexId::new(&keyspace, &index)).await else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub struct ScyllaDbUri(String);
 pub struct IndexId(String);
 
 impl IndexId {
-    pub fn new(keyspace: &KeyspaceName, index: &TableName) -> Self {
+    pub fn new(keyspace: &KeyspaceName, index: &IndexName) -> Self {
         Self(format!("{}.{}", keyspace.0, index.0))
     }
 
@@ -65,7 +65,7 @@ impl IndexId {
         self.0.split_once('.').unwrap().0.to_string().into()
     }
 
-    pub fn index(&self) -> TableName {
+    pub fn index(&self) -> IndexName {
         self.0.split_once('.').unwrap().1.to_string().into()
     }
 }
@@ -95,6 +95,32 @@ impl SerializeValue for IndexId {
 pub struct KeyspaceName(String);
 
 impl SerializeValue for KeyspaceName {
+    fn serialize<'b>(
+        &self,
+        typ: &ColumnType,
+        writer: CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, SerializationError> {
+        <String as SerializeValue>::serialize(&self.0, typ, writer)
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    derive_more::From,
+    derive_more::AsRef,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::Display,
+    utoipa::ToSchema,
+)]
+/// A table name of the table with vectors in a db
+pub struct IndexName(String);
+
+impl SerializeValue for IndexName {
     fn serialize<'b>(
         &self,
         typ: &ColumnType,
@@ -321,7 +347,7 @@ pub struct IndexVersion(Uuid);
 /// Information about an index
 pub struct IndexMetadata {
     pub keyspace_name: KeyspaceName,
-    pub index_name: TableName,
+    pub index_name: IndexName,
     pub table_name: TableName,
     pub target_column: ColumnName,
     pub dimensions: Dimensions,
@@ -340,7 +366,7 @@ impl IndexMetadata {
 #[derive(Debug)]
 pub struct DbCustomIndex {
     pub keyspace: KeyspaceName,
-    pub index: TableName,
+    pub index: IndexName,
     pub table: TableName,
     pub target_column: ColumnName,
 }

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -24,6 +24,7 @@ use vector_store::Embeddings;
 use vector_store::ExpansionAdd;
 use vector_store::ExpansionSearch;
 use vector_store::IndexMetadata;
+use vector_store::IndexName;
 use vector_store::KeyspaceName;
 use vector_store::PrimaryKey;
 use vector_store::TableName;
@@ -97,7 +98,7 @@ pub(crate) struct Index {
 
 struct Keyspace {
     tables: HashMap<TableName, TableStore>,
-    indexes: HashMap<TableName, IndexStore>,
+    indexes: HashMap<IndexName, IndexStore>,
 }
 
 impl Keyspace {
@@ -152,7 +153,7 @@ impl DbBasic {
     pub(crate) fn add_index(
         &self,
         keyspace_name: &KeyspaceName,
-        index_name: TableName,
+        index_name: IndexName,
         index: Index,
     ) -> anyhow::Result<()> {
         let mut db = self.0.write().unwrap();
@@ -182,7 +183,7 @@ impl DbBasic {
     pub(crate) fn del_index(
         &self,
         keyspace_name: &KeyspaceName,
-        index_name: &TableName,
+        index_name: &IndexName,
     ) -> anyhow::Result<()> {
         let mut db = self.0.write().unwrap();
 


### PR DESCRIPTION
For readability and maintenance reasons there is a need to semantically
distinguish a type for a table name (a store for embedding) and a type for
an index name (a custom index). This patch adds IndexName type and
modify sources to use it.

Fixes: #105

