### PR TITLE
validator: implement type for managing subnet for services

### DIFF
--- a/crates/validator/src/tests/crud.rs
+++ b/crates/validator/src/tests/crud.rs
@@ -15,8 +15,11 @@ pub(crate) async fn new() -> TestCase {
         .with_test("dummy", timeout, dummy)
 }
 
-async fn init(_actors: TestActors) {
+const VS_OCTET: u8 = 1;
+
+async fn init(actors: TestActors) {
     info!("started");
+    let _vs_ip = actors.services_subnet.ip(VS_OCTET);
     info!("finished");
 }
 

--- a/crates/validator/src/tests/mod.rs
+++ b/crates/validator/src/tests/mod.rs
@@ -5,6 +5,7 @@
 
 mod crud;
 
+use crate::ServicesSubnet;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use futures::stream;
@@ -22,7 +23,9 @@ use tracing::info;
 use tracing::info_span;
 
 #[derive(Clone)]
-pub(crate) struct TestActors {}
+pub(crate) struct TestActors {
+    pub(crate) services_subnet: Arc<ServicesSubnet>,
+}
 
 type TestFuture = BoxFuture<'static, ()>;
 


### PR DESCRIPTION

The change introduces a ServicesSubnet type. The type is responsible for synchronizing access to the specific subnet of IP addresses used for testing.

Reference: VECTOR-52

---

### List of PRs for [VECTOR-52](https://scylladb.atlassian.net/browse/VECTOR-52)
- #192
- #193
- -> validator: implement type for managing subnet for services
- validator: implement dns server
- validator: implement scylla manager
- httpclient: create a separate crate
- validator: implement vector-store manager
- validator: implement simple test: create/delete index
- validator: implement environment for running integration tests



[VECTOR-52]: https://scylladb.atlassian.net/browse/VECTOR-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ