### PR TITLE
validator: implement dns server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +740,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -984,6 +1008,55 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "ring",
+ "serde",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-util",
+ "hickory-proto",
+ "ipnet",
+ "prefix-trie",
+ "serde",
+ "thiserror 2.0.12",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "http"
@@ -1315,6 +1388,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1641,6 +1717,10 @@ name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1772,6 +1852,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1896,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+dependencies = [
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -2664,6 +2760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,6 +3041,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3042,6 +3154,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "futures",
+ "hickory-server",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.5.40", features = ["derive"] }
 derive_more = { version = "2.0.1", features = ["full"] }
 dotenvy = "0.15.7"
 futures = "0.3.31"
+hickory-server = "0.25.2"
 httpclient = { path = "crates/httpclient" }
 itertools = "0.14.0"
 macros = { path = "crates/macros" }

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 [dependencies]
 clap.workspace = true
 futures.workspace = true
+hickory-server.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/validator/src/dns.rs
+++ b/crates/validator/src/dns.rs
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use hickory_server::authority::Catalog;
+use hickory_server::authority::ZoneType;
+use hickory_server::proto::rr::DNSClass;
+use hickory_server::proto::rr::LowerName;
+use hickory_server::proto::rr::Name;
+use hickory_server::proto::rr::rdata::a::A;
+use hickory_server::proto::rr::rdata::soa::SOA;
+use hickory_server::proto::rr::record_data::RData;
+use hickory_server::proto::rr::record_type::RecordType;
+use hickory_server::proto::rr::resource::Record;
+use hickory_server::server::ServerFuture;
+use hickory_server::store::in_memory::InMemoryAuthority;
+use std::net::Ipv4Addr;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tracing::Instrument;
+use tracing::debug;
+use tracing::debug_span;
+
+pub(crate) enum Dns {
+    Version { tx: oneshot::Sender<String> },
+    Domain { tx: oneshot::Sender<String> },
+    Upsert { name: String, ip: Option<Ipv4Addr> },
+}
+
+pub(crate) trait DnsExt {
+    /// Returns the version of the DNS server.
+    async fn version(&self) -> String;
+
+    /// Returns the domain name of the DNS server.
+    async fn domain(&self) -> String;
+
+    /// Upserts an A DNS record with the given name and IP address.
+    async fn upsert(&self, name: String, ip: Option<Ipv4Addr>);
+}
+
+impl DnsExt for mpsc::Sender<Dns> {
+    async fn version(&self) -> String {
+        let (tx, rx) = oneshot::channel();
+        self.send(Dns::Version { tx })
+            .await
+            .expect("DnsExt::version: internal actor should receive request");
+        rx.await
+            .expect("DnsExt::version: internal actor should send response")
+    }
+
+    async fn domain(&self) -> String {
+        let (tx, rx) = oneshot::channel();
+        self.send(Dns::Domain { tx })
+            .await
+            .expect("DnsExt::domain: internal actor should receive request");
+        rx.await
+            .expect("DnsExt::domain: internal actor should send response")
+    }
+
+    async fn upsert(&self, name: String, ip: Option<Ipv4Addr>) {
+        self.send(Dns::Upsert { name, ip })
+            .await
+            .expect("DnsExt::upsert: internal actor should receive request");
+    }
+}
+
+/// Starts the DNS server on the given IP address.
+pub(crate) async fn new(ip: Ipv4Addr) -> mpsc::Sender<Dns> {
+    assert!(ip.is_loopback(), "DNS server should listen on a localhost");
+
+    let (tx, mut rx) = mpsc::channel(10);
+
+    let mut state = State::new().await;
+
+    let socket = UdpSocket::bind((ip, 53))
+        .await
+        .expect("dns: failed to bind UDP socket");
+
+    let mut catalog = Catalog::new();
+    catalog.upsert(
+        LowerName::from_str(ZONE).unwrap(),
+        vec![state.authority.clone()],
+    );
+    let mut server = ServerFuture::new(catalog);
+    server.register_socket(socket);
+
+    tokio::spawn(
+        async move {
+            debug!("starting");
+
+            while let Some(msg) = rx.recv().await {
+                process(msg, &mut state).await;
+            }
+
+            server
+                .shutdown_gracefully()
+                .await
+                .expect("stop: failed to shutdown server gracefully");
+
+            debug!("stopped");
+        }
+        .instrument(debug_span!("dns")),
+    );
+
+    tx
+}
+
+struct State {
+    version: String,
+    authority: Arc<InMemoryAuthority>,
+    serial: u32,
+}
+
+const ZONE: &str = "validator.test.";
+const TTL: u32 = 60;
+
+impl State {
+    async fn new() -> Self {
+        let version = format!("hicory-server-{}", hickory_server::version());
+
+        let authority = Arc::new(InMemoryAuthority::empty(
+            Name::from_str(ZONE).unwrap(),
+            ZoneType::Primary,
+            false,
+        ));
+        let mut soa = Record::from_rdata(
+            Name::from_str(ZONE).unwrap(),
+            TTL,
+            RData::SOA(SOA::new(
+                Name::from_str(ZONE).unwrap(),
+                Name::new(),
+                0,
+                0,
+                0,
+                0,
+                0,
+            )),
+        );
+        soa.set_dns_class(DNSClass::IN);
+        authority.upsert(soa, 0).await;
+
+        Self {
+            version,
+            authority,
+            serial: 0,
+        }
+    }
+}
+
+async fn process(msg: Dns, state: &mut State) {
+    match msg {
+        Dns::Version { tx } => {
+            tx.send(state.version.clone())
+                .expect("process Dns::Version: failed to send a response");
+        }
+
+        Dns::Domain { tx } => {
+            tx.send(ZONE[..ZONE.len() - 1].to_string())
+                .expect("process Dns::Domain: failed to send a response");
+        }
+
+        Dns::Upsert { name, ip } => {
+            upsert(name, ip, state).await;
+        }
+    }
+}
+
+async fn upsert(name: String, ip: Option<Ipv4Addr>, state: &mut State) {
+    let serial = state.serial;
+    state.serial += 1;
+    let name = Name::from_str(&format!("{name}.{ZONE}")).expect("upsert: failed to parse name");
+
+    let mut record = if let Some(ip) = ip {
+        let octets = ip.octets();
+        Record::from_rdata(
+            name,
+            TTL,
+            RData::A(A::new(octets[0], octets[1], octets[2], octets[3])),
+        )
+    } else {
+        Record::update0(name, TTL, RecordType::A)
+    };
+    record.set_dns_class(DNSClass::IN);
+
+    state.authority.upsert(record, serial).await;
+}

--- a/crates/validator/src/tests/mod.rs
+++ b/crates/validator/src/tests/mod.rs
@@ -6,6 +6,7 @@
 mod crud;
 
 use crate::ServicesSubnet;
+use crate::dns::Dns;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use futures::stream;
@@ -15,6 +16,7 @@ use std::collections::HashSet;
 use std::future;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc;
 use tokio::time;
 use tracing::Instrument;
 use tracing::Span;
@@ -25,6 +27,7 @@ use tracing::info_span;
 #[derive(Clone)]
 pub(crate) struct TestActors {
     pub(crate) services_subnet: Arc<ServicesSubnet>,
+    pub(crate) dns: mpsc::Sender<Dns>,
 }
 
 type TestFuture = BoxFuture<'static, ()>;


### PR DESCRIPTION

This change creates a dns service actor based on the hickory-server crate. It allows add or remove an A record (name -> ip addr) from the dns. It listen on the provided localhost ip address.

Reference: VECTOR-52

---

### List of PRs for [VECTOR-52](https://scylladb.atlassian.net/browse/VECTOR-52)
- #192
- #197
- #193
- #194
- -> validator: implement dns server
- #196
- #199
- #201
- #203



[VECTOR-52]: https://scylladb.atlassian.net/browse/VECTOR-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ