### PR TITLE
Move status endpoint test to a dedicated file

### DIFF
--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -8,6 +8,7 @@ mod info;
 mod mock_opensearch;
 mod openapi;
 mod opensearch;
+mod status;
 mod usearch;
 
 use std::sync::Once;

--- a/crates/vector-store/tests/integration/status.rs
+++ b/crates/vector-store/tests/integration/status.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::usearch::setup_store_and_wait_for_index;
+use vector_store::httproutes::Status;
+
+#[tokio::test]
+async fn status_is_serving_after_creation() {
+    crate::enable_tracing();
+    let (_index, client, _db, _server, _node_state) = setup_store_and_wait_for_index().await;
+
+    let result = client.status().await;
+    assert_eq!(result.unwrap(), Status::Serving);
+}

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -19,7 +19,6 @@ use uuid::Uuid;
 use vector_store::IndexMetadata;
 use vector_store::Percentage;
 use vector_store::Vector;
-use vector_store::httproutes::Status;
 use vector_store::node_state::NodeState;
 
 async fn setup_store() -> (
@@ -86,7 +85,7 @@ async fn setup_store() -> (
     (index, HttpClient::new(addr), db, server, node_state)
 }
 
-async fn setup_store_and_wait_for_index() -> (
+pub(crate) async fn setup_store_and_wait_for_index() -> (
     IndexMetadata,
     HttpClient,
     DbBasic,
@@ -340,15 +339,6 @@ async fn ann_fail_while_building() {
         result.text().await.unwrap(),
         "Full scan is in progress, percentage: 33.33%"
     );
-}
-
-#[tokio::test]
-async fn status_is_serving_after_creation() {
-    crate::enable_tracing();
-    let (_index, client, _db, _server, _node_state) = setup_store_and_wait_for_index().await;
-
-    let result = client.status().await;
-    assert_eq!(result.unwrap(), Status::Serving);
 }
 
 #[tokio::test]


### PR DESCRIPTION
To improve the organization of tests, the status endpoint test is moved from `usearch.rs` to a new `status.rs` file.
This keeps test files focused on a single responsibility and makes it easier to add related tests in the future.