### PR TITLE
Update USearch dependency to version 2.17.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,8 +2651,8 @@ dependencies = [
 
 [[package]]
 name = "usearch"
-version = "2.17.2"
-source = "git+https://github.com/unum-cloud/usearch.git?rev=306d6646#306d6646b8f539cee6c3fa11879dd3bc0edfa31f"
+version = "2.17.12"
+source = "git+https://github.com/unum-cloud/usearch.git?rev=68e403a#68e403aef75311313570af5340a2612777d3a986"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1.44.1", features = ["full"] }
 tower-http = { version = "0.6.2", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-usearch = { git = "https://github.com/unum-cloud/usearch.git", rev = "306d6646" }
+usearch = { git = "https://github.com/unum-cloud/usearch.git", rev = "68e403a" }
 utoipa = { version = "5.3.1", features = ["axum_extras"] }
 utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }


### PR DESCRIPTION
There were few performance improvements since 2.17.2 so it is worth updating before proceeding to performance benchmarks. In particular this is the list of important changes: https://github.com/unum-cloud/usearch/releases/tag/v2.17.8.

Fixes: VS-89