### PR TITLE
db_index: run `initial_scan` once

### DIFF
--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -12,6 +12,8 @@ use vector_store::ColumnName;
 use vector_store::Distance;
 use vector_store::IndexInfo;
 use vector_store::IndexMetadata;
+use vector_store::IndexName;
+use vector_store::KeyspaceName;
 use vector_store::Limit;
 use vector_store::Vector;
 use vector_store::httproutes::InfoResponse;
@@ -87,11 +89,15 @@ impl HttpClient {
             .unwrap()
     }
 
-    pub async fn count(&self, index: &IndexMetadata) -> Option<usize> {
+    pub async fn count(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+    ) -> Option<usize> {
         self.client
             .get(format!(
                 "{}/indexes/{}/{}/count",
-                self.url_api, index.keyspace_name, index.index_name
+                self.url_api, keyspace_name, index_name
             ))
             .send()
             .await

--- a/crates/validator/src/tests/full_scan.rs
+++ b/crates/validator/src/tests/full_scan.rs
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::common::*;
+use crate::tests::*;
+use std::time::Duration;
+use tracing::info;
+
+pub(crate) async fn new() -> TestCase {
+    let timeout = Duration::from_secs(30);
+    TestCase::empty()
+        .with_init(timeout, init)
+        .with_cleanup(timeout, cleanup)
+        .with_test(
+            "full_scan_is_completed_when_responding_to_messages_concurrently",
+            timeout,
+            full_scan_is_completed_when_responding_to_messages_concurrently,
+        )
+}
+
+async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors: TestActors) {
+    info!("started");
+
+    let (session, client) = prepare_connection(actors).await;
+
+    session.query_unpaged(
+        "CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        (),
+    ).await.expect("failed to create a keyspace");
+
+    session
+        .use_keyspace("ks", false)
+        .await
+        .expect("failed to use a keyspace");
+
+    session
+        .query_unpaged(
+            "
+            CREATE TABLE tbl (id INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>)
+            WITH cdc = {'enabled': true }
+            ",
+            (),
+        )
+        .await
+        .expect("failed to create a table");
+
+    let embedding: Vec<f32> = vec![0.0, 0.0, 0.0];
+    for i in 0..1000 {
+        session
+            .query_unpaged(
+                "INSERT INTO tbl (id, embedding) VALUES (?, ?)",
+                (i, embedding.clone()),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    session
+        .query_unpaged(
+            "CREATE INDEX idx ON tbl(embedding) USING 'vector_index'",
+            (),
+        )
+        .await
+        .expect("failed to create an index");
+
+    while client.indexes().await.is_empty() {}
+    let indexes = client.indexes().await;
+    assert_eq!(indexes.len(), 1);
+    let index = &indexes[0];
+    assert_eq!(index.keyspace.as_ref(), "ks");
+    assert_eq!(index.index.as_ref(), "idx");
+
+    let result = session
+        .query_unpaged(
+            "SELECT * FROM tbl ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+            (),
+        )
+        .await;
+
+    match &result {
+        Err(e) if format!("{e:?}").contains("503 Service Unavailable") => {}
+        _ => panic!("Expected SERVICE_UNAVAILABLE error, got: {result:?}"),
+    }
+
+    wait_for(
+        || async { client.count(&index.keyspace, &index.index).await == Some(1000) },
+        "Waiting for 1000 vectors to be indexed",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            "SELECT * FROM tbl ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+            (),
+        )
+        .await
+        .expect("failed to query ANN search");
+
+    session
+        .query_unpaged("DROP INDEX idx", ())
+        .await
+        .expect("failed to drop an index");
+
+    while !client.indexes().await.is_empty() {}
+
+    session
+        .query_unpaged("DROP KEYSPACE ks", ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}

--- a/crates/validator/src/tests/mod.rs
+++ b/crates/validator/src/tests/mod.rs
@@ -4,6 +4,7 @@
  */
 
 mod crud;
+mod full_scan;
 
 use crate::ServicesSubnet;
 use crate::dns::Dns;
@@ -191,10 +192,13 @@ async fn run_single(span: Span, timeout: Duration, future: TestFuture) -> bool {
 
 /// Returns a vector of all known test cases to be run. Each test case is registered with a name
 pub(crate) async fn register() -> Vec<(String, TestCase)> {
-    vec![("crud", crud::new().await)]
-        .into_iter()
-        .map(|(name, test_case)| (name.to_string(), test_case))
-        .collect::<Vec<_>>()
+    vec![
+        ("crud", crud::new().await),
+        ("full_scan", full_scan::new().await),
+    ]
+    .into_iter()
+    .map(|(name, test_case)| (name.to_string(), test_case))
+    .collect::<Vec<_>>()
 }
 
 /// Runs all test cases, filtering them based on the provided filter map.

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -142,9 +142,14 @@ pub(crate) async fn new(
             debug!("starting");
             let completed_scan_length = Arc::new(AtomicU64::new(0));
 
+            let mut initial_scan = Box::pin(statements.initial_scan(
+                tx_embeddings.clone(),
+                completed_scan_length.clone(),
+            ));
+
             while !rx_index.is_closed() {
                 tokio::select! {
-                    _ = statements.initial_scan(tx_embeddings.clone(), completed_scan_length.clone()) => {
+                    _ = &mut initial_scan => {
                         node_state
                             .send_event(Event::FullScanFinished(metadata))
                             .await;

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -99,7 +99,7 @@ async fn simple_create_search_delete_index() {
     .unwrap();
 
     wait_for(
-        || async { client.count(&index).await == Some(3) },
+        || async { client.count(&index.keyspace_name, &index.index_name).await == Some(3) },
         "Waiting for index to be added to the store",
     )
     .await;

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -142,7 +142,7 @@ async fn simple_create_search_delete_index() {
     .unwrap();
 
     wait_for(
-        || async { client.count(&index).await == Some(3) },
+        || async { client.count(&index.keyspace_name, &index.index_name).await == Some(3) },
         "Waiting for 3 vectors to be indexed",
     )
     .await;


### PR DESCRIPTION
When received a message during initial scanning, the `initial_scan` future was built every time again.
Due to the bug, the completed_scan_length counter was incremented to many times, leading the counter to overflow, which lead into the infinite loop described in the Jira ticket.

Now it's built outside the select once and is still listened to concurrently with listening for messages.

Fixes: VECTOR-192