### PR TITLE
Introduce configuration of the Rust toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ service supports also `.env` files. Supported parameters:
 
 ## Development builds
 
+You need to install [Rust
+environment](https://www.rust-lang.org/tools/install). To install all
+components run `rustup install` in the main directory of the repository.
+
 Development workflow is similar to the typical `Cargo` development in Rust.
 
 ```
 $ cargo b [-r]
 $ cargo r [-r]
 ```
-
 
 ## Docker image
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.88.0"
+components = ["clippy", "rustfmt", "cargo"]


### PR DESCRIPTION
This patch setup a specific version of the Rust toolchain for the
product, to be able to reproduce binary with the same environment.

It updates documentation how to prepare the Rust environment.

Fixes: VECTOR-106
