### PR TITLE
Add CI for opensearch feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Clippy check
       run: cargo clippy --all-targets
 
+    - name: Clippy check with opensearch feature
+      run: cargo clippy --all-targets --features opensearch
+
   tests:
     runs-on: ubuntu-latest
     steps:
@@ -55,4 +58,7 @@ jobs:
 
     - name: Run tests
       run: cargo test --verbose
+
+    - name: Run tests with opensearch feature
+      run: cargo test --verbose --features opensearch
 

--- a/src/index/opensearch.rs
+++ b/src/index/opensearch.rs
@@ -3,30 +3,41 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+// TODO: Please remove if necessary implementation is provided.
+#![allow(dead_code)]
+
 use crate::Connectivity;
 use crate::Dimensions;
-use crate::Distance;
-use crate::Embeddings;
 use crate::ExpansionAdd;
 use crate::ExpansionSearch;
 use crate::IndexId;
-use crate::IndexItemsCount;
-use crate::Key;
-use crate::Limit;
-use crate::db::Db;
+use crate::PrimaryKey;
 use crate::index::actor::Index;
+use bimap::BiMap;
+use opensearch::OpenSearch;
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::AtomicU64;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 use tracing::info;
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    derive_more::From,
+    derive_more::AsRef,
+    derive_more::Display,
+)]
+/// Key for index embeddings
+struct Key(u64);
 
 pub fn new(
     id: IndexId,
-    db: mpsc::Sender<Db>,
-    dimensions: Dimensions,
+    _dimensions: Dimensions,
     _connectivity: Connectivity,
     _expansion_add: ExpansionAdd,
     _expansion_search: ExpansionSearch,
@@ -39,34 +50,37 @@ pub fn new(
     Ok(tx)
 }
 
-async fn housekeeping(
-    db: &mpsc::Sender<Db>,
-    id: IndexId,
-    items_count_db: &mut IndexItemsCount,
-    items_count: &AtomicU32,
-    counter_add: &AtomicUsize,
-    counter_ann: &AtomicUsize,
-    channel_len: usize,
+async fn _process(
+    msg: Index,
+    _dimensions: Dimensions,
+    _id: Arc<IndexId>,
+    _keys: Arc<RwLock<BiMap<PrimaryKey, Key>>>,
+    _opensearch_key: Arc<AtomicU64>,
+    _client: Arc<OpenSearch>,
 ) {
-    {}
-}
-
-async fn add(
-    idx: Arc<usearch::Index>,
-    idx_lock: Arc<RwLock<()>>,
-    key: Key,
-    embeddings: Embeddings,
-    items_count: Arc<AtomicU32>,
-    counter: Arc<AtomicUsize>,
-) {
-}
-
-async fn ann(
-    idx: Arc<usearch::Index>,
-    tx: oneshot::Sender<anyhow::Result<(Vec<Key>, Vec<Distance>)>>,
-    embeddings: Embeddings,
-    dimensions: Dimensions,
-    limit: Limit,
-    counter: Arc<AtomicUsize>,
-) {
+    // TODO: Implement the logic for processing the messages
+    match msg {
+        Index::AddOrReplace {
+            primary_key,
+            embedding,
+        } => {
+            let _ = primary_key;
+            let _ = embedding;
+        }
+        Index::Remove { primary_key } => {
+            let _ = primary_key;
+        }
+        Index::Ann {
+            embedding,
+            limit,
+            tx,
+        } => {
+            let _ = embedding;
+            let _ = limit;
+            let _ = tx;
+        }
+        Index::Count { tx } => {
+            let _ = tx;
+        }
+    }
 }

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+// TODO: This should be removed when the opensearch tests are implemented.
+#![cfg_attr(feature = "opensearch", allow(dead_code))]
+
 use anyhow::anyhow;
 use anyhow::bail;
 use futures::Stream;

--- a/tests/integration/httpclient.rs
+++ b/tests/integration/httpclient.rs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+// TODO: This should be removed when the opensearch tests are implemented.
+#![cfg_attr(feature = "opensearch", allow(dead_code))]
+
 use reqwest::Client;
 use serde_json::Value;
 use std::collections::HashMap;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -3,8 +3,13 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+// TODO: This should be removed when the opensearch tests are implemented.
+#![cfg_attr(feature = "opensearch", allow(dead_code))]
+
 mod db_basic;
 mod httpclient;
+
+#[cfg(not(feature = "opensearch"))]
 mod usearch;
 
 use tracing_subscriber::EnvFilter;


### PR DESCRIPTION
According to [Paweł's comment](https://github.com/scylladb/vector-store/pull/125#pullrequestreview-2802631857) this patch introduces github workflow adjustments to check and test the code written under the opensearch feature.