### PR TITLE
db: fetch index version from `system_schema.indexes`

### DIFF
--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -114,7 +114,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
     let mut indexes = HashSet::new();
     for idx in db.get_indexes().await?.into_iter() {
         let Some(version) = db
-            .get_index_version(idx.keyspace.clone(), idx.index.clone())
+            .get_index_version(idx.keyspace.clone(), idx.table.clone(), idx.index.clone())
             .await
             .inspect_err(|err| warn!("unable to get index version: {err}"))?
         else {
@@ -431,7 +431,7 @@ mod tests {
 
         mock_db.expect_get_index_version().returning({
             let state = state.clone();
-            move |_, index, tx| {
+            move |_, _, index, tx| {
                 let state = state.clone();
                 async move {
                     // Return a version for all indexes
@@ -560,7 +560,7 @@ mod tests {
         });
 
         mock_db.expect_get_index_version().returning({
-            move |_, _, tx| {
+            move |_, _, _, tx| {
                 async move {
                     tx.send(Ok(Some(Uuid::new_v4().into()))).unwrap();
                 }

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -305,6 +305,7 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
         }
         Db::GetIndexVersion {
             keyspace,
+            table: _,
             index,
             tx,
         } => tx


### PR DESCRIPTION
Since the index version is available in the `options` column of type map by the key `version` in `system_schema.indexes`, we will be using this version to identify each vector index entity.

This will allow us to discover the fast drop/create index with the same parameters.

We will proceed after https://github.com/scylladb/scylladb/pull/25614 is merged.

Fixes: VECTOR-142