### PR TITLE
validator: implement scylla manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
@@ -3155,6 +3155,7 @@ dependencies = [
  "clap",
  "futures",
  "hickory-server",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ scylla-cdc = "0.4.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 syn = { version = "2.0", features = ["full"] }
+tempfile = "3.20.0"
 thiserror = "2.0.12"
 time = { version = "0.3.41", features = ["formatting"] }
 tokio = { version = "1.44.1", features = ["full"] }

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 clap.workspace = true
 futures.workspace = true
 hickory-server.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/validator/src/scylla_cluster.rs
+++ b/crates/validator/src/scylla_cluster.rs
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::fs;
+use tokio::process::Child;
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::time;
+use tracing::Instrument;
+use tracing::debug;
+use tracing::debug_span;
+
+pub(crate) enum ScyllaCluster {
+    Version {
+        tx: oneshot::Sender<String>,
+    },
+    Start {
+        vs_uri: String,
+        db_ip: Ipv4Addr,
+        conf: Option<Vec<u8>>,
+    },
+    WaitForReady {
+        tx: oneshot::Sender<bool>,
+    },
+    Stop,
+}
+
+pub(crate) trait ScyllaClusterExt {
+    /// Returns the version of the ScyllaDB executable.
+    async fn version(&self) -> String;
+
+    /// Starts the ScyllaDB cluster with the given vector store URI and database IP.
+    async fn start(&self, vs_uri: String, db_ip: Ipv4Addr, conf: Option<Vec<u8>>);
+
+    /// Stops the ScyllaDB instance.
+    async fn stop(&self);
+
+    /// Waits for the ScyllaDB cluster to be ready.
+    async fn wait_for_ready(&self) -> bool;
+}
+
+impl ScyllaClusterExt for mpsc::Sender<ScyllaCluster> {
+    async fn version(&self) -> String {
+        let (tx, rx) = oneshot::channel();
+        self.send(ScyllaCluster::Version { tx })
+            .await
+            .expect("ScyllaClusterExt::version: internal actor should receive request");
+        rx.await
+            .expect("ScyllaClusterExt::version: internal actor should send response")
+    }
+
+    async fn start(&self, vs_uri: String, db_ip: Ipv4Addr, conf: Option<Vec<u8>>) {
+        self.send(ScyllaCluster::Start {
+            vs_uri,
+            db_ip,
+            conf,
+        })
+        .await
+        .expect("ScyllaClusterExt::start: internal actor should receive request");
+    }
+
+    async fn stop(&self) {
+        self.send(ScyllaCluster::Stop)
+            .await
+            .expect("ScyllaClusterExt::stop: internal actor should receive request");
+    }
+
+    async fn wait_for_ready(&self) -> bool {
+        let (tx, rx) = oneshot::channel();
+        self.send(ScyllaCluster::WaitForReady { tx })
+            .await
+            .expect("ScyllaClusterExt::wait_for_ready: internal actor should receive request");
+        rx.await
+            .expect("ScyllaClusterExt::wait_for_ready: internal actor should send response")
+    }
+}
+
+pub(crate) async fn new(
+    path: PathBuf,
+    default_conf: PathBuf,
+    verbose: bool,
+) -> mpsc::Sender<ScyllaCluster> {
+    let (tx, mut rx) = mpsc::channel(10);
+
+    assert!(
+        crate::executable_exists(&path).await,
+        "scylla executable '{path:?}' does not exist"
+    );
+    assert!(
+        crate::file_exists(&default_conf).await,
+        "scylla config '{path:?}' does not exist"
+    );
+
+    let mut state = State::new(path, default_conf, verbose).await;
+
+    tokio::spawn(
+        async move {
+            debug!("starting");
+
+            while let Some(msg) = rx.recv().await {
+                process(msg, &mut state).await;
+            }
+
+            debug!("finished");
+        }
+        .instrument(debug_span!("db")),
+    );
+
+    tx
+}
+
+struct State {
+    path: PathBuf,
+    default_conf: PathBuf,
+    db_ip: Option<Ipv4Addr>,
+    child: Option<Child>,
+    workdir: Option<TempDir>,
+    version: String,
+    verbose: bool,
+}
+
+impl State {
+    async fn new(path: PathBuf, default_conf: PathBuf, verbose: bool) -> Self {
+        let version = String::from_utf8_lossy(
+            &Command::new(&path)
+                .arg("--version")
+                .output()
+                .await
+                .expect("db: State::new: failed to execute scylla")
+                .stdout,
+        )
+        .trim()
+        .to_string();
+
+        Self {
+            path,
+            default_conf,
+            version,
+            db_ip: None,
+            child: None,
+            workdir: None,
+            verbose,
+        }
+    }
+}
+
+async fn process(msg: ScyllaCluster, state: &mut State) {
+    match msg {
+        ScyllaCluster::Version { tx } => {
+            tx.send(state.version.clone())
+                .expect("process ScyllaCluster::Version: failed to send a response");
+        }
+
+        ScyllaCluster::Start {
+            vs_uri,
+            db_ip,
+            conf,
+        } => {
+            start(vs_uri, db_ip, conf, state).await;
+        }
+
+        ScyllaCluster::Stop => {
+            stop(state).await;
+        }
+
+        ScyllaCluster::WaitForReady { tx } => {
+            tx.send(wait_for_ready(state).await)
+                .expect("process ScyllaCluster::WaitForReady: failed to send a response");
+        }
+    }
+}
+
+async fn start(vs_uri: String, db_ip: Ipv4Addr, conf: Option<Vec<u8>>, state: &mut State) {
+    let workdir = TempDir::new().expect("start: failed to create temporary directory for scylladb");
+    let conf = if let Some(conf) = conf {
+        let conf_path = workdir.path().join("scylla.conf");
+        fs::write(&conf_path, conf)
+            .await
+            .expect("start: failed to write scylla config");
+        conf_path
+    } else {
+        state.default_conf.clone()
+    };
+    let mut cmd = Command::new(&state.path);
+    if !state.verbose {
+        cmd.stdout(Stdio::null()).stderr(Stdio::null());
+    }
+    state.child = Some(
+        cmd.arg("--overprovisioned")
+            .arg("--options-file")
+            .arg(&conf)
+            .arg("--workdir")
+            .arg(workdir.path())
+            .arg("--listen-address")
+            .arg(db_ip.to_string())
+            .arg("--rpc-address")
+            .arg(db_ip.to_string())
+            .arg("--api-address")
+            .arg(db_ip.to_string())
+            .arg("--seed-provider-parameters")
+            .arg(format!("seeds={db_ip}"))
+            .arg("--vector-store-uri")
+            .arg(vs_uri)
+            .arg("--developer-mode")
+            .arg("true")
+            .arg("--smp")
+            .arg("2")
+            .spawn()
+            .expect("start: failed to spawn scylladb"),
+    );
+    state.workdir = Some(workdir);
+    state.db_ip = Some(db_ip);
+}
+
+async fn stop(state: &mut State) {
+    let Some(mut child) = state.child.take() else {
+        return;
+    };
+    child
+        .start_kill()
+        .expect("stop: failed to send SIGTERM to scylladb process");
+    child
+        .wait()
+        .await
+        .expect("stop: failed to wait for scylladb process to exit");
+    state.child = None;
+    state.workdir = None;
+    state.db_ip = None;
+}
+
+/// Waits for ScyllaDB to be ready by checking the nodetool status.
+async fn wait_for_ready(state: &State) -> bool {
+    let Some(db_ip) = state.db_ip else {
+        return false;
+    };
+    let mut cmd = Command::new(&state.path);
+    cmd.arg("nodetool")
+        .arg("-h")
+        .arg(db_ip.to_string())
+        .arg("status");
+
+    loop {
+        if String::from_utf8_lossy(
+            &cmd.output()
+                .await
+                .expect("start: failed to run nodetool")
+                .stdout,
+        )
+        .lines()
+        .any(|line| line.starts_with(&format!("UN {db_ip}")))
+        {
+            return true;
+        }
+        time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/crates/validator/src/tests/crud.rs
+++ b/crates/validator/src/tests/crud.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::dns::DnsExt;
+use crate::scylla_cluster::ScyllaClusterExt;
 use crate::tests::*;
 use std::time::Duration;
 use tracing::info;
@@ -18,7 +19,10 @@ pub(crate) async fn new() -> TestCase {
 
 const VS_NAME: &str = "vs";
 
+const VS_PORT: u16 = 6080;
+
 const VS_OCTET: u8 = 1;
+const DB_OCTET: u8 = 2;
 
 async fn init(actors: TestActors) {
     info!("started");
@@ -26,19 +30,25 @@ async fn init(actors: TestActors) {
     let vs_ip = actors.services_subnet.ip(VS_OCTET);
 
     actors.dns.upsert(VS_NAME.to_string(), Some(vs_ip)).await;
-    info!(
-        "dns entry created for {}.{}: {}",
+
+    let vs_url = format!(
+        "http://{}.{}:{}",
         VS_NAME,
         actors.dns.domain().await,
-        vs_ip
+        VS_PORT
     );
 
+    let db_ip = actors.services_subnet.ip(DB_OCTET);
+
+    actors.db.start(vs_url, db_ip, None).await;
+    assert!(actors.db.wait_for_ready().await);
     info!("finished");
 }
 
 async fn cleanup(actors: TestActors) {
     info!("started");
     actors.dns.upsert(VS_NAME.to_string(), None).await;
+    actors.db.stop().await;
     info!("finished");
 }
 

--- a/crates/validator/src/tests/mod.rs
+++ b/crates/validator/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod crud;
 
 use crate::ServicesSubnet;
 use crate::dns::Dns;
+use crate::scylla_cluster::ScyllaCluster;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use futures::stream;
@@ -28,6 +29,7 @@ use tracing::info_span;
 pub(crate) struct TestActors {
     pub(crate) services_subnet: Arc<ServicesSubnet>,
     pub(crate) dns: mpsc::Sender<Dns>,
+    pub(crate) db: mpsc::Sender<ScyllaCluster>,
 }
 
 type TestFuture = BoxFuture<'static, ()>;


### PR DESCRIPTION

This change adds an actor to manage the ScyllaDB cluster. It allows starting, stopping and waiting for ready functionality. The cluster is started as a background processes. Currently the cluster contains one ScyllaDB process, in the future it should contains 3 processes to simulate 3 nodes.

Reference: VECTOR-52

---

### List of PRs for VECTOR-52
- #192
- #197
- #193
- #194
- #195
- -> validator: implement scylla manager
- #199
- #201
- #203

