### PR TITLE
fix: remove index metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -212,7 +212,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -473,7 +473,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -486,7 +486,7 @@ dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -504,7 +504,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "unicode-xid",
 ]
 
@@ -616,7 +616,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -770,7 +770,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1152,7 +1152,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1333,7 +1333,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1411,6 +1411,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntest"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb183f0a1da7a937f672e5ee7b7edb727bf52b8a52d531374ba8ebb9345c0330"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d0d3f2a488592e5368ebbe996e7f1d44aa13156efad201f5b4d84e150eaa93"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc7c92f190c97f79b4a332f5e81dcf68c8420af2045c936c9be0bc9de6f63b5"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,7 +1486,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1514,7 +1547,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1869,7 +1902,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn",
+ "syn 2.0.100",
  "walkdir",
 ]
 
@@ -2066,7 +2099,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2115,7 +2148,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2179,7 +2212,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2280,6 +2313,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
@@ -2306,7 +2350,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2378,7 +2422,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2389,7 +2433,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2469,7 +2513,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2601,7 +2645,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2767,7 +2811,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2823,6 +2867,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "macros",
+ "ntest",
  "opensearch",
  "prometheus",
  "rayon",
@@ -2913,7 +2958,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2948,7 +2993,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3243,7 +3288,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3273,7 +3318,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3284,7 +3329,7 @@ checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3304,7 +3349,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3333,7 +3378,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dotenvy = "0.15.7"
 futures = "0.3.31"
 itertools = "0.14.0"
 macros = { path = "crates/macros" }
+ntest = "0.9.3"
 opensearch = { version = "2.3.0" }
 proc-macro2 = "1.0"
 prometheus = "0.14"

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -28,6 +28,7 @@ dotenvy.workspace = true
 futures.workspace = true
 itertools.workspace = true
 macros.workspace = true
+ntest.workspace = true
 opensearch.workspace = true
 prometheus.workspace = true
 rayon.workspace = true

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -63,7 +63,7 @@ pub(crate) async fn new(
                         node_state.send_event(
                             Event::IndexesDiscovered(new_indexes.clone()),
                         ).await;
-                        del_indexes(&engine, indexes.difference(&new_indexes)).await;
+                        del_indexes(&engine, indexes.extract_if(|idx| !new_indexes.contains(idx))).await;
                         let AddIndexesR {added, has_failures} = add_indexes(
                             &engine,
                             new_indexes.into_iter().filter(|idx| !indexes.contains(idx))
@@ -197,7 +197,7 @@ async fn add_indexes(
     }
 }
 
-async fn del_indexes(engine: &Sender<Engine>, idxs: impl Iterator<Item = &IndexMetadata>) {
+async fn del_indexes(engine: &Sender<Engine>, idxs: impl Iterator<Item = IndexMetadata>) {
     for idx in idxs {
         engine.del_index(idx.id()).await;
     }
@@ -301,5 +301,224 @@ mod tests {
         assert!(sv.has_changed(&tx_db).await);
 
         task_db.await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ntest::timeout(5_000)]
+    async fn index_metadata_are_removed_once() {
+        use crate::DbCustomIndex;
+        use crate::IndexId;
+        use crate::IndexName;
+        use std::collections::HashMap;
+        use std::collections::HashSet;
+        use std::num::NonZeroUsize;
+        use std::sync::{Arc, Mutex};
+        use tokio::sync::Notify;
+        use uuid::Uuid;
+
+        type IndexesT = HashSet<IndexId>;
+
+        // Dummy db index for testing
+        fn sample_db_index(name: &str) -> DbCustomIndex {
+            DbCustomIndex {
+                keyspace: "ks".to_string().into(),
+                index: name.to_string().into(),
+                table: "tbl".to_string().into(),
+                target_column: "embedding".to_string().into(),
+            }
+        }
+
+        // Shared state for the test
+        #[derive(Debug, Clone)]
+        struct TestState {
+            // The current set of indexes in the "database"
+            db_indexes: Arc<Mutex<Vec<DbCustomIndex>>>,
+            // The indexes that the engine currently has
+            engine_indexes: Arc<Mutex<IndexesT>>,
+            // Schema version counter
+            schema_version: Arc<Mutex<u16>>,
+            // Indexes version map
+            index_versions: Arc<Mutex<HashMap<IndexName, Uuid>>>,
+            // Notify to signal changes
+            notify: Arc<Notify>,
+            // Count of delete calls for each index
+            del_calls: Arc<Mutex<HashMap<IndexId, usize>>>,
+        }
+
+        impl TestState {
+            fn new() -> Self {
+                Self {
+                    db_indexes: Arc::new(Mutex::new(Vec::new())),
+                    engine_indexes: Arc::new(Mutex::new(HashSet::new())),
+                    schema_version: Arc::new(Mutex::new(0)),
+                    index_versions: Arc::new(Mutex::new(HashMap::new())),
+                    notify: Arc::new(Notify::new()),
+                    del_calls: Arc::new(Mutex::new(HashMap::new())),
+                }
+            }
+
+            async fn add_index(&self, index: DbCustomIndex) {
+                self.db_indexes.lock().unwrap().push(index);
+                *self.schema_version.lock().unwrap() += 1;
+                self.notify.notified().await;
+            }
+
+            async fn del_index(&self, index_name: IndexName) {
+                self.db_indexes
+                    .lock()
+                    .unwrap()
+                    .retain(|idx| idx.index != index_name);
+                *self.schema_version.lock().unwrap() += 1;
+                self.notify.notified().await;
+            }
+
+            fn get_db_indexes(&self) -> Vec<DbCustomIndex> {
+                let guard = self.db_indexes.lock().unwrap();
+                guard
+                    .iter()
+                    .map(|idx| DbCustomIndex {
+                        keyspace: idx.keyspace.clone(),
+                        index: idx.index.clone(),
+                        table: idx.table.clone(),
+                        target_column: idx.target_column.clone(),
+                    })
+                    .collect()
+            }
+        }
+
+        // Engine mock
+        async fn new_engine(state: TestState) -> anyhow::Result<mpsc::Sender<Engine>> {
+            let (tx_eng, mut rx_eng) = mpsc::channel(10);
+
+            tokio::spawn(async move {
+                while let Some(msg) = rx_eng.recv().await {
+                    match msg {
+                        Engine::GetIndexIds { .. } => {}
+                        Engine::AddIndex { metadata, tx } => {
+                            state.engine_indexes.lock().unwrap().insert(metadata.id());
+                            tx.send(Ok(())).unwrap();
+                            state.notify.notify_waiters();
+                        }
+                        Engine::DelIndex { id } => {
+                            let mut calls = state.del_calls.lock().unwrap();
+                            *calls.entry(id.clone()).or_insert(0) += 1;
+                            state.engine_indexes.lock().unwrap().remove(&id);
+                            state.notify.notify_waiters();
+                        }
+                        Engine::GetIndex { .. } => {}
+                    }
+                }
+            });
+
+            Ok(tx_eng)
+        }
+
+        // DB mock
+        async fn new_db(state: TestState) -> anyhow::Result<mpsc::Sender<Db>> {
+            let (tx_db, mut rx_db) = mpsc::channel(10);
+            tokio::spawn(async move {
+                while let Some(msg) = rx_db.recv().await {
+                    match msg {
+                        Db::GetDbIndex { tx, .. } => {
+                            // Not needed for this test
+                            let _ = tx.send(Err(anyhow::anyhow!("Not implemented")));
+                        }
+                        Db::LatestSchemaVersion { tx } => {
+                            let version = *state.schema_version.lock().unwrap();
+                            let version_bytes = [version as u8; 16];
+                            tx.send(Ok(Some(CqlTimeuuid::from_bytes(version_bytes))))
+                                .unwrap();
+                        }
+                        Db::GetIndexes { tx } => {
+                            let indexes = state.get_db_indexes();
+                            tx.send(Ok(indexes)).unwrap();
+                        }
+                        Db::GetIndexVersion { index, tx, .. } => {
+                            // Return a version for all indexes
+                            let mut guard = state.index_versions.lock().unwrap();
+                            let version = guard.entry(index).or_insert_with(Uuid::new_v4);
+                            tx.send(Ok(Some((*version).into()))).unwrap();
+                        }
+                        Db::GetIndexTargetType { tx, .. } => {
+                            // Return dimensions for all indexes
+                            tx.send(Ok(Some(NonZeroUsize::new(3).unwrap().into())))
+                                .unwrap();
+                        }
+                        Db::GetIndexParams { tx, .. } => {
+                            // Return default params for all indexes
+                            tx.send(Ok(Some((
+                                Default::default(), // connectivity
+                                Default::default(), // expansion_add
+                                Default::default(), // expansion_search
+                                Default::default(), // space_type
+                            ))))
+                            .unwrap();
+                        }
+                        Db::IsValidIndex { tx, .. } => {
+                            // All indexes are valid for this test
+                            tx.send(true).unwrap();
+                        }
+                    }
+                }
+            });
+            Ok(tx_db)
+        }
+
+        let state = TestState::new();
+
+        let tx_db = new_db(state.clone()).await.unwrap();
+        let tx_eng = new_engine(state.clone()).await.unwrap();
+        let (tx_ns, _rx_ns) = mpsc::channel(10);
+
+        // Start the monitor
+        let _monitor = new(tx_db.clone(), tx_eng.clone(), tx_ns.clone())
+            .await
+            .unwrap();
+
+        // Add two indexes
+        let index1 = sample_db_index("index1");
+        let index2 = sample_db_index("index2");
+        let index1_id = index1.id();
+        let index2_id = index2.id();
+
+        state.add_index(index1).await;
+        state.add_index(index2).await;
+
+        let engine_indexes = state.engine_indexes.lock().unwrap().clone();
+        assert!(
+            engine_indexes.contains(&index1_id) && engine_indexes.contains(&index2_id),
+            "Both indexes should be present"
+        );
+
+        // Remove index2 from the list
+        state.del_index(index2_id.index()).await;
+
+        let engine_indexes = state.engine_indexes.lock().unwrap().clone();
+        assert!(
+            engine_indexes.contains(&index1_id) && !engine_indexes.contains(&index2_id),
+            "Only index1 should remain"
+        );
+
+        // Remove index1 from the list
+        state.del_index(index1_id.index()).await;
+
+        let engine_indexes = state.engine_indexes.lock().unwrap().clone();
+        assert!(
+            !engine_indexes.contains(&index1_id) && !engine_indexes.contains(&index2_id),
+            "Both indexes should be removed"
+        );
+
+        // Assert del_index called only once per index
+        let calls = state.del_calls.lock().unwrap();
+        assert_eq!(
+            calls.get(&index1_id).copied().unwrap_or(0),
+            1,
+            "index1 should be removed once"
+        );
+        assert_eq!(
+            calls.get(&index2_id).copied().unwrap_or(0),
+            1,
+            "index2 should be removed once"
+        );
     }
 }


### PR DESCRIPTION
The index metadata in `MonitorIndexes` was never removed, which led to storing unnecessary metadata.
Furthermore it caused logging multiple communicates of removing the indexes that were already removed.

Remove index metadata from `MonitorIndexes` after deleting the index.

Fixes: VECTOR-138