### PR TITLE
Bypass cache during range queries

### DIFF
--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -254,6 +254,7 @@ impl Statements {
             WHERE
                 token({st_partition_key_list}) >= ?
                 AND token({st_partition_key_list}) <= ?
+            BYPASS CACHE
             "
         )
     }


### PR DESCRIPTION
[It is recommended](https://www.scylladb.com/2022/05/11/5-tips-to-optimize-your-cql-queries/) to use `BYPASS CACHE` option while doing range scans in ScyllaDB. This will also not destroy the cache for other users while building the index (see [documentation](https://enterprise.docs.scylladb.com/stable/cql/cql-extensions.html#bypass-cache-clause)).

This PR adds the `BYPASS CACHE` option to queries executed during the index creation.

Fixes VECTOR-185