### PR TITLE
vsc: read from vsc log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,8 +2020,7 @@ dependencies = [
 [[package]]
 name = "scylla-cdc"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef47312c2d9ab846dd5117773dd01df4122de8b36f54945970c4f25614f4f80"
+source = "git+https://github.com/QuerthDP/scylla-cdc-rust.git?rev=d454411c54ce18685f8c187a0d752ae5112b630f#d454411c54ce18685f8c187a0d752ae5112b630f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rayon = "1.10.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.15", features = ["json"] }
 scylla = { version = "1.2.0", features = ["time-03"] }
-scylla-cdc = "0.4.0"
+scylla-cdc = { git = "https://github.com/QuerthDP/scylla-cdc-rust.git", rev = "d454411c54ce18685f8c187a0d752ae5112b630f" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 syn = { version = "2.0", features = ["full"] }

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -479,10 +479,10 @@ impl Statements {
             return false;
         }
 
-        // check a cdc log table
+        // check a vsc log table
         if !keyspace
             .tables
-            .contains_key(&format!("{}_scylla_cdc_log", metadata.table_name))
+            .contains_key(&format!("{}_scylla_vsc_log", metadata.table_name))
         {
             return false;
         }

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -25,6 +25,7 @@ use scylla_cdc::consumer::CDCRow;
 use scylla_cdc::consumer::Consumer;
 use scylla_cdc::consumer::ConsumerFactory;
 use scylla_cdc::log_reader::CDCLogReaderBuilder;
+use scylla_cdc::log_reader::LogTableType;
 use std::iter;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -83,6 +84,7 @@ pub(crate) async fn new(
             &metadata,
             tx_embeddings.clone(),
         )?))
+        .log_table(LogTableType::VSC)
         .build()
         .await?;
 


### PR DESCRIPTION
Set `CDCLogReader` to read from `_scylla_vsc_log` tables.

Fixes: VECTOR-91