### PR TITLE
Refactor message processing in engine

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ pub async fn run(
     addr: HttpServerAddr,
     background_threads: Option<usize>,
     db_actor: Sender<Db>,
-    index_factory: Box<dyn IndexFactory + Send>,
+    index_factory: Box<dyn IndexFactory + Send + Sync>,
 ) -> anyhow::Result<(impl Sized, SocketAddr)> {
     if let Some(background_threads) = background_threads {
         INIT_RAYON.call_once(|| {
@@ -456,11 +456,13 @@ pub async fn new_db(uri: ScyllaDbUri) -> anyhow::Result<Sender<Db>> {
     db::new(uri).await
 }
 
-pub fn new_index_factory_usearch() -> anyhow::Result<Box<dyn IndexFactory + Send>> {
+pub fn new_index_factory_usearch() -> anyhow::Result<Box<dyn IndexFactory + Send + Sync>> {
     Ok(Box::new(index::usearch::new_usearch()?))
 }
 
-pub fn new_index_factory_opensearch(addr: String) -> anyhow::Result<Box<dyn IndexFactory + Send>> {
+pub fn new_index_factory_opensearch(
+    addr: String,
+) -> anyhow::Result<Box<dyn IndexFactory + Send + Sync>> {
     Ok(Box::new(index::opensearch::new_opensearch(&addr)?))
 }
 


### PR DESCRIPTION
Divide one big function with enum and processing logic into several
functions which are responsible for processing single messages.

Reference: VS-90

---

### List of PRs for [VS-90](https://scylladb.atlassian.net/browse/VS-90)
- -> Refactor message processing in engine
- #151



[VS-90]: https://scylladb.atlassian.net/browse/VS-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ