### PR TITLE
fix: change debug message in engine actor

### DIFF
--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -122,7 +122,7 @@ pub(crate) async fn new(
             }
             drop(monitor_actor);
 
-            debug!("starting");
+            debug!("finished");
         }
         .instrument(debug_span!("engine")),
     );


### PR DESCRIPTION
As I assume the message "starting" was accidently copy-pased from above, and it should state "finished" like in other actors.