### PR TITLE
Log more information about serving status and finishing full scan

### DIFF
--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -45,6 +45,7 @@ use tokio::sync::oneshot;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
+use tracing::info;
 use tracing::trace;
 use tracing::warn;
 
@@ -151,7 +152,7 @@ pub(crate) async fn new(
                 tokio::select! {
                     _ = &mut initial_scan => {
                         node_state
-                            .send_event(Event::FullScanFinished(metadata))
+                            .send_event(Event::FullScanFinished(metadata.clone()))
                             .await;
                         break;
                     }
@@ -161,7 +162,7 @@ pub(crate) async fn new(
                 }
             }
 
-            debug!("finished initial load");
+            info!("finished full scan on {}", metadata.id());
 
             while let Some(msg) = rx_index.recv().await {
                 tokio::spawn(process(Arc::clone(&statements), msg, completed_scan_length.clone()));

--- a/crates/vector-store/src/node_state.rs
+++ b/crates/vector-store/src/node_state.rs
@@ -10,6 +10,7 @@ use tokio::sync::oneshot;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
+use tracing::info;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Status {
@@ -79,8 +80,9 @@ pub(crate) async fn new() -> mpsc::Sender<NodeState> {
                             }
                         }
                         Event::IndexesDiscovered(indexes) => {
-                            if indexes.is_empty() {
+                            if indexes.is_empty() && status != Status::Serving {
                                 status = Status::Serving;
+                                info!("Service is running, no indexes to build");
                                 continue;
                             }
                             if status == Status::DiscoveringIndexes {
@@ -90,8 +92,9 @@ pub(crate) async fn new() -> mpsc::Sender<NodeState> {
                         }
                         Event::FullScanFinished(metadata) => {
                             idxs.remove(&metadata);
-                            if idxs.is_empty() {
+                            if idxs.is_empty() && status != Status::Serving {
                                 status = Status::Serving;
+                                info!("Service is running, finished building indexes");
                             }
                         }
                     },

--- a/crates/vector-store/src/node_state.rs
+++ b/crates/vector-store/src/node_state.rs
@@ -74,7 +74,9 @@ pub(crate) async fn new() -> mpsc::Sender<NodeState> {
                         }
                         Event::ConnectedToDb => {}
                         Event::DiscoveringIndexes => {
-                            status = Status::DiscoveringIndexes;
+                            if status != Status::Serving {
+                                status = Status::DiscoveringIndexes;
+                            }
                         }
                         Event::IndexesDiscovered(indexes) => {
                             if indexes.is_empty() {


### PR DESCRIPTION
This patch adds the debug information on the `node_state`, informs the user about SERVING status and when the full scan has been completed.

Fixes the issue that discovering indexes after the initial bootstrapping caused the status to change to BOOTSTRAPING again, although it is properly setup and does respond to the requests on built indexes.

Fixes: VECTOR-195