### PR TITLE
VECTOR-55 Add space type to index options

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -15,6 +15,7 @@ use crate::IndexName;
 use crate::IndexVersion;
 use crate::KeyspaceName;
 use crate::ScyllaDbUri;
+use crate::SpaceType;
 use crate::TableName;
 use crate::db_index;
 use crate::db_index::DbIndex;
@@ -40,7 +41,8 @@ type LatestSchemaVersionR = anyhow::Result<Option<CqlTimeuuid>>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;
 type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;
 type GetIndexTargetTypeR = anyhow::Result<Option<Dimensions>>;
-type GetIndexParamsR = anyhow::Result<Option<(Connectivity, ExpansionAdd, ExpansionSearch)>>;
+type GetIndexParamsR =
+    anyhow::Result<Option<(Connectivity, ExpansionAdd, ExpansionSearch, SpaceType)>>;
 type IsValidIndexR = bool;
 
 pub enum Db {
@@ -406,6 +408,7 @@ impl Statements {
             Connectivity::default(),
             ExpansionAdd::default(),
             ExpansionSearch::default(),
+            SpaceType::default(),
         )))
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -116,6 +116,7 @@ pub(crate) async fn new(
                             metadata.connectivity,
                             metadata.expansion_add,
                             metadata.expansion_search,
+                            metadata.space_type,
                         )
                         .inspect_err(|err| error!("unable to create an index {id}: {err}")) else {
                             continue;

--- a/src/index/factory.rs
+++ b/src/index/factory.rs
@@ -8,6 +8,7 @@ use crate::Dimensions;
 use crate::ExpansionAdd;
 use crate::ExpansionSearch;
 use crate::IndexId;
+use crate::SpaceType;
 use crate::index::actor::Index;
 use tokio::sync::mpsc;
 
@@ -19,5 +20,6 @@ pub trait IndexFactory {
         connectivity: Connectivity,
         expansion_add: ExpansionAdd,
         expansion_search: ExpansionSearch,
+        space_type: SpaceType,
     ) -> anyhow::Result<mpsc::Sender<Index>>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
+use std::str::FromStr;
 use time::OffsetDateTime;
 use tokio::signal;
 use tokio::sync::mpsc::Sender;
@@ -289,6 +290,43 @@ pub struct ExpansionSearch(usize);
 #[derive(
     Copy,
     Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::From,
+    utoipa::ToSchema,
+)]
+pub enum SpaceType {
+    Euclidean,
+    Cosine,
+    DotProduct,
+}
+
+impl Default for SpaceType {
+    fn default() -> Self {
+        Self::Cosine
+    }
+}
+
+impl FromStr for SpaceType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "EUCLIDEAN" => Ok(Self::Euclidean),
+            "COSINE" => Ok(Self::Cosine),
+            "DOT_PRODUCT" => Ok(Self::DotProduct),
+            _ => Err(format!("Unknown space type: {s}")),
+        }
+    }
+}
+
+#[derive(
+    Copy,
+    Clone,
     serde::Serialize,
     serde::Deserialize,
     derive_more::AsRef,
@@ -356,6 +394,7 @@ pub struct IndexMetadata {
     pub connectivity: Connectivity,
     pub expansion_add: ExpansionAdd,
     pub expansion_search: ExpansionSearch,
+    pub space_type: SpaceType,
     pub version: IndexVersion,
 }
 

--- a/src/monitor_indexes.rs
+++ b/src/monitor_indexes.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::IndexMetadata;
+use crate::SpaceType;
 use crate::db::Db;
 use crate::db::DbExt;
 use crate::engine::Engine;
@@ -112,7 +113,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             continue;
         };
 
-        let (connectivity, expansion_add, expansion_search) = if let Some(params) = db
+        let (connectivity, expansion_add, expansion_search, space_type) = if let Some(params) = db
             .get_index_params(idx.keyspace.clone(), idx.index.clone())
             .await
             .inspect_err(|err| warn!("unable to get index params: {err}"))?
@@ -120,7 +121,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             params
         } else {
             debug!("get_indexes: no params for index {idx:?}");
-            (0.into(), 0.into(), 0.into())
+            (0.into(), 0.into(), 0.into(), SpaceType::default())
         };
 
         let metadata = IndexMetadata {
@@ -132,6 +133,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             connectivity,
             expansion_add,
             expansion_search,
+            space_type,
             version,
         };
 

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -30,6 +30,7 @@ use vector_store::IndexMetadata;
 use vector_store::IndexName;
 use vector_store::KeyspaceName;
 use vector_store::PrimaryKey;
+use vector_store::SpaceType;
 use vector_store::TableName;
 use vector_store::Timestamp;
 use vector_store::db::Db;
@@ -97,6 +98,7 @@ pub(crate) struct Index {
     pub(crate) connectivity: Connectivity,
     pub(crate) expansion_add: ExpansionAdd,
     pub(crate) expansion_search: ExpansionSearch,
+    pub(crate) space_type: SpaceType,
 }
 
 struct Keyspace {
@@ -323,6 +325,7 @@ fn process_db(db: &DbBasic, msg: Db) {
                         index.index.connectivity,
                         index.index.expansion_add,
                         index.index.expansion_search,
+                        index.index.space_type,
                     )
                 })))
             .map_err(|_| anyhow!("Db::GetIndexParams: unable to send response"))

--- a/tests/integration/usearch.rs
+++ b/tests/integration/usearch.rs
@@ -33,6 +33,7 @@ async fn simple_create_search_delete_index() {
         connectivity: Default::default(),
         expansion_add: Default::default(),
         expansion_search: Default::default(),
+        space_type: Default::default(),
         version: Uuid::new_v4().into(),
     };
 
@@ -68,6 +69,7 @@ async fn simple_create_search_delete_index() {
             connectivity: index.connectivity,
             expansion_add: index.expansion_add,
             expansion_search: index.expansion_search,
+            space_type: index.space_type,
         },
     )
     .unwrap();


### PR DESCRIPTION
This patch adds space type to index options as we want it to be customizable.