### PR TITLE
VS-84: Add /api/v1/info route to REST API

### DIFF
--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -14,6 +14,7 @@ use crate::db_index::DbIndexExt;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::index::IndexExt;
+use crate::info::Info;
 use anyhow::bail;
 use axum::Router;
 use axum::extract;
@@ -267,8 +268,8 @@ pub struct InfoResponse {
 )]
 async fn get_info() -> response::Json<InfoResponse> {
     response::Json(InfoResponse {
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        service: env!("CARGO_PKG_NAME").to_string(),
+        version: Info::version().to_string(),
+        service: Info::name().to_string(),
     })
 }
 

--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -56,6 +56,7 @@ pub(crate) fn new(engine: Sender<Engine>) -> Router {
                 .routes(routes!(get_indexes))
                 .routes(routes!(get_index_count))
                 .routes(routes!(post_index_ann))
+                .routes(routes!(get_info))
                 .layer(TraceLayer::new_for_http())
                 .with_state(engine),
         )
@@ -248,6 +249,27 @@ fn to_json(value: CqlValue) -> Value {
 
         _ => unimplemented!(),
     }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+pub struct InfoResponse {
+    pub version: String,
+    pub service: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/info",
+    description = "Get application info",
+    responses(
+        (status = 200, description = "Application info", body = InfoResponse)
+    )
+)]
+async fn get_info() -> response::Json<InfoResponse> {
+    response::Json(InfoResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        service: env!("CARGO_PKG_NAME").to_string(),
+    })
 }
 
 #[cfg(test)]

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,11 @@
+pub struct Info;
+
+impl Info {
+    pub fn name() -> &'static str {
+        env!("CARGO_PKG_NAME")
+    }
+
+    pub fn version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod engine;
 pub mod httproutes;
 mod httpserver;
 mod index;
+mod info;
 mod monitor_indexes;
 mod monitor_items;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::net::ToSocketAddrs;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
+mod info;
 
 // Index creating/querying is CPU bound task, so that vector-store uses rayon ThreadPool for them.
 // From the start there was no need (network traffic seems to be not so high) to support more than
@@ -19,6 +20,12 @@ async fn main() -> anyhow::Result<()> {
         .with(EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("info"))?)
         .with(fmt::layer().with_target(false))
         .init();
+
+    tracing::info!(
+        "Starting {} version {}",
+        info::Info::name(),
+        info::Info::version()
+    );
 
     let scylla_usearch_addr = dotenvy::var("SCYLLA_USEARCH_URI")
         .unwrap_or("127.0.0.1:6080".to_string())

--- a/tests/integration/httpclient.rs
+++ b/tests/integration/httpclient.rs
@@ -13,6 +13,7 @@ use vector_store::Embedding;
 use vector_store::IndexId;
 use vector_store::IndexMetadata;
 use vector_store::Limit;
+use vector_store::httproutes::InfoResponse;
 use vector_store::httproutes::PostIndexAnnRequest;
 use vector_store::httproutes::PostIndexAnnResponse;
 
@@ -74,5 +75,16 @@ impl HttpClient {
             .json::<usize>()
             .await
             .ok()
+    }
+
+    pub(crate) async fn info(&self) -> InfoResponse {
+        self.client
+            .get(format!("{}/info", self.url_api))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap()
     }
 }

--- a/tests/integration/info.rs
+++ b/tests/integration/info.rs
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::db_basic;
+use crate::httpclient::HttpClient;
+use std::net::SocketAddr;
+
+#[tokio::test]
+async fn get_applicaiton_info() {
+    let (db_actor, _) = db_basic::new();
+    let (_server_actor, addr) = vector_store::run(
+        SocketAddr::from(([127, 0, 0, 1], 0)).into(),
+        Some(1),
+        db_actor,
+        vector_store::new_index_factory_usearch().unwrap(),
+    )
+    .await
+    .unwrap();
+    let client = HttpClient::new(addr);
+
+    let info = client.info().await;
+
+    assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(info.service, env!("CARGO_PKG_NAME"));
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -11,6 +11,8 @@ mod usearch;
 mod mock_opensearch;
 mod opensearch;
 
+mod info;
+
 use std::sync::Once;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;


### PR DESCRIPTION
Add /api/v1/info route to REST API
Add logging of service name and version at startup

This PR introduces a new /api/v1/info endpoint to provide service metadata.
A GET request to this endpoint returns a JSON object containing the service name and version.
The PR also adds logging the service name and version upon startup.

Closes https://scylladb.atlassian.net/browse/VS-84