### PR TITLE
Change docker image OS to RedHat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:1.86 AS build
+FROM rust:1.87 AS build
 WORKDIR /build/vector-store-build
 RUN --mount=type=bind,target=.,rw cargo b -r && cp target/release/vector-store ..
 
-FROM ubuntu:24.04
+FROM redhat/ubi9-minimal
 RUN mkdir /opt/vector-store
 COPY --from=build /build/vector-store /opt/vector-store
-CMD /opt/vector-store/vector-store
+CMD ["/opt/vector-store/vector-store"]


### PR DESCRIPTION
Scylla changed based container image to RedHat. Vector-Store should
follow this approach.

Fixes: VS-86

---

### List of PRs for [VS-86](https://scylladb.atlassian.net/browse/VS-86)
- -> Change docker image OS to RedHat



[VS-86]: https://scylladb.atlassian.net/browse/VS-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ