### PR TITLE
gh-107: rename Embeddings into Embedding

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -6,7 +6,7 @@
 use crate::ColumnName;
 use crate::Connectivity;
 use crate::DbCustomIndex;
-use crate::DbEmbeddings;
+use crate::DbEmbedding;
 use crate::Dimensions;
 use crate::ExpansionAdd;
 use crate::ExpansionSearch;
@@ -34,7 +34,7 @@ use tracing::debug_span;
 use tracing::trace;
 use uuid::Uuid;
 
-type GetDbIndexR = anyhow::Result<(mpsc::Sender<DbIndex>, mpsc::Receiver<DbEmbeddings>)>;
+type GetDbIndexR = anyhow::Result<(mpsc::Sender<DbIndex>, mpsc::Receiver<DbEmbedding>)>;
 type LatestSchemaVersionR = anyhow::Result<Option<CqlTimeuuid>>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;
 type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;

--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -5,7 +5,7 @@
 
 use crate::ColumnName;
 use crate::Distance;
-use crate::Embeddings;
+use crate::Embedding;
 use crate::IndexId;
 use crate::KeyspaceName;
 use crate::Limit;
@@ -109,7 +109,7 @@ async fn get_index_count(
 
 #[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 pub struct PostIndexAnnRequest {
-    pub embeddings: Embeddings,
+    pub embedding: Embedding,
     #[serde(default)]
     pub limit: Limit,
 }
@@ -143,7 +143,7 @@ async fn post_index_ann(
         return (StatusCode::NOT_FOUND, "").into_response();
     };
 
-    match index.ann(request.embeddings, request.limit).await {
+    match index.ann(request.embedding, request.limit).await {
         Err(err) => {
             let msg = format!("index.ann request error: {err}");
             debug!("post_index_ann: {msg}");

--- a/src/index/actor.rs
+++ b/src/index/actor.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::Distance;
-use crate::Embeddings;
+use crate::Embedding;
 use crate::Limit;
 use crate::PrimaryKey;
 use tokio::sync::mpsc;
@@ -16,10 +16,10 @@ pub(crate) type CountR = anyhow::Result<usize>;
 pub(crate) enum Index {
     AddOrReplace {
         primary_key: PrimaryKey,
-        embeddings: Embeddings,
+        embedding: Embedding,
     },
     Ann {
-        embeddings: Embeddings,
+        embedding: Embedding,
         limit: Limit,
         tx: oneshot::Sender<AnnR>,
     },
@@ -29,25 +29,25 @@ pub(crate) enum Index {
 }
 
 pub(crate) trait IndexExt {
-    async fn add_or_replace(&self, primary_key: PrimaryKey, embeddings: Embeddings);
-    async fn ann(&self, embeddings: Embeddings, limit: Limit) -> AnnR;
+    async fn add_or_replace(&self, primary_key: PrimaryKey, embedding: Embedding);
+    async fn ann(&self, embedding: Embedding, limit: Limit) -> AnnR;
     async fn count(&self) -> CountR;
 }
 
 impl IndexExt for mpsc::Sender<Index> {
-    async fn add_or_replace(&self, primary_key: PrimaryKey, embeddings: Embeddings) {
+    async fn add_or_replace(&self, primary_key: PrimaryKey, embedding: Embedding) {
         self.send(Index::AddOrReplace {
             primary_key,
-            embeddings,
+            embedding,
         })
         .await
         .expect("internal actor should receive request");
     }
 
-    async fn ann(&self, embeddings: Embeddings, limit: Limit) -> AnnR {
+    async fn ann(&self, embedding: Embedding, limit: Limit) -> AnnR {
         let (tx, rx) = oneshot::channel();
         self.send(Index::Ann {
-            embeddings,
+            embedding,
             limit,
             tx,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,8 +279,8 @@ struct ParamM(usize);
     derive_more::From,
     utoipa::ToSchema,
 )]
-/// Embeddings vector
-pub struct Embeddings(Vec<f32>);
+/// Embedding vector
+pub struct Embedding(Vec<f32>);
 
 #[derive(
     Clone,
@@ -355,9 +355,9 @@ impl DbCustomIndex {
 pub struct Timestamp(OffsetDateTime);
 
 #[derive(Debug)]
-pub struct DbEmbeddings {
+pub struct DbEmbedding {
     pub primary_key: PrimaryKey,
-    pub embeddings: Embeddings,
+    pub embedding: Embedding,
     pub timestamp: Timestamp,
 }
 

--- a/src/monitor_items.rs
+++ b/src/monitor_items.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::DbEmbeddings;
+use crate::DbEmbedding;
 use crate::IndexId;
 use crate::PrimaryKey;
 use crate::Timestamp;
@@ -21,7 +21,7 @@ pub(crate) enum MonitorItems {}
 
 pub(crate) async fn new(
     id: IndexId,
-    mut embeddings: Receiver<DbEmbeddings>,
+    mut embeddings: Receiver<DbEmbedding>,
     index: Sender<Index>,
 ) -> anyhow::Result<Sender<MonitorItems>> {
     // The value was taken from initial benchmarks
@@ -36,11 +36,11 @@ pub(crate) async fn new(
 
             while !rx.is_closed() {
                 tokio::select! {
-                    embeddings = embeddings.recv() => {
-                        let Some(embeddings) = embeddings else {
+                    embedding = embeddings.recv() => {
+                        let Some(embedding) = embedding else {
                             break;
                         };
-                        add(&mut timestamps, & index, embeddings).await;
+                        add(&mut timestamps, &index, embedding).await;
                     }
                     _ = rx.recv() => { }
                 }
@@ -56,22 +56,22 @@ pub(crate) async fn new(
 async fn add(
     timestamps: &mut HashMap<PrimaryKey, Timestamp>,
     index: &Sender<Index>,
-    embeddings: DbEmbeddings,
+    embedding: DbEmbedding,
 ) {
     let mut add = true;
     timestamps
-        .entry(embeddings.primary_key.clone())
+        .entry(embedding.primary_key.clone())
         .and_modify(|timestamp| {
-            if timestamp.0 < embeddings.timestamp.0 {
-                *timestamp = embeddings.timestamp;
+            if timestamp.0 < embedding.timestamp.0 {
+                *timestamp = embedding.timestamp;
             } else {
                 add = false;
             }
         })
-        .or_insert(embeddings.timestamp);
+        .or_insert(embedding.timestamp);
     if add {
         index
-            .add_or_replace(embeddings.primary_key, embeddings.embeddings)
+            .add_or_replace(embedding.primary_key, embedding.embedding)
             .await;
     }
 }
@@ -95,35 +95,35 @@ mod tests {
         .unwrap();
 
         tx_embeddings
-            .send(DbEmbeddings {
+            .send(DbEmbedding {
                 primary_key: vec![CqlValue::Int(1)].into(),
-                embeddings: vec![1.].into(),
+                embedding: vec![1.].into(),
                 timestamp: OffsetDateTime::from_unix_timestamp(10).unwrap().into(),
             })
             .await
             .unwrap();
         tx_embeddings
-            .send(DbEmbeddings {
+            .send(DbEmbedding {
                 primary_key: vec![CqlValue::Int(2)].into(),
-                embeddings: vec![2.].into(),
+                embedding: vec![2.].into(),
                 timestamp: OffsetDateTime::from_unix_timestamp(11).unwrap().into(),
             })
             .await
             .unwrap();
         tx_embeddings
-            .send(DbEmbeddings {
+            .send(DbEmbedding {
                 // should be dropped
                 primary_key: vec![CqlValue::Int(1)].into(),
-                embeddings: vec![3.].into(),
+                embedding: vec![3.].into(),
                 timestamp: OffsetDateTime::from_unix_timestamp(5).unwrap().into(),
             })
             .await
             .unwrap();
         tx_embeddings
-            .send(DbEmbeddings {
+            .send(DbEmbedding {
                 // should be accepted
                 primary_key: vec![CqlValue::Int(2)].into(),
-                embeddings: vec![4.].into(),
+                embedding: vec![4.].into(),
                 timestamp: OffsetDateTime::from_unix_timestamp(15).unwrap().into(),
             })
             .await
@@ -131,33 +131,33 @@ mod tests {
 
         let Some(Index::AddOrReplace {
             primary_key,
-            embeddings,
+            embedding,
         }) = rx_index.recv().await
         else {
             unreachable!();
         };
         assert_eq!(primary_key, vec![CqlValue::Int(1)].into());
-        assert_eq!(embeddings, vec![1.].into());
+        assert_eq!(embedding, vec![1.].into());
 
         let Some(Index::AddOrReplace {
             primary_key,
-            embeddings,
+            embedding,
         }) = rx_index.recv().await
         else {
             unreachable!();
         };
         assert_eq!(primary_key, vec![CqlValue::Int(2)].into());
-        assert_eq!(embeddings, vec![2.].into());
+        assert_eq!(embedding, vec![2.].into());
 
         let Some(Index::AddOrReplace {
             primary_key,
-            embeddings,
+            embedding,
         }) = rx_index.recv().await
         else {
             unreachable!();
         };
         assert_eq!(primary_key, vec![CqlValue::Int(2)].into());
-        assert_eq!(embeddings, vec![4.].into());
+        assert_eq!(embedding, vec![4.].into());
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -18,9 +18,9 @@ use uuid::Uuid;
 use vector_store::ColumnName;
 use vector_store::Connectivity;
 use vector_store::DbCustomIndex;
-use vector_store::DbEmbeddings;
+use vector_store::DbEmbedding;
 use vector_store::Dimensions;
-use vector_store::Embeddings;
+use vector_store::Embedding;
 use vector_store::ExpansionAdd;
 use vector_store::ExpansionSearch;
 use vector_store::IndexMetadata;
@@ -50,7 +50,7 @@ pub(crate) fn new() -> (mpsc::Sender<Db>, DbBasic) {
 
 struct TableStore {
     table: Table,
-    embeddings: HashMap<ColumnName, HashMap<PrimaryKey, (Embeddings, Timestamp)>>,
+    embeddings: HashMap<ColumnName, HashMap<PrimaryKey, (Embedding, Timestamp)>>,
 }
 
 impl TableStore {
@@ -202,7 +202,7 @@ impl DbBasic {
         keyspace_name: &KeyspaceName,
         table_name: &TableName,
         target_column: &ColumnName,
-        values: impl IntoIterator<Item = (PrimaryKey, Embeddings, Timestamp)>,
+        values: impl IntoIterator<Item = (PrimaryKey, Embedding, Timestamp)>,
     ) -> anyhow::Result<()> {
         let mut db = self.0.write().unwrap();
 
@@ -218,16 +218,16 @@ impl DbBasic {
 
         values
             .into_iter()
-            .for_each(|(primary_key, embeddings, timestamp)| {
+            .for_each(|(primary_key, embedding, timestamp)| {
                 column
                     .entry(primary_key)
-                    .and_modify(|(entry_embeddings, entry_timestamp)| {
+                    .and_modify(|(entry_embedding, entry_timestamp)| {
                         if entry_timestamp.as_ref() < timestamp.as_ref() {
-                            *entry_embeddings = embeddings.clone();
+                            *entry_embedding = embedding.clone();
                             *entry_timestamp = timestamp;
                         }
                     })
-                    .or_insert((embeddings, timestamp));
+                    .or_insert((embedding, timestamp));
             });
 
         Ok(())
@@ -334,7 +334,7 @@ fn process_db(db: &DbBasic, msg: Db) {
 pub(crate) fn new_db_index(
     db: DbBasic,
     metadata: IndexMetadata,
-) -> anyhow::Result<(mpsc::Sender<DbIndex>, mpsc::Receiver<DbEmbeddings>)> {
+) -> anyhow::Result<(mpsc::Sender<DbIndex>, mpsc::Receiver<DbEmbedding>)> {
     let (tx_index, mut rx_index) = mpsc::channel(10);
     let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
     tokio::spawn({
@@ -363,7 +363,7 @@ pub(crate) fn new_db_index(
     Ok((tx_index, rx_embeddings))
 }
 
-fn initial_scan(db: &DbBasic, metadata: &IndexMetadata) -> impl Stream<Item = DbEmbeddings> {
+fn initial_scan(db: &DbBasic, metadata: &IndexMetadata) -> impl Stream<Item = DbEmbedding> {
     stream::iter(
         db.0.read()
             .unwrap()
@@ -373,9 +373,9 @@ fn initial_scan(db: &DbBasic, metadata: &IndexMetadata) -> impl Stream<Item = Db
             .and_then(|table| table.embeddings.get(&metadata.target_column))
             .map(|rows| {
                 rows.iter()
-                    .map(|(primary_key, (embeddings, timestamp))| DbEmbeddings {
+                    .map(|(primary_key, (embedding, timestamp))| DbEmbedding {
                         primary_key: primary_key.clone(),
-                        embeddings: embeddings.clone(),
+                        embedding: embedding.clone(),
                         timestamp: *timestamp,
                     })
                     .collect_vec()

--- a/tests/integration/httpclient.rs
+++ b/tests/integration/httpclient.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use vector_store::ColumnName;
 use vector_store::Distance;
-use vector_store::Embeddings;
+use vector_store::Embedding;
 use vector_store::IndexId;
 use vector_store::IndexMetadata;
 use vector_store::Limit;
@@ -43,7 +43,7 @@ impl HttpClient {
     pub(crate) async fn ann(
         &self,
         index: &IndexMetadata,
-        embeddings: Embeddings,
+        embedding: Embedding,
         limit: Limit,
     ) -> (HashMap<ColumnName, Vec<Value>>, Vec<Distance>) {
         let resp = self
@@ -52,7 +52,7 @@ impl HttpClient {
                 "{}/indexes/{}/{}/ann",
                 self.url_api, index.keyspace_name, index.index_name
             ))
-            .json(&PostIndexAnnRequest { embeddings, limit })
+            .json(&PostIndexAnnRequest { embedding, limit })
             .send()
             .await
             .unwrap()

--- a/tests/integration/usearch.rs
+++ b/tests/integration/usearch.rs
@@ -27,7 +27,7 @@ async fn simple_create_search_delete_index() {
         keyspace_name: "vector".to_string().into(),
         table_name: "items".to_string().into(),
         index_name: "ann".to_string().into(),
-        target_column: "embeddings".to_string().into(),
+        target_column: "embedding".to_string().into(),
         dimensions: NonZeroUsize::new(3).unwrap().into(),
         connectivity: Default::default(),
         expansion_add: Default::default(),


### PR DESCRIPTION
The terminology in a Vector Search space is not consistent. It seems we
should use Embedding as its semantic is a vector of float. See
https://tanelpoder.com/posts/embedding-vectors-vs-vector-embeddings/.
This patch changes a newtype from Embeddings into Embedding and
changes variable names accordingly.

Fixes: #107

---

### List of PRs for #107
- -> rename Embeddings into Embedding
