### PR TITLE
Rename quantization to data_type

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -231,6 +231,13 @@
   },
   "components": {
     "schemas": {
+      "DataType": {
+        "type": "string",
+        "description": "Data type and precision used for storing and processing vectors in the index.",
+        "enum": [
+          "F32"
+        ]
+      },
       "Distance": {
         "type": "number",
         "format": "float",
@@ -242,7 +249,7 @@
           "type": "number",
           "format": "float"
         },
-        "description": "The embedding vector to use for the Approximate Nearest Neighbor search. The format of data must match the quantization of the index."
+        "description": "The embedding vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index."
       },
       "ErrorMessage": {
         "type": "string",
@@ -250,21 +257,21 @@
       },
       "IndexInfo": {
         "type": "object",
-        "description": "Information about a vector index, such as keyspace, name and quantization.",
+        "description": "Information about a vector index, such as keyspace, name and data type.",
         "required": [
           "keyspace",
           "index",
-          "quantization"
+          "data_type"
         ],
         "properties": {
+          "data_type": {
+            "$ref": "#/components/schemas/DataType"
+          },
           "index": {
             "$ref": "#/components/schemas/IndexName"
           },
           "keyspace": {
             "$ref": "#/components/schemas/KeyspaceName"
-          },
-          "quantization": {
-            "$ref": "#/components/schemas/Quantization"
           }
         }
       },
@@ -334,13 +341,6 @@
             }
           }
         }
-      },
-      "Quantization": {
-        "type": "string",
-        "description": "Data type and precision used for storing and processing embedding vectors in the index.",
-        "enum": [
-          "F32"
-        ]
       },
       "Status": {
         "type": "string",

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -130,17 +130,17 @@ fn new_open_api_router() -> (Router<RoutesInnerState>, utoipa::openapi::OpenApi)
 }
 
 #[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema, PartialEq, Debug)]
-/// Data type and precision used for storing and processing embedding vectors in the index.
-pub enum Quantization {
+/// Data type and precision used for storing and processing vectors in the index.
+pub enum DataType {
     F32,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema, PartialEq, Debug)]
-/// Information about a vector index, such as keyspace, name and quantization.
+/// Information about a vector index, such as keyspace, name and data type.
 pub struct IndexInfo {
     pub keyspace: KeyspaceName,
     pub index: IndexName,
-    pub quantization: Quantization,
+    pub data_type: DataType,
 }
 
 impl IndexInfo {
@@ -148,7 +148,7 @@ impl IndexInfo {
         IndexInfo {
             keyspace: String::from(keyspace).into(),
             index: String::from(index).into(),
-            quantization: Quantization::F32,
+            data_type: DataType::F32,
         }
     }
 }
@@ -177,7 +177,7 @@ async fn get_indexes(State(state): State<RoutesInnerState>) -> Response {
         .map(|id| IndexInfo {
             keyspace: id.keyspace(),
             index: id.index(),
-            quantization: Quantization::F32, // currently the only supported quantization by Vector Store
+            data_type: DataType::F32, // currently the only supported data type by Vector Store
         })
         .collect();
     (StatusCode::OK, response::Json(indexes)).into_response()

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -18,8 +18,8 @@ pub mod node_state;
 use crate::metrics::Metrics;
 use crate::node_state::NodeState;
 use db::Db;
+pub use httproutes::DataType;
 pub use httproutes::IndexInfo;
-pub use httproutes::Quantization;
 use index::factory;
 use index::factory::IndexFactory;
 use scylla::cluster::metadata::ColumnType;
@@ -345,7 +345,7 @@ struct ParamM(usize);
     derive_more::From,
     utoipa::ToSchema,
 )]
-/// The embedding vector to use for the Approximate Nearest Neighbor search. The format of data must match the quantization of the index.
+/// The embedding vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index.
 pub struct Embedding(Vec<f32>);
 
 #[derive(


### PR DESCRIPTION
The term "quantization" may be confusing for end users, while "data_type" more accurately describes the expected vector format. Since there are no existing API clients, backward compatibility is not a concern.

References: VECTOR-148