### PR TITLE
Fix description of 404 status

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -92,7 +92,7 @@
             }
           },
           "404": {
-            "description": "Index not found. Possible causes: index does not exist, or is not built yet.",
+            "description": "Index not found. Possible causes: index does not exist, or is not discovered yet.",
             "content": {
               "application/json": {
                 "schema": {
@@ -164,7 +164,7 @@
             }
           },
           "404": {
-            "description": "Index not found. Possible causes: index does not exist, or is not built yet.",
+            "description": "Index not found. Possible causes: index does not exist, or is not discovered yet.",
             "content": {
               "application/json": {
                 "schema": {

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -207,7 +207,7 @@ struct ErrorMessage(#[allow(dead_code)] String);
         ),
         (
             status = 404,
-            description = "Index not found. Possible causes: index does not exist, or is not built yet.",
+            description = "Index not found. Possible causes: index does not exist, or is not discovered yet.",
             content_type = "application/json",
             body = ErrorMessage
         ),
@@ -330,7 +330,7 @@ The similarity metric is determined at index creation and cannot be changed per 
         ),
         (
             status = 404,
-            description = "Index not found. Possible causes: index does not exist, or is not built yet.",
+            description = "Index not found. Possible causes: index does not exist, or is not discovered yet.",
             content_type = "application/json",
             body = ErrorMessage
         ),


### PR DESCRIPTION
The previous description was misleading.
When indexes are being built, a 404 error does not occur because the index is already known to the vector store. The actual reason for a 404 is that the index has not yet been discovered for the database.

References: VECTOR-148