### PR TITLE
cleanup: remove unnecessary attributes and comments

### DIFF
--- a/src/index/opensearch.rs
+++ b/src/index/opensearch.rs
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-// TODO: Please remove if necessary implementation is provided.
-#![allow(dead_code)]
-
 use crate::Connectivity;
 use crate::Dimensions;
 use crate::Distance;
@@ -252,7 +249,6 @@ async fn process(
     opensearch_key: Arc<AtomicU64>,
     client: Arc<OpenSearch>,
 ) {
-    // TODO: Implement the logic for processing the messages
     match msg {
         Index::AddOrReplace {
             primary_key,

--- a/tests/integration/db_basic.rs
+++ b/tests/integration/db_basic.rs
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-// TODO: This should be removed when the opensearch tests are implemented.
-#![cfg_attr(feature = "opensearch", allow(dead_code))]
-
 use anyhow::anyhow;
 use anyhow::bail;
 use futures::Stream;

--- a/tests/integration/httpclient.rs
+++ b/tests/integration/httpclient.rs
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-// TODO: This should be removed when the opensearch tests are implemented.
-#![cfg_attr(feature = "opensearch", allow(dead_code))]
-
 use reqwest::Client;
 use serde_json::Value;
 use std::collections::HashMap;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-// TODO: This should be removed when the opensearch tests are implemented.
-#![cfg_attr(feature = "opensearch", allow(dead_code))]
-
 mod db_basic;
 mod httpclient;
 

--- a/tests/integration/usearch.rs
+++ b/tests/integration/usearch.rs
@@ -17,7 +17,6 @@ use tokio::time;
 use uuid::Uuid;
 use vector_store::IndexMetadata;
 
-#[cfg(not(feature = "opensearch"))]
 #[tokio::test]
 async fn simple_create_search_delete_index() {
     crate::enable_tracing();


### PR DESCRIPTION
Removed `#![allow(dead_code)]` attributes as this should be checked by CI since we implemented all the necessities.

Same reasoning for removing the comments related to missing implementation of OpenSearch integration.