### PR TITLE
Update workflow trigger to pull_request_target - fixing fork PR bug

### DIFF
--- a/.github/workflows/call_jira_status_in_progress.yml
+++ b/.github/workflows/call_jira_status_in_progress.yml
@@ -1,11 +1,11 @@
 name: Call Jira Status In Progress
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
   call-jira-status-in-progress:
     uses: scylladb/github-automation/.github/workflows/main_update_jira_status_to_in_progress.yml@main
     secrets:
-      jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}

--- a/.github/workflows/call_jira_status_in_review.yml
+++ b/.github/workflows/call_jira_status_in_review.yml
@@ -1,11 +1,11 @@
 name: Call Jira Status In Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ready_for_review, review_requested]
 
 jobs:
   call-jira-status-in-review:
     uses: scylladb/github-automation/.github/workflows/main_update_jira_status_to_in_review.yml@main
     secrets:
-      jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}

--- a/.github/workflows/call_jira_status_ready_for_merge.yml
+++ b/.github/workflows/call_jira_status_ready_for_merge.yml
@@ -1,13 +1,11 @@
 name: Call Jira Status Ready For Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 jobs:
   call-jira-status-update:
     uses: scylladb/github-automation/.github/workflows/main_update_jira_status_to_ready_for_merge.yml@main
-    with:
-      label_name: 'status/merge_candidate'
     secrets:
-      jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+      caller_jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}


### PR DESCRIPTION
The previous version had a problem: Fork PRs didn't manage to pass the Jira credentials to the main code, which updates the Jira key status.