### PR TITLE
VECTOR-74: Remove opensearch feature flag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,9 +42,6 @@ jobs:
     - name: Clippy check
       run: cargo clippy --all-targets
 
-    - name: Clippy check with opensearch feature
-      run: cargo clippy --all-targets --features opensearch
-
   tests:
     runs-on: ubuntu-latest
     steps:
@@ -58,7 +55,3 @@ jobs:
 
     - name: Run tests
       run: cargo test --verbose
-
-    - name: Run tests with opensearch feature
-      run: cargo test --verbose --features opensearch
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-default = ["dep:usearch"]
-opensearch = ["dep:opensearch"]
+default = []
 
 [dependencies]
 anyhow = "1.0.97"
@@ -21,7 +20,7 @@ derive_more = { version = "2.0.1", features = ["full"] }
 dotenvy = "0.15.7"
 futures = "0.3.31"
 itertools = "0.14.0"
-opensearch = { version = "2.3.0", optional = true }
+opensearch = { version = "2.3.0" }
 rayon = "1.10.0"
 regex = "1.11.1"
 scylla = { version = "1.1.0", features = ["time-03"] }
@@ -34,7 +33,7 @@ tokio = { version = "1.44.1", features = ["full"] }
 tower-http = { version = "0.6.2", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-usearch = { git = "https://github.com/unum-cloud/usearch.git", rev = "306d6646", optional = true }
+usearch = { git = "https://github.com/unum-cloud/usearch.git", rev = "306d6646" }
 utoipa = { version = "5.3.1", features = ["axum_extras"] }
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -82,7 +82,7 @@ impl EngineExt for mpsc::Sender<Engine> {
 
 pub(crate) async fn new(
     db: mpsc::Sender<Db>,
-    index_factory: impl IndexFactory + Send + 'static,
+    index_factory: Box<dyn IndexFactory + Send>,
 ) -> anyhow::Result<mpsc::Sender<Engine>> {
     let (tx, mut rx) = mpsc::channel(10);
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -8,7 +8,6 @@ pub mod factory;
 
 pub(crate) use actor::Index;
 pub(crate) use actor::IndexExt;
-#[cfg(feature = "opensearch")]
+
 pub(crate) mod opensearch;
-#[cfg(not(feature = "opensearch"))]
 pub(crate) mod usearch;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -6,21 +6,23 @@
 mod db_basic;
 mod httpclient;
 
-#[cfg(not(feature = "opensearch"))]
 mod usearch;
 
-#[cfg(feature = "opensearch")]
 mod mock_opensearch;
-#[cfg(feature = "opensearch")]
 mod opensearch;
 
+use std::sync::Once;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
 
+static INIT_TRACING: Once = Once::new();
+
 fn enable_tracing() {
-    tracing_subscriber::registry()
-        .with(EnvFilter::try_new("info").unwrap())
-        .with(fmt::layer().with_target(false))
-        .init();
+    INIT_TRACING.call_once(|| {
+        tracing_subscriber::registry()
+            .with(EnvFilter::try_new("info").unwrap())
+            .with(fmt::layer().with_target(false))
+            .init();
+    });
 }

--- a/tests/integration/opensearch.rs
+++ b/tests/integration/opensearch.rs
@@ -38,7 +38,7 @@ async fn simple_create_search_delete_index() {
     };
     let server = mock_opensearch::TestOpenSearchServer::start().await;
 
-    let index_factory = vector_store::new_index_factory(server.base_url()).unwrap();
+    let index_factory = vector_store::new_index_factory_opensearch(server.base_url()).unwrap();
 
     let (_server_actor, addr) = vector_store::run(
         SocketAddr::from(([127, 0, 0, 1], 0)).into(),

--- a/tests/integration/usearch.rs
+++ b/tests/integration/usearch.rs
@@ -36,7 +36,7 @@ async fn simple_create_search_delete_index() {
         version: Uuid::new_v4().into(),
     };
 
-    let index_factory = vector_store::new_index_factory().unwrap();
+    let index_factory = vector_store::new_index_factory_usearch().unwrap();
 
     let (_server_actor, addr) = vector_store::run(
         SocketAddr::from(([127, 0, 0, 1], 0)).into(),


### PR DESCRIPTION
Removed `opensearch` feature.
Now both the code for Usearch and OpenSearch are compiled and available to use.

This change is required to build docker image able to use either provider. 
One of the above is now chosen setting `SCYLLA_INDEXING_PROVIDER` environmental variable to `opensearch` or `usearch` respectively. By default the Usearch is being used.

Fixes: VECTOR-74 (Add opensearch index)
