### PR TITLE
Add bad request to search response

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -84,6 +84,9 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request. Possible causes: invalid embedding size, malformed input, or missing required fields."
+          },
           "404": {
             "description": "Index not found. Possible causes: index does not exist, or is not built yet."
           },

--- a/crates/vector-store/src/index/mod.rs
+++ b/crates/vector-store/src/index/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod actor;
 pub mod factory;
+pub mod validator;
 
 pub(crate) use actor::Index;
 pub(crate) use actor::IndexExt;

--- a/crates/vector-store/src/index/validator.rs
+++ b/crates/vector-store/src/index/validator.rs
@@ -1,0 +1,92 @@
+use crate::Dimensions;
+use crate::Embedding;
+use anyhow::bail;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Wrong embedding dimension: expected {expected}, got {actual}")]
+    WrongEmbeddingDimension { expected: usize, actual: usize },
+}
+
+pub fn embedding_dimensions(embedding: &Embedding, dimensions: Dimensions) -> anyhow::Result<()> {
+    let Some(embedding_len) = std::num::NonZeroUsize::new(embedding.0.len()) else {
+        bail!(Error::WrongEmbeddingDimension {
+            expected: dimensions.0.get(),
+            actual: 0,
+        });
+    };
+    if embedding_len != dimensions.0 {
+        bail!(Error::WrongEmbeddingDimension {
+            expected: dimensions.0.get(),
+            actual: embedding_len.get(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroUsize;
+
+    fn dims(n: usize) -> Dimensions {
+        Dimensions(NonZeroUsize::new(n).unwrap())
+    }
+
+    #[test]
+    fn validate_embedding_empty() {
+        let embedding = Embedding(vec![]);
+        let dimensions = dims(3);
+
+        let result = embedding_dimensions(&embedding, dimensions);
+
+        assert!(matches!(
+            result.unwrap_err().downcast_ref::<Error>(),
+            Some(Error::WrongEmbeddingDimension {
+                expected: 3,
+                actual: 0
+            })
+        ));
+    }
+
+    #[test]
+    fn validate_embedding_too_short() {
+        let embedding = Embedding(vec![0.1, 0.2]);
+        let dimensions = dims(3);
+
+        let result = embedding_dimensions(&embedding, dimensions);
+
+        assert!(matches!(
+            result.unwrap_err().downcast_ref::<Error>(),
+            Some(Error::WrongEmbeddingDimension {
+                expected: 3,
+                actual: 2
+            })
+        ));
+    }
+
+    #[test]
+    fn validate_embedding_too_long() {
+        let embedding = Embedding(vec![0.1, 0.2, 0.3, 0.4]);
+        let dimensions = dims(3);
+        let result = embedding_dimensions(&embedding, dimensions);
+        assert!(matches!(
+            result.unwrap_err().downcast_ref::<Error>(),
+            Some(Error::WrongEmbeddingDimension {
+                expected: 3,
+                actual: 4
+            })
+        ));
+    }
+
+    #[test]
+    fn validate_embedding_ok() {
+        let embedding = Embedding(vec![0.1, 0.2, 0.3]);
+        let dimensions = dims(3);
+
+        let result = embedding_dimensions(&embedding, dimensions);
+
+        assert!(matches!(result, Ok(())));
+    }
+}

--- a/crates/vector-store/tests/integration/httpclient.rs
+++ b/crates/vector-store/tests/integration/httpclient.rs
@@ -48,7 +48,21 @@ impl HttpClient {
         limit: Limit,
     ) -> (HashMap<ColumnName, Vec<Value>>, Vec<Distance>) {
         let resp = self
-            .client
+            .post_ann(index, embedding, limit)
+            .await
+            .json::<PostIndexAnnResponse>()
+            .await
+            .unwrap();
+        (resp.primary_keys, resp.distances)
+    }
+
+    pub(crate) async fn post_ann(
+        &self,
+        index: &IndexMetadata,
+        embedding: Embedding,
+        limit: Limit,
+    ) -> reqwest::Response {
+        self.client
             .post(format!(
                 "{}/indexes/{}/{}/ann",
                 self.url_api, index.keyspace_name, index.index_name
@@ -57,10 +71,6 @@ impl HttpClient {
             .send()
             .await
             .unwrap()
-            .json::<PostIndexAnnResponse>()
-            .await
-            .unwrap();
-        (resp.primary_keys, resp.distances)
     }
 
     pub(crate) async fn count(&self, index: &IndexMetadata) -> Option<usize> {


### PR DESCRIPTION
Add 400 response when embedding in search request has wrong size

This commit adds a 400 (Bad Request) response to the /ann search endpoint when the embedding vector size does not match the index dimension.

Reference: VECTOR-32