### PR TITLE
Implement script for building release binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM rust:1.87 AS build
-WORKDIR /build/vector-store-build
-RUN --mount=type=bind,target=.,rw cargo b -r && cp target/release/vector-store ..
-
-FROM redhat/ubi9-minimal
-RUN mkdir /opt/vector-store
-COPY --from=build /build/vector-store /opt/vector-store
-CMD ["/opt/vector-store/vector-store"]

--- a/build-release
+++ b/build-release
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+repo=$(dirname "${BASH_SOURCE[0]}")
+repo=$(realpath $repo)
+
+cd $repo
+
+vector_store_version=$(./run-with-release-toolchain cargo info vector-store | grep ^version: | cut -d ' ' -f 2)
+
+# ensure the git repository is clean
+git status --porcelain | grep -q . && echo "git repository is not clean." && exit 1
+
+# ensure the git repository is on the tag with the version
+[[ -z $(git tag --points-at HEAD | grep "^$vector_store_version\$") ]] && echo "git repository is not on tag $vector_store_version." && exit 1
+
+echo rebuild the release version $vector_store_version
+./run-with-release-toolchain cargo clean --release
+./run-with-release-toolchain cargo build --release
+
+echo build the tar archive
+vector_store_dir=vector-store-$vector_store_version
+vector_store_tarball=$vector_store_dir.tar.gz
+(cd target/release && tar -czf $vector_store_tarball --transform "s,^,$vector_store_dir/," vector-store)
+ls -lh target/release/$vector_store_tarball
+
+echo build the docker image
+docker_tag=scylladb/vector-store:$vector_store_version
+docker build --tag $docker_tag -f- . <<EOF
+FROM redhat/ubi9-minimal
+RUN mkdir /opt/vector-store
+COPY target/release/vector-store /opt/vector-store
+CMD ["/opt/vector-store/vector-store"]
+EOF


### PR DESCRIPTION
Currently the Dockerfile doesn't check rust toolchain version and do not use rust release toolchain. This change removes Dockerfile and creates a docker from the script using `scylladb/vector-store:{version}` as a tag. The script will rebuild the binary of vector-store service.

The script will prepare a release version of vector-store in a `vector-store-{version}.tar.gz` tarball in a `target/release` directory.

This is a first step to prepare automation for releasing.

Reference: VECTOR-108
