### PR TITLE
Rename embedding to vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ name = "httpclient"
 version = "0.1.0"
 dependencies = [
  "reqwest",
+ "serde",
  "serde_json",
  "vector-store",
 ]

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -38,7 +38,7 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Performs an Approximate Nearest Neighbor (ANN) search using the specified index. Returns the vectors most similar to the provided embedding. The maximum number of results is controlled by the optional 'limit' parameter in the payload. The similarity metric is determined at index creation and cannot be changed per query.",
+        "description": "Performs an Approximate Nearest Neighbor (ANN) search using the specified index. Returns the vectors most similar to the provided vector. The maximum number of results is controlled by the optional 'limit' parameter in the payload. The similarity metric is determined at index creation and cannot be changed per query.",
         "operationId": "post_index_ann",
         "parameters": [
           {
@@ -82,7 +82,7 @@
             }
           },
           "400": {
-            "description": "Bad request. Possible causes: invalid embedding size, malformed input, or missing required fields.",
+            "description": "Bad request. Possible causes: invalid vector size, malformed input, or missing required fields.",
             "content": {
               "application/json": {
                 "schema": {
@@ -102,7 +102,7 @@
             }
           },
           "500": {
-            "description": "Error while searching embeddings. Possible causes: internal error, or search engine issues.",
+            "description": "Error while searching vectors. Possible causes: internal error, or search engine issues.",
             "content": {
               "application/json": {
                 "schema": {
@@ -129,7 +129,7 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Returns the number of embeddings indexed by a specific vector index. Reflects only available embeddings and excludes any 'tombstones' (elements marked for deletion but still present in the index structure).",
+        "description": "Returns the number of vectors indexed by a specific vector index. Reflects only available vectors and excludes any 'tombstones' (elements marked for deletion but still present in the index structure).",
         "operationId": "get_index_count",
         "parameters": [
           {
@@ -144,7 +144,7 @@
           {
             "name": "index",
             "in": "path",
-            "description": "The name of the ScyllaDB vector index within the specified keyspace to count embeddings for.",
+            "description": "The name of the ScyllaDB vector index within the specified keyspace to count vectors for.",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/IndexName"
@@ -153,7 +153,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful count operation. Returns the total number of embeddings currently stored in the index.",
+            "description": "Successful count operation. Returns the total number of vectors currently stored in the index.",
             "content": {
               "application/json": {
                 "schema": {
@@ -174,7 +174,7 @@
             }
           },
           "500": {
-            "description": "Error while counting embeddings. Possible causes: internal error, or issues accessing the database.",
+            "description": "Error while counting vectors. Possible causes: internal error, or issues accessing the database.",
             "content": {
               "application/json": {
                 "schema": {
@@ -241,15 +241,7 @@
       "Distance": {
         "type": "number",
         "format": "float",
-        "description": "Distance between embedding vectors measured using the distance function defined while creating the index."
-      },
-      "Embedding": {
-        "type": "array",
-        "items": {
-          "type": "number",
-          "format": "float"
-        },
-        "description": "The embedding vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index."
+        "description": "Distance between vectors measured using the distance function defined while creating the index."
       },
       "ErrorMessage": {
         "type": "string",
@@ -305,14 +297,14 @@
       "PostIndexAnnRequest": {
         "type": "object",
         "required": [
-          "embedding"
+          "vector"
         ],
         "properties": {
-          "embedding": {
-            "$ref": "#/components/schemas/Embedding"
-          },
           "limit": {
             "$ref": "#/components/schemas/Limit"
+          },
+          "vector": {
+            "$ref": "#/components/schemas/Vector"
           }
         }
       },
@@ -349,16 +341,24 @@
           "INITIALIZING",
           "CONNECTING_TO_DB",
           "DISCOVERING_INDEXES",
-          "INDEXING_EMBEDDINGS",
+          "INDEXING_VECTORS",
           "SERVING"
         ],
         "x-enum-descriptions": [
           "The node is starting up.",
           "The node is establishing a connection to ScyllaDB.",
           "The node is discovering available vector indexes in ScyllaDB.",
-          "The node is indexing embeddings into the discovered vector indexes.",
+          "The node is indexing vectors into the discovered vector indexes.",
           "The node has completed the initial database scan and built the indexes defined at that time. It is now monitoring the database for changes."
         ]
+      },
+      "Vector": {
+        "type": "array",
+        "items": {
+          "type": "number",
+          "format": "float"
+        },
+        "description": "The vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index."
       }
     }
   },

--- a/crates/httpclient/Cargo.toml
+++ b/crates/httpclient/Cargo.toml
@@ -10,3 +10,4 @@ edition.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
 vector-store.workspace = true
+serde.workspace = true

--- a/crates/vector-store/src/index/opensearch.rs
+++ b/crates/vector-store/src/index/opensearch.rs
@@ -6,7 +6,6 @@
 use crate::Connectivity;
 use crate::Dimensions;
 use crate::Distance;
-use crate::Embedding;
 use crate::ExpansionAdd;
 use crate::ExpansionSearch;
 use crate::IndexFactory;
@@ -14,6 +13,7 @@ use crate::IndexId;
 use crate::Limit;
 use crate::PrimaryKey;
 use crate::SpaceType;
+use crate::Vector;
 use crate::index::actor::Index;
 use crate::index::validator;
 use anyhow::anyhow;
@@ -269,7 +269,7 @@ async fn add_or_replace(
     keys: Arc<RwLock<BiMap<PrimaryKey, Key>>>,
     opensearch_key: Arc<AtomicU64>,
     primary_key: PrimaryKey,
-    embeddings: Embedding,
+    embeddings: Vector,
     client: Arc<OpenSearch>,
 ) {
     let key = opensearch_key.fetch_add(1, Ordering::Relaxed).into();
@@ -356,7 +356,7 @@ async fn ann(
     id: Arc<IndexId>,
     tx_ann: oneshot::Sender<AnnR>,
     keys: Arc<RwLock<BiMap<PrimaryKey, Key>>>,
-    embedding: Embedding,
+    embedding: Vector,
     dimensions: Dimensions,
     limit: Limit,
     client: Arc<OpenSearch>,

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -5,7 +5,6 @@
 
 use crate::Connectivity;
 use crate::Dimensions;
-use crate::Embedding;
 use crate::ExpansionAdd;
 use crate::ExpansionSearch;
 use crate::IndexFactory;
@@ -13,6 +12,7 @@ use crate::IndexId;
 use crate::Limit;
 use crate::PrimaryKey;
 use crate::SpaceType;
+use crate::Vector;
 use crate::index::actor::AnnR;
 use crate::index::actor::CountR;
 use crate::index::actor::Index;
@@ -192,7 +192,7 @@ async fn add_or_replace(
     keys: Arc<RwLock<BiMap<PrimaryKey, Key>>>,
     usearch_key: Arc<AtomicU64>,
     primary_key: PrimaryKey,
-    embedding: Embedding,
+    embedding: Vector,
 ) {
     let key = usearch_key.fetch_add(1, Ordering::Relaxed).into();
 
@@ -268,7 +268,7 @@ async fn ann(
     idx: Arc<RwLock<usearch::Index>>,
     tx_ann: oneshot::Sender<AnnR>,
     keys: Arc<RwLock<BiMap<PrimaryKey, Key>>>,
-    embedding: Embedding,
+    embedding: Vector,
     dimensions: Dimensions,
     limit: Limit,
 ) {

--- a/crates/vector-store/src/index/validator.rs
+++ b/crates/vector-store/src/index/validator.rs
@@ -1,5 +1,5 @@
 use crate::Dimensions;
-use crate::Embedding;
+use crate::Vector;
 use anyhow::bail;
 use thiserror::Error;
 
@@ -9,7 +9,7 @@ pub enum Error {
     WrongEmbeddingDimension { expected: usize, actual: usize },
 }
 
-pub fn embedding_dimensions(embedding: &Embedding, dimensions: Dimensions) -> anyhow::Result<()> {
+pub fn embedding_dimensions(embedding: &Vector, dimensions: Dimensions) -> anyhow::Result<()> {
     let Some(embedding_len) = std::num::NonZeroUsize::new(embedding.0.len()) else {
         bail!(Error::WrongEmbeddingDimension {
             expected: dimensions.0.get(),
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn validate_embedding_empty() {
-        let embedding = Embedding(vec![]);
+        let embedding = Vector(vec![]);
         let dimensions = dims(3);
 
         let result = embedding_dimensions(&embedding, dimensions);
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn validate_embedding_too_short() {
-        let embedding = Embedding(vec![0.1, 0.2]);
+        let embedding = Vector(vec![0.1, 0.2]);
         let dimensions = dims(3);
 
         let result = embedding_dimensions(&embedding, dimensions);
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn validate_embedding_too_long() {
-        let embedding = Embedding(vec![0.1, 0.2, 0.3, 0.4]);
+        let embedding = Vector(vec![0.1, 0.2, 0.3, 0.4]);
         let dimensions = dims(3);
         let result = embedding_dimensions(&embedding, dimensions);
         assert!(matches!(
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn validate_embedding_ok() {
-        let embedding = Embedding(vec![0.1, 0.2, 0.3]);
+        let embedding = Vector(vec![0.1, 0.2, 0.3]);
         let dimensions = dims(3);
 
         let result = embedding_dimensions(&embedding, dimensions);

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -205,7 +205,7 @@ impl Eq for PrimaryKey {}
 #[derive(
     Clone, Debug, serde::Serialize, serde::Deserialize, derive_more::From, utoipa::ToSchema,
 )]
-/// Distance between embedding vectors measured using the distance function defined while creating the index.
+/// Distance between vectors measured using the distance function defined while creating the index.
 pub struct Distance(f32);
 
 impl SerializeValue for Distance {
@@ -345,8 +345,8 @@ struct ParamM(usize);
     derive_more::From,
     utoipa::ToSchema,
 )]
-/// The embedding vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index.
-pub struct Embedding(Vec<f32>);
+/// The vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index.
+pub struct Vector(Vec<f32>);
 
 #[derive(
     Clone,
@@ -424,7 +424,7 @@ pub struct Timestamp(OffsetDateTime);
 #[derive(Debug)]
 pub struct DbEmbedding {
     pub primary_key: PrimaryKey,
-    pub embedding: Option<Embedding>,
+    pub embedding: Option<Vector>,
     pub timestamp: Timestamp,
 }
 

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -21,7 +21,6 @@ use vector_store::Connectivity;
 use vector_store::DbCustomIndex;
 use vector_store::DbEmbedding;
 use vector_store::Dimensions;
-use vector_store::Embedding;
 use vector_store::ExpansionAdd;
 use vector_store::ExpansionSearch;
 use vector_store::IndexMetadata;
@@ -32,6 +31,7 @@ use vector_store::Progress;
 use vector_store::SpaceType;
 use vector_store::TableName;
 use vector_store::Timestamp;
+use vector_store::Vector;
 use vector_store::db::Db;
 use vector_store::db_index::DbIndex;
 use vector_store::node_state::Event;
@@ -56,7 +56,7 @@ pub(crate) fn new(node_state: Sender<NodeState>) -> (mpsc::Sender<Db>, DbBasic) 
 
 struct TableStore {
     table: Table,
-    embeddings: HashMap<ColumnName, HashMap<PrimaryKey, (Option<Embedding>, Timestamp)>>,
+    embeddings: HashMap<ColumnName, HashMap<PrimaryKey, (Option<Vector>, Timestamp)>>,
 }
 
 impl TableStore {
@@ -213,7 +213,7 @@ impl DbBasic {
         keyspace_name: &KeyspaceName,
         table_name: &TableName,
         target_column: &ColumnName,
-        values: impl IntoIterator<Item = (PrimaryKey, Option<Embedding>, Timestamp)>,
+        values: impl IntoIterator<Item = (PrimaryKey, Option<Vector>, Timestamp)>,
     ) -> anyhow::Result<()> {
         let mut db = self.0.write().unwrap();
 


### PR DESCRIPTION
Rename 'embedding' to 'vector' in public API
    
Rename 'embedding' to 'vector' in public API.
Maintain backward compatibility through serde field aliasing to support existing clients using the "embedding" field name.
Verify backward compatibility with test.

References: VECTOR-148