### PR TITLE
Add engine name and version into /info endpoint

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -274,10 +274,15 @@
       "InfoResponse": {
         "type": "object",
         "required": [
-          "version",
-          "service"
+          "engine",
+          "service",
+          "version"
         ],
         "properties": {
+          "engine": {
+            "type": "string",
+            "description": "Information about the underlying search engine."
+          },
           "service": {
             "type": "string",
             "description": "The name of the Vector Store indexing service."

--- a/crates/vector-store/src/index/factory.rs
+++ b/crates/vector-store/src/index/factory.rs
@@ -22,4 +22,5 @@ pub trait IndexFactory {
         expansion_search: ExpansionSearch,
         space_type: SpaceType,
     ) -> anyhow::Result<mpsc::Sender<Index>>;
+    fn index_engine_version(&self) -> String;
 }

--- a/crates/vector-store/src/index/opensearch.rs
+++ b/crates/vector-store/src/index/opensearch.rs
@@ -89,6 +89,10 @@ impl IndexFactory for OpenSearchIndexFactory {
             self.client.clone(),
         )
     }
+
+    fn index_engine_version(&self) -> String {
+        "opensearch".into()
+    }
 }
 
 pub fn new_opensearch(addr: &str) -> Result<OpenSearchIndexFactory, anyhow::Error> {

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -55,6 +55,10 @@ impl IndexFactory for UsearchIndexFactory {
             space_type,
         )
     }
+
+    fn index_engine_version(&self) -> String {
+        format!("usearch-{}", usearch::version())
+    }
 }
 
 pub fn new_usearch() -> anyhow::Result<UsearchIndexFactory> {

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -21,7 +21,7 @@ use db::Db;
 pub use httproutes::DataType;
 pub use httproutes::IndexInfo;
 use index::factory;
-use index::factory::IndexFactory;
+pub use index::factory::IndexFactory;
 use scylla::cluster::metadata::ColumnType;
 use scylla::serialize::SerializationError;
 use scylla::serialize::value::SerializeValue;
@@ -455,11 +455,13 @@ pub async fn run(
         });
     }
     let metrics: Arc<Metrics> = Arc::new(metrics::Metrics::new());
+    let index_engine_version = index_factory.index_engine_version();
     httpserver::new(
         addr,
         node_state.clone(),
         engine::new(db_actor, index_factory, node_state, metrics.clone()).await?,
         metrics,
+        index_engine_version,
     )
     .await
 }

--- a/crates/vector-store/tests/integration/info.rs
+++ b/crates/vector-store/tests/integration/info.rs
@@ -3,27 +3,47 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::db_basic;
+use crate::{db_basic, mock_opensearch};
 use httpclient::HttpClient;
 use std::net::SocketAddr;
 
-#[tokio::test]
-async fn get_applicaiton_info() {
+async fn run_vs(
+    index_factory: Box<dyn vector_store::IndexFactory + Send + Sync>,
+) -> (HttpClient, impl Sized) {
     let node_state = vector_store::new_node_state().await;
     let (db_actor, _) = db_basic::new(node_state.clone());
-    let (_server_actor, addr) = vector_store::run(
+    let (server, addr) = vector_store::run(
         SocketAddr::from(([127, 0, 0, 1], 0)).into(),
         Some(1),
         node_state,
         db_actor,
-        vector_store::new_index_factory_usearch().unwrap(),
+        index_factory,
     )
     .await
     .unwrap();
-    let client = HttpClient::new(addr);
+    (HttpClient::new(addr), server)
+}
+
+#[tokio::test]
+async fn get_application_info_usearch() {
+    let (client, _server) = run_vs(vector_store::new_index_factory_usearch().unwrap()).await;
 
     let info = client.info().await;
 
     assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
     assert_eq!(info.service, env!("CARGO_PKG_NAME"));
+    assert_eq!(info.engine, format!("usearch-{}", usearch::version()));
+}
+
+#[tokio::test]
+async fn get_application_info_opensearch() {
+    let server = mock_opensearch::TestOpenSearchServer::start().await;
+    let index_factory = vector_store::new_index_factory_opensearch(server.base_url()).unwrap();
+    let (client, _server) = run_vs(index_factory).await;
+
+    let info = client.info().await;
+
+    assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(info.service, env!("CARGO_PKG_NAME"));
+    assert_eq!(info.engine, "opensearch");
 }


### PR DESCRIPTION
Add engine type and version in /info endpoint

The /info response now includes an engine object with type and
version fields. This allows clients to identify the underlying
search engine, which is useful for debugging and inspection.

The OpenSearch engine implementation returns an empty string for the
version, as it is not intended for production use.

A PR for usearch to add userach::version() function: https://github.com/unum-cloud/usearch/pull/644.

References: VECTOR-148
