### PR TITLE
Merge DISCOVERING_INDEXES and INDEXING_EMBEDDINGS into BOOTSTRAPPING node status

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -340,16 +340,14 @@
         "enum": [
           "INITIALIZING",
           "CONNECTING_TO_DB",
-          "DISCOVERING_INDEXES",
-          "INDEXING_VECTORS",
+          "BOOTSTRAPPING",
           "SERVING"
         ],
         "x-enum-descriptions": [
           "The node is starting up.",
           "The node is establishing a connection to ScyllaDB.",
           "The node is discovering available vector indexes in ScyllaDB.",
-          "The node is indexing vectors into the discovered vector indexes.",
-          "The node has completed the initial database scan and built the indexes defined at that time. It is now monitoring the database for changes."
+          "The node is making initial indexes discovering and vector data indexing."
         ]
       },
       "Vector": {

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -527,10 +527,8 @@ pub enum Status {
     /// The node is establishing a connection to ScyllaDB.
     ConnectingToDb,
     /// The node is discovering available vector indexes in ScyllaDB.
-    DiscoveringIndexes,
-    /// The node is indexing vectors into the discovered vector indexes.
-    IndexingVectors,
-    /// The node has completed the initial database scan and built the indexes defined at that time. It is now monitoring the database for changes.
+    Bootstrapping,
+    /// The node is making initial indexes discovering and vector data indexing.
     Serving,
 }
 
@@ -539,21 +537,9 @@ impl From<crate::node_state::Status> for Status {
         match status {
             crate::node_state::Status::Initializing => Status::Initializing,
             crate::node_state::Status::ConnectingToDb => Status::ConnectingToDb,
-            crate::node_state::Status::DiscoveringIndexes => Status::DiscoveringIndexes,
-            crate::node_state::Status::IndexingEmbeddings => Status::IndexingVectors,
+            crate::node_state::Status::IndexingEmbeddings => Status::Bootstrapping,
+            crate::node_state::Status::DiscoveringIndexes => Status::Bootstrapping,
             crate::node_state::Status::Serving => Status::Serving,
-        }
-    }
-}
-
-impl From<Status> for crate::node_state::Status {
-    fn from(status: Status) -> Self {
-        match status {
-            Status::Initializing => crate::node_state::Status::Initializing,
-            Status::ConnectingToDb => crate::node_state::Status::ConnectingToDb,
-            Status::DiscoveringIndexes => crate::node_state::Status::DiscoveringIndexes,
-            Status::IndexingVectors => crate::node_state::Status::IndexingEmbeddings,
-            Status::Serving => crate::node_state::Status::Serving,
         }
     }
 }
@@ -633,6 +619,30 @@ mod tests {
                     .format(&Iso8601::DEFAULT)
                     .unwrap()
             )
+        );
+    }
+
+    #[test]
+    fn status_conversion() {
+        assert_eq!(
+            Status::from(crate::node_state::Status::Initializing),
+            Status::Initializing
+        );
+        assert_eq!(
+            Status::from(crate::node_state::Status::ConnectingToDb),
+            Status::ConnectingToDb
+        );
+        assert_eq!(
+            Status::from(crate::node_state::Status::IndexingEmbeddings),
+            Status::Bootstrapping
+        );
+        assert_eq!(
+            Status::from(crate::node_state::Status::DiscoveringIndexes),
+            Status::Bootstrapping
+        );
+        assert_eq!(
+            Status::from(crate::node_state::Status::Serving),
+            Status::Serving
         );
     }
 }


### PR DESCRIPTION
The `DISCOVERING_INDEXES` and `INDEXING_VECTORS` statuses are ambiguous because these actions can happen at any time,
not just during initial startup. The status endpoint's primary goal is to report on this initial phase.
To make the API clearer and more specific, this change merges them into a single `BOOTSTRAPPING` status.

References: [VECTOR-148](https://scylladb.atlassian.net/browse/VECTOR-148)

[VECTOR-148]: https://scylladb.atlassian.net/browse/VECTOR-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ