### PR TITLE
Use workspace package keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ members = ["crates/*"]
 default-members = ["crates/vector-store"]
 resolver = "3"
 
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+
 [workspace.dependencies]
 anyhow = "1.0.97"
 async-trait = "0.1.88"

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "macros"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -5,8 +5,8 @@
 
 [package]
 name = "vector-store"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 default-run = "vector-store"
 
 [[bin]]


### PR DESCRIPTION
For easier maintenance creates can use keys from workspace Cargo.toml.
This patch introduce usage of workspace's version & edition keys.

Reference: VECTOR-107

---

### List of PRs for [VECTOR-107](https://scylladb.atlassian.net/browse/VECTOR-107)
- #175
- -> Use workspace package keys



[VECTOR-107]: https://scylladb.atlassian.net/browse/VECTOR-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ