### PR TITLE
Add Prometheus metrics infrastructure with index latency tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,7 +2004,7 @@ dependencies = [
  "smallvec",
  "snap",
  "socket2",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "uuid",
@@ -2008,7 +2043,7 @@ dependencies = [
  "scylla-macros",
  "snap",
  "stable_deref_trait",
- "thiserror",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "uuid",
@@ -2311,11 +2346,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2760,6 +2815,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "opensearch",
+ "prometheus",
  "rayon",
  "regex",
  "reqwest",
@@ -2767,7 +2823,7 @@ dependencies = [
  "scylla-cdc",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tower-http",
@@ -3284,7 +3340,7 @@ dependencies = [
  "flate2",
  "indexmap 2.8.0",
  "memchr",
- "thiserror",
+ "thiserror 2.0.12",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ utoipa = { version = "5.3.1", features = ["axum_extras"] }
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
 uuid = "1.16.0"
+prometheus = "0.14"
+
 
 [patch.crates-io]
 scylla = { git = "https://github.com/ewienik/scylla-rust-driver.git", rev = "5fef6ae" }

--- a/src/httproutes.rs
+++ b/src/httproutes.rs
@@ -2,7 +2,8 @@
  * Copyright 2025-present ScyllaDB
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
-
+use crate::metrics::Metrics;
+use std::sync::Arc;
 use crate::ColumnName;
 use crate::Distance;
 use crate::Embedding;
@@ -39,7 +40,7 @@ use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
 use utoipa_swagger_ui::SwaggerUi;
-
+use axum::routing::get;
 #[derive(OpenApi)]
 #[openapi(
     tags(
@@ -48,8 +49,10 @@ use utoipa_swagger_ui::SwaggerUi;
 )]
 // TODO: modify HTTP API after design
 struct ApiDoc;
-
-pub(crate) fn new(engine: Sender<Engine>) -> Router {
+#[derive(Clone)]
+struct RoutesInnerState { engine: Sender<Engine>, metrics: Arc<Metrics>}
+pub(crate) fn new(engine: Sender<Engine>, metrics: Arc<Metrics>) -> Router {
+    let state = RoutesInnerState { engine, metrics: metrics.clone() };
     let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .merge(
             OpenApiRouter::new()
@@ -57,11 +60,20 @@ pub(crate) fn new(engine: Sender<Engine>) -> Router {
                 .routes(routes!(get_index_count))
                 .routes(routes!(post_index_ann))
                 .layer(TraceLayer::new_for_http())
-                .with_state(engine),
+                .with_state(state)
+
         )
         .split_for_parts();
 
+    let metrics_route = Router::new().route(
+        "/metrics",
+        get({
+            let metrics = metrics.clone();
+            move || metrics.clone().handler()
+        }),
+    );
     router.merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", api))
+    .merge(metrics_route)
 }
 
 #[utoipa::path(
@@ -72,8 +84,8 @@ pub(crate) fn new(engine: Sender<Engine>) -> Router {
         (status = 200, description = "List of indexes", body = [IndexId])
     )
 )]
-async fn get_indexes(State(engine): State<Sender<Engine>>) -> response::Json<Vec<IndexId>> {
-    response::Json(engine.get_index_ids().await)
+async fn get_indexes(State(state): State<RoutesInnerState>) -> response::Json<Vec<IndexId>> {
+    response::Json(state.engine.get_index_ids().await)
 }
 
 #[utoipa::path(
@@ -89,10 +101,10 @@ async fn get_indexes(State(engine): State<Sender<Engine>>) -> response::Json<Vec
     )
 )]
 async fn get_index_count(
-    State(engine): State<Sender<Engine>>,
+    State(state): State<RoutesInnerState>,
     Path((keyspace, index)): Path<(KeyspaceName, IndexName)>,
 ) -> Response {
-    let Some((index, _)) = engine.get_index(IndexId::new(&keyspace, &index)).await else {
+    let Some((index, _)) = state.engine.get_index(IndexId::new(&keyspace, &index)).await else {
         debug!("get_index_size: missing index: {keyspace}/{index}");
         return (StatusCode::NOT_FOUND, "").into_response();
     };
@@ -134,16 +146,30 @@ pub struct PostIndexAnnResponse {
         (status = 404, description = "Index not found")
     )
 )]
+
 async fn post_index_ann(
-    State(engine): State<Sender<Engine>>,
+    State(state): State<RoutesInnerState>,
     Path((keyspace, index)): Path<(KeyspaceName, IndexName)>,
     extract::Json(request): extract::Json<PostIndexAnnRequest>,
 ) -> Response {
-    let Some((index, db_index)) = engine.get_index(IndexId::new(&keyspace, &index)).await else {
+    // Start timing
+    let timer = state.metrics
+            .latency
+            .with_label_values(&[
+                keyspace.as_ref().as_str(),
+                index.as_ref().as_str()
+            ])
+            .start_timer();
+
+    let Some((index, db_index)) = state.engine.get_index(IndexId::new(&keyspace, &index)).await else {
         return (StatusCode::NOT_FOUND, "").into_response();
     };
 
-    match index.ann(request.embedding, request.limit).await {
+    let search_result = index.ann(request.embedding, request.limit).await;
+    // Record duration in Prometheus
+    timer.observe_duration();
+
+    match search_result {
         Err(err) => {
             let msg = format!("index.ann request error: {err}");
             debug!("post_index_ann: {msg}");

--- a/src/httpserver.rs
+++ b/src/httpserver.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::metrics::Metrics;
 use crate::HttpServerAddr;
 use crate::engine::Engine;
 use crate::httproutes;
@@ -18,6 +19,7 @@ pub(crate) enum HttpServer {}
 pub(crate) async fn new(
     addr: HttpServerAddr,
     engine: Sender<Engine>,
+    metrics: Arc<Metrics>,
 ) -> anyhow::Result<(Sender<HttpServer>, SocketAddr)> {
     let listener = TcpListener::bind(addr.0).await?;
     let addr = listener.local_addr()?;
@@ -37,7 +39,7 @@ pub(crate) async fn new(
     });
 
     tokio::spawn(async move {
-        axum::serve(listener, httproutes::new(engine))
+        axum::serve(listener, httproutes::new(engine, metrics))
             .with_graceful_shutdown(async move {
                 notify.notified().await;
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod httpserver;
 mod index;
 mod monitor_indexes;
 mod monitor_items;
-
+mod metrics;
 use db::Db;
 use index::factory;
 use index::factory::IndexFactory;
@@ -27,6 +27,7 @@ use std::hash::Hasher;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
+use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::signal;
 use tokio::sync::mpsc::Sender;
@@ -39,6 +40,8 @@ use utoipa::openapi::Schema;
 use utoipa::openapi::SchemaFormat;
 use utoipa::openapi::schema::Type;
 use uuid::Uuid;
+
+use crate::metrics::Metrics;
 
 #[derive(Clone, derive_more::From, derive_more::Display)]
 pub struct ScyllaDbUri(String);
@@ -443,7 +446,8 @@ pub async fn run(
             .build_global()?;
     }
     let engine_actor = engine::new(db_actor, index_factory).await?;
-    httpserver::new(addr, engine_actor).await
+    let metrics: Arc<Metrics> = metrics::Metrics::new();
+    httpserver::new(addr, engine_actor, metrics).await
 }
 
 pub async fn new_db(uri: ScyllaDbUri) -> anyhow::Result<Sender<Db>> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,55 @@
+use prometheus::{Encoder, TextEncoder, Registry, HistogramVec};
+use axum::{response::IntoResponse, http::{StatusCode, header, HeaderMap}};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct Metrics {
+    pub registry: Registry,
+    pub latency: HistogramVec,
+}
+
+impl Metrics {
+    pub fn new() -> Arc<Self> {
+        let registry = Registry::new();
+
+        let latency = HistogramVec::new(
+            prometheus::HistogramOpts::new("request_latency_seconds", "Latency per index (seconds)"),
+            &["keyspace", "index_name"],
+        ).unwrap();
+
+        registry.register(Box::new(latency.clone())).unwrap();
+
+        Arc::new(Self {
+            registry,
+            latency,
+        })
+    }
+     pub async fn handler(self: Arc<Self>) -> impl IntoResponse {
+        let metric_families = self.registry.gather();
+        let mut buffer = Vec::new();
+        let encoder = TextEncoder::new();
+
+        match encoder.encode(&metric_families, &mut buffer) {
+            Ok(_) => {
+                let mut headers = HeaderMap::new();
+                headers.insert(
+                    header::CONTENT_TYPE,
+                    "text/plain; version=0.0.4; charset=utf-8".parse().unwrap(),
+                );
+                (StatusCode::OK, headers, buffer)
+            }
+            Err(_) => {
+                let mut headers = HeaderMap::new();
+                headers.insert(
+                    header::CONTENT_TYPE,
+                    "text/plain; charset=utf-8".parse().unwrap(),
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    headers,
+                    b"failed to encode metrics".to_vec(),
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This series introduces basic Prometheus observability to the vector search service. The following changes are included:

Prometheus dependencies were added to support metrics collection and export.

A new metrics module defines a Metrics object containing a latency histogram (request_latency_seconds) labeled by keyspace and index name.

The HTTP server and route handlers were updated to:
Wire the Metrics object through the application state.
Expose a /metrics endpoint for Prometheus scraping.
Record latency for vector search requests in the post_index_ann handler.

This lays the groundwork for more comprehensive metric tracking per index in future changes.