### PR TITLE
Refactor httpclient to use httproutes::Status

### DIFF
--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -16,7 +16,7 @@ use vector_store::Limit;
 use vector_store::httproutes::InfoResponse;
 use vector_store::httproutes::PostIndexAnnRequest;
 use vector_store::httproutes::PostIndexAnnResponse;
-use vector_store::node_state::Status;
+use vector_store::httproutes::Status;
 
 pub struct HttpClient {
     client: Client,

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -517,10 +517,10 @@ async fn get_info() -> response::Json<InfoResponse> {
     })
 }
 
-#[derive(ToEnumSchema, serde::Deserialize, serde::Serialize)]
+#[derive(ToEnumSchema, serde::Deserialize, serde::Serialize, PartialEq, Debug)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")] // This line makes all variants uppercase in the schema
 /// Operational status of the Vector Store node.
-enum Status {
+pub enum Status {
     /// The node is starting up.
     Initializing,
     /// The node is establishing a connection to ScyllaDB.

--- a/crates/vector-store/src/node_state.rs
+++ b/crates/vector-store/src/node_state.rs
@@ -7,8 +7,7 @@ use crate::IndexMetadata;
 use std::collections::HashSet;
 use tokio::sync::{mpsc, oneshot};
 
-#[derive(serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Status {
     Initializing,
     ConnectingToDb,

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -346,5 +346,5 @@ async fn status_is_serving_after_creation() {
     let (_index, client, _db, _server, _node_state) = setup_store_and_wait_for_index().await;
 
     let result = client.status().await;
-    assert_eq!(result, vector_store::node_state::Status::Serving);
+    assert_eq!(result, vector_store::httproutes::Status::Serving);
 }


### PR DESCRIPTION
Refactor httpclient to use httproutes::Status

Updated the test httpclient to use `httproutes::Status` enum instead of `node_state::Status`.
The `httproutes::Status` is the correct, HTTP API-facing type, while `node_state::Status` is a business logic related type.
As a result, serialization support has been removed from `node_state::Status` as it's no longer needed.