### PR TITLE
build cloud images using packer

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,58 @@
+# ScyllaDB vector service Image
+
+## Requirements
+- Packer >= v1.10.0
+- Packer AWS and GCP plugins
+
+To install the required plugins, run the following:
+
+```shell
+packer plugins install github.com/hashicorp/googlecompute
+packer plugins install github.com/hashicorp/amazon
+```
+
+## Build
+To build the ScyllaDB vector store Image, make sure you have [Authentication](#authentication) set up, and run the following command from the `vector-store/packer` directory:
+
+```shell
+packer build -var vector_version="0.1.0" vector-store-template.json
+```
+You can build a specific cloud only by using the `-only` flag. for example:
+```shell
+# AWS only
+packer build -only=amazon-ebs -var vector_version="0.1.0" vector-store-template.json
+
+# GCP only
+packer build -only=googlecompute -var vector_version="0.1.0" vector-store-template.json
+```
+## Variables
+
+
+The ScyllaDB vector store Image uses default variables that are declared in the packer template file, for example `aws_source_ami`, `gcp_project_id` etc.
+You can override these default variables by creating a `variables.json` with the desired variable values, for example:
+
+```json
+{
+  "vector_version": "0.1.0",
+  "aws_subnet_id": "your_aws_subnet_id",
+  "gcp_project_id": "your_gcp_project_id",
+  "gcp_zone": "your_gcp_zone"
+}
+```
+And when running the packer build command, include the `-var-file` option to specify the `variables.json` file:
+
+```shell
+packer build -var-file=variables.json vector-store-template.json
+```
+
+
+## Authentication
+
+### AWS
+Ensure `aws_access_key_id` and `aws_secret_access_key` are configured either in a local credentials file (ex. `~/.aws/credentials`) or as environment variables.
+
+#### GCP
+Set your GCP service account key as an environment variable:
+```shell
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-file.json"
+```

--- a/packer/files/user_data.txt
+++ b/packer/files/user_data.txt
@@ -1,0 +1,2 @@
+#!/bin/sh
+sed -i 's/Defaults    requiretty/#Defaults    requiretty/g' /etc/sudoers

--- a/packer/files/vector-store.service
+++ b/packer/files/vector-store.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Vector Rust Service
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/home/ubuntu/vector-store/
+ExecStart=/home/ubuntu/vector-store/target/release/vector-store
+Restart=on-failure
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target

--- a/packer/files/vector_store_install_image
+++ b/packer/files/vector_store_install_image
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+
+# Copyright 2025-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+import os
+import sys
+import shlex
+import argparse
+import subprocess
+
+HOME_DIR='/home/ubuntu'
+USER='ubuntu'
+COPY_OR_MOVE='mv'
+
+def run(template_cmd, shell=False):
+    cmd = template_cmd.format(_HOME=HOME_DIR, _USER=USER, _COPY_OR_MOVE=COPY_OR_MOVE)
+    if dry_run:
+        print(cmd)
+        return
+    if verbose:
+        print(cmd)
+    if not shell:
+        cmd = shlex.split(cmd)
+    try:
+        res = subprocess.check_output(cmd, shell=shell)
+        if verbose:
+            print(res)
+        return res
+    except Exception as e:
+        print("Error while running:")
+        print(cmd,end =" ")
+        print(e.output)
+        raise
+
+def chdir(template_dir):
+    dir = template_dir.format(_HOME=HOME_DIR, _USER=USER)
+    if dry_run:
+        print('cd ', dir)
+        return
+    if verbose:
+        print('cd ', dir)
+    os.chdir(dir)
+
+def install():
+    run("apt install -y libssl-dev pkg-config build-essential")
+    run("sudo -u {_USER} -H sh -c 'curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y'")
+
+def install_vector_store(version):
+    run('sudo -u {_USER} curl -L -o {_HOME}/vector-store.tar.gz  https://github.com/scylladb/vector-store/archive/refs/tags/v{VERSION}.tar.gz'.format(VERSION=version, _HOME=HOME_DIR, _USER=USER))
+    name = 'vector-store-{VERSION}'.format(VERSION=version)
+    run('sudo -u {_USER} tar -xvf {_HOME}/vector-store.tar.gz -C {_HOME}/')
+    run('sudo -u {_USER} {_COPY_OR_MOVE} {_HOME}/{NAME} {_HOME}/vector-store'.format(NAME=name, _HOME=HOME_DIR, _USER=USER, _COPY_OR_MOVE=COPY_OR_MOVE))
+    chdir('{_HOME}/vector-store')
+    run('sudo -u {_USER} {_HOME}/.cargo/bin/cargo b -r')
+
+def install_service():
+    run('cp {_HOME}/vector-store.service /etc/systemd/system/')
+    try:
+        run('cp {_HOME}/vector-store.service /usr/lib/systemd/system/')
+    except Exception as e:
+        print("could not place vector-store file in user/lib/systemd" + str(e))
+        print(e.output)
+    run('systemctl daemon-reload')
+
+if __name__ == '__main__':
+    if os.getuid() > 0:
+        print('Requires root permission.')
+        sys.exit(1)
+    parser = argparse.ArgumentParser(description='Construct a vector store image')
+    parser.add_argument('--version', default="0.1.0", help='Monitoring version to install')
+    parser.add_argument('--cloud', default="aws", choices=['aws','gce'], help='What cloud we are running on')
+    parser.add_argument('--verbose', action='store_true', default=False, help='Verbose trace mode')
+    parser.add_argument('--do-not-move', action='store_true', default=False, help='For testing, do not move files, copy them instead')
+    parser.add_argument('-d', '--dry-run', action='store_true', default=False, help='Dry run mode')
+
+    args = parser.parse_args()
+    dry_run = args.dry_run
+    verbose = args.verbose
+
+    if args.do_not_move:
+        COPY_OR_MOVE='cp'
+    install()
+    install_vector_store(args.version)
+    install_service()

--- a/packer/vector-store-template.json
+++ b/packer/vector-store-template.json
@@ -1,0 +1,126 @@
+{
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "{{user `aws_region`}}",
+      "ami_name": "{{ user `vector_image_name` }}",
+      "source_ami": "{{user `aws_source_ami`}}",
+      "instance_type": "{{user `aws_instance_type`}}",
+      "ami_regions": "us-west-2,eu-west-2,eu-west-1,eu-central-1,eu-north-1",
+      "user_data_file": "files/user_data.txt",
+      "subnet_filter": {
+        "filters": {
+          "tag:Name": "image-build-subnet*"
+        },
+        "most_free": true,
+        "random": false
+      },
+      "associate_public_ip_address": "true",
+      "ssh_username": "{{user `aws_ssh_username`}}",
+      "ssh_timeout": "5m",
+      "ena_support": true,
+      "shutdown_behavior": "terminate",
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_type": "gp3",
+          "volume_size": 30,
+          "delete_on_termination": true
+        }
+      ],
+      "ami_org_arns": [
+        "arn:aws:organizations::978072043225:organization/o-o561yy1rs6"
+      ],
+      "snapshot_users": [
+        "797456418907",
+        "734708892259"
+      ],
+      "tags": {
+        "Name": "{{ user `vector_image_name` }}",
+        "vector-store-version": "{{ user `vector_version`| clean_resource_name }}"
+      }
+    },
+    {
+      "type": "googlecompute",
+      "project_id": "{{user `gcp_project_id`}}",
+      "zone": "{{user `gcp_zone`}}",
+      "source_image_family": "{{user `gcp_source_image_family`}}",
+      "image_storage_locations": ["{{user `gcp_image_storage_location`}}"],
+      "machine_type": "{{user `gcp_instance_type`}}",
+      "ssh_username": "{{user `gcp_ssh_username`}}",
+      "ssh_timeout": "6m",
+      "metadata": { "block-project-ssh-keys": "TRUE" },
+      "image_family": "vector-store",
+      "image_name": "{{ user `vector_image_name` }}",
+      "instance_name": "{{ user `vector_image_name` }}",
+      "image_description": "ScyllaDB vector store service {{user `vector_version`| clean_resource_name}}",
+      "use_internal_ip": false,
+      "preemptible": true,
+      "omit_external_ip": false,
+      "disk_size": 40,
+      "disk_type": "pd-balanced",
+      "image_labels": {
+        "vector-store-version": "{{ user `vector_version`| clean_resource_name }}"
+      },
+      "labels": {
+        "keep": 1,
+        "keep_action": "terminate"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "files/",
+      "destination": "/home/ubuntu/"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo apt-get update --fix-missing -y",
+        "sudo apt-get upgrade -y",
+        "sudo apt-get install -y python3-setuptools",
+        "sudo apt-get install -y python3-pip"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo /home/{{user `aws_ssh_username`}}/vector_store_install_image {{ user `aws_install_args` }}"
+      ],
+      "only": ["amazon-ebs"]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo /home/{{user `gcp_ssh_username`}}/vector_store_install_image {{ user `gcp_install_args` }}"
+      ],
+      "only": ["googlecompute"]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "packer-manifest.json",
+      "strip_path": true
+    }
+  ],
+  "variables": {
+    "vector_version": "",
+    "vector_image_name": "vector-store-{{ user `vector_version` | replace_all \".\" \"-\" }}-{{ isotime \"2006-01-02t03-04-05z\" }}",
+
+    "aws_region": "us-east-1",
+    "aws_source_ami": "ami-020cba7c55df1f615",
+    "aws_instance_type": "c4.xlarge",
+    "aws_ssh_username": "ubuntu",
+    "aws_install_args": "--cloud aws --verbose --version {{ user `vector_version` }}",
+
+    "gcp_project_id": "scylla-images",
+    "gcp_zone": "europe-west1-b",
+    "gcp_source_image_family": "ubuntu-minimal-2204-lts",
+    "gcp_image_storage_location": "europe-west1",
+    "gcp_instance_type": "n1-standard-1",
+    "gcp_ssh_username": "ubuntu",
+    "gcp_install_args": "--cloud gce --verbose --version {{ user `vector_version` }}"
+  }
+}


### PR DESCRIPTION
This patch adds image creation using packer.
It can build images for AWS and GCE.

Currently, the code does not compile on ubuntu mimial, as a workaround AWS image is based on regular ubuntu.

Fixes https://scylladb.atlassian.net/browse/VECTOR-65