### PR TITLE
httproutes, api: fix status SERVING docs

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -354,7 +354,7 @@
           "The node is starting up.",
           "The node is establishing a connection to ScyllaDB.",
           "The node is discovering available vector indexes in ScyllaDB.",
-          "The node is making initial indexes discovering and vector data indexing."
+          "The node has completed the initial database scan and built the indexes defined at that time. It is now monitoring the database for changes."
         ]
       },
       "Vector": {

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -549,7 +549,7 @@ pub enum Status {
     ConnectingToDb,
     /// The node is discovering available vector indexes in ScyllaDB.
     Bootstrapping,
-    /// The node is making initial indexes discovering and vector data indexing.
+    /// The node has completed the initial database scan and built the indexes defined at that time. It is now monitoring the database for changes.
     Serving,
 }
 


### PR DESCRIPTION
Fix SERVING status documentation deleted by mistake in #200.