### PR TITLE
Add a counter for vector operations

### DIFF
--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 use dashmap::DashSet;
+use prometheus::CounterVec;
 use prometheus::GaugeVec;
 use prometheus::HistogramVec;
 use prometheus::Registry;
@@ -13,6 +14,7 @@ pub struct Metrics {
     pub registry: Registry,
     pub latency: HistogramVec,
     pub size: GaugeVec,
+    pub modified: CounterVec,
     dirty_indexes: Arc<DashSet<(String, String)>>,
 }
 
@@ -56,13 +58,21 @@ impl Metrics {
         )
         .unwrap();
 
+        let modified: CounterVec = CounterVec::new(
+            prometheus::Opts::new("index_modified", "Number of modified items per index"),
+            &["keyspace", "index_name", "operation"],
+        )
+        .unwrap();
+
         registry.register(Box::new(latency.clone())).unwrap();
         registry.register(Box::new(size.clone())).unwrap();
+        registry.register(Box::new(modified.clone())).unwrap();
 
         Self {
             registry,
             latency,
             size,
+            modified,
             dirty_indexes: Arc::new(DashSet::new()),
         }
     }

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -78,8 +78,24 @@ async fn add(
     if modify {
         let primary_key = embedding.primary_key;
         if let Some(embedding) = embedding.embedding {
+            metrics
+                .modified
+                .with_label_values(&[
+                    id.keyspace().as_ref().as_str(),
+                    id.index().as_ref().as_str(),
+                    "update",
+                ])
+                .inc();
             index.add_or_replace(primary_key, embedding).await;
         } else {
+            metrics
+                .modified
+                .with_label_values(&[
+                    id.keyspace().as_ref().as_str(),
+                    id.index().as_ref().as_str(),
+                    "remove",
+                ])
+                .inc();
             index.remove(primary_key).await;
         }
         metrics.mark_dirty(


### PR DESCRIPTION
This patch adds a counter for the number of times an index was modified. The counter is split between "update" (which includes both insert and update operations) and "delete".

The counter reflects the number of modification attempts, not their success.

This is how it looks:
    # HELP index_modified Number of modified items per index
    # TYPE index_modified counter
  index_modified{index_name="myindex",keyspace="mykey",operation="update"} 200

Reference: https://scylladb.atlassian.net/browse/VECTOR-63