### PR TITLE
Add stub for /api/v1/status endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,6 +2833,16 @@ dependencies = [
  "utoipa-axum",
  "utoipa-swagger-ui",
  "uuid",
+ "vector-store-macros",
+]
+
+[[package]]
+name = "vector-store-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ utoipa-axum = "0.2.0"
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
 uuid = "1.16.0"
 prometheus = "0.14"
-
+vector-store-macros = { path = "./vector-store-macros" }
 
 [dev-dependencies]
 reqwest = { version = "0.12.15", features = ["json"] }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -161,6 +161,27 @@
           }
         }
       }
+    },
+    "/api/v1/status": {
+      "get": {
+        "tags": [
+          "scylla-vector-store-info"
+        ],
+        "description": "Returns the current operational status of the Vector Store node.",
+        "operationId": "get_status",
+        "responses": {
+          "200": {
+            "description": "Successful operation. Returns the current operational status of the Vector Store node.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Status"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -270,6 +291,24 @@
         "description": "Data type and precision used for storing and processing embedding vectors in the index.",
         "enum": [
           "F32"
+        ]
+      },
+      "Status": {
+        "type": "string",
+        "description": "Operational status of the Vector Store node.",
+        "enum": [
+          "INITIALIZING",
+          "CONNECTING_TO_DB",
+          "DISCOVERING_INDEXES",
+          "INDEXING_EMBEDDINGS",
+          "SERVING"
+        ],
+        "x-enum-descriptions": [
+          "The node is starting up.",
+          "The node is establishing a connection to ScyllaDB.",
+          "The node is discovering available vector indexes in ScyllaDB.",
+          "The node is indexing embeddings into the discovered vector indexes.",
+          "The node has completed the initial database scan and built the indexes defined at that time. It is now monitoring the database for changes."
         ]
       }
     }

--- a/vector-store-macros/Cargo.toml
+++ b/vector-store-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "vector-store-macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/vector-store-macros/src/lib.rs
+++ b/vector-store-macros/src/lib.rs
@@ -1,0 +1,107 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DataEnum, DeriveInput, parse_macro_input};
+
+#[proc_macro_derive(ToEnumSchema)]
+pub fn derive_to_enum_schema(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let enum_name = &input.ident;
+    let variants = match &input.data {
+        Data::Enum(DataEnum { variants, .. }) => variants,
+        _ => panic!("ToEnumSchema can only be derived for enums"),
+    };
+
+    let enum_doc = get_enum_doc(&input).unwrap_or(enum_name.to_string());
+
+    let (variant_values, variant_docs): (Vec<_>, Vec<_>) = variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            let doc = get_variant_doc(variant).unwrap_or_default();
+            (quote! { #enum_name::#variant_ident }, doc)
+        })
+        .unzip();
+
+    let schema = quote! {
+        let enum_values = vec![#(#variant_values),*];
+        let enum_descriptions = vec![#(#variant_docs.to_string()),*];
+        let enum_names: Vec<String> = enum_values.iter().map(|variant| {
+            serde_json::to_value(variant).unwrap().as_str().unwrap().to_string()
+        }).collect();
+
+        let extension = utoipa::openapi::extensions::Extensions::builder()
+            .add(
+                "x-enum-descriptions",
+                enum_descriptions,
+            )
+            .build();
+
+        utoipa::openapi::schema::Object::builder()
+            .schema_type(utoipa::openapi::schema::SchemaType::new(
+                utoipa::openapi::schema::Type::String,
+            ))
+            .description(Some(#enum_doc))
+            .enum_values(Some(enum_names))
+            .extensions(Some(extension))
+            .build()
+            .into()
+    };
+
+    let expanded = quote! {
+        impl utoipa::PartialSchema for #enum_name {
+            fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                #schema
+            }
+        }
+        impl utoipa::ToSchema for #enum_name {}
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn get_variant_doc(variant: &syn::Variant) -> Option<String> {
+    variant.attrs.iter().find_map(|attr| {
+        if attr.path().is_ident("doc") {
+            if let syn::Meta::NameValue(nv) = &attr.meta {
+                if let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(lit),
+                    ..
+                }) = &nv.value
+                {
+                    return Some(lit.value().trim().to_string());
+                }
+            }
+        }
+        None
+    })
+}
+
+fn get_enum_doc(input: &DeriveInput) -> Option<String> {
+    let doc = input
+        .attrs
+        .iter()
+        .filter(|attr| matches!(attr.meta, syn::Meta::NameValue(ref nv) if nv.path.is_ident("doc")))
+        .filter_map(|attr| {
+            if let syn::Meta::NameValue(nv) = &attr.meta {
+                if let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(lit),
+                    ..
+                }) = &nv.value
+                {
+                    let value = lit.value().trim().to_string();
+                    if !value.is_empty() {
+                        return Some(value);
+                    }
+                }
+            }
+            None
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if doc.is_empty() {
+        None
+    } else {
+        Some(doc.trim().to_string())
+    }
+}


### PR DESCRIPTION
Add stub for /api/v1/status endpoint

Introduce a stub /api/v1/status endpoint for future service status reporting.

Add a custom ToEnumSchema macro to generate x-enum-description fields in the OpenAPI spec,
addressing the limitation in utoipa where enum variant documentation is not included (see: https://github.com/juhaku/utoipa/issues/1317).

Reference: VECTOR-92