### PR TITLE
validator/tests: add CRUD test with multiple indexes

### DIFF
--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -12,7 +12,6 @@ use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::task;
 use tokio::time;
 use tracing::info;
 
@@ -79,7 +78,7 @@ where
 {
     time::timeout(timeout, async {
         while !condition().await {
-            task::yield_now().await;
+            time::sleep(Duration::from_millis(100)).await;
         }
     })
     .await

--- a/crates/validator/src/tests/crud.rs
+++ b/crates/validator/src/tests/crud.rs
@@ -18,6 +18,11 @@ pub(crate) async fn new() -> TestCase {
             timeout,
             simple_create_drop_index,
         )
+        .with_test(
+            "simple_create_drop_multiple_indexes",
+            timeout,
+            simple_create_drop_multiple_indexes,
+        )
 }
 
 async fn simple_create_drop_index(actors: TestActors) {
@@ -69,6 +74,173 @@ async fn simple_create_drop_index(actors: TestActors) {
 
     session
         .query_unpaged("DROP KEYSPACE ks", ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+async fn simple_create_drop_multiple_indexes(actors: TestActors) {
+    info!("started");
+
+    let (session, client) = prepare_connection(actors).await;
+
+    // Create keyspace
+    // Different keyspace name have to be used until the issue VECTOR-213 is fixed.
+    // When fixed please remove the comment and change the keyspace back to "ks"
+    session.query_unpaged(
+        "CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+        (),
+    ).await.expect("failed to create a keyspace");
+
+    // Use keyspace
+    session
+        .use_keyspace("ks2", false)
+        .await
+        .expect("failed to use a keyspace");
+
+    // Create table
+    session
+        .query_unpaged(
+            "
+            CREATE TABLE tbl (pk INT PRIMARY KEY, v1 VECTOR<FLOAT, 3>, v2 VECTOR<FLOAT, 3>)
+            ",
+            (),
+        )
+        .await
+        .expect("failed to create a table");
+
+    // Create index on column v1
+    session
+        .query_unpaged("CREATE INDEX idx1 ON tbl(v1) USING 'vector_index'", ())
+        .await
+        .expect("failed to create an index");
+
+    // Wait for the index to be created
+    wait_for(
+        || async { client.indexes().await.len() == 1 },
+        "Waiting for the first index to be created",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Wait for the full scan to complete and check if ANN query succeeds on v1
+    wait_for(
+        || async {
+            session
+                .query_unpaged(
+                    "SELECT * FROM tbl ORDER BY v1 ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+                    (),
+                )
+                .await
+                .is_ok()
+        },
+        "Waiting for full scan to complete. ANN query should succeed",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // ANN query on v2 should not succeed without the index
+    session
+        .query_unpaged(
+            "SELECT * FROM tbl ORDER BY v2 ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+            (),
+        )
+        .await
+        .expect_err("ANN query should fail when index does not exist");
+
+    // Create index on column v2
+    session
+        .query_unpaged("CREATE INDEX idx2 ON tbl(v2) USING 'vector_index'", ())
+        .await
+        .expect("failed to create an index");
+
+    info!("waiting for the second index to be created");
+
+    // Wait for the second index to be created
+    wait_for(
+        || async { client.indexes().await.len() == 2 },
+        "Waiting for 2 indexes to be created",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Check if ANN query on v1 still succeeds
+    session
+        .query_unpaged(
+            "SELECT * FROM tbl ORDER BY v1 ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+            (),
+        )
+        .await
+        .expect("failed to run ANN query");
+
+    // Wait for the full scan to complete and check if ANN query succeeds on v2
+    wait_for(
+        || async {
+            session
+                .query_unpaged(
+                    "SELECT * FROM tbl ORDER BY v2 ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+                    (),
+                )
+                .await
+                .is_ok()
+        },
+        "Waiting for full scan to complete. ANN query should succeed",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Drop index on column v1
+    session
+        .query_unpaged("DROP INDEX idx1", ())
+        .await
+        .expect("failed to drop an index");
+
+    info!("waiting for the first index to be dropped");
+
+    // Wait for the first index to be dropped
+    wait_for(
+        || async { client.indexes().await.len() == 1 },
+        "Waiting for the first index to be dropped",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // ANN query on v1 should not succeed after dropping the index
+    session
+        .query_unpaged(
+            "SELECT * FROM tbl ORDER BY v1 ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+            (),
+        )
+        .await
+        .expect_err("ANN query should fail when index does not exist");
+
+    // Check if ANN query on v2 still succeeds
+    session
+        .query_unpaged(
+            "SELECT * FROM tbl ORDER BY v2 ANN OF [1.0, 2.0, 3.0] LIMIT 5",
+            (),
+        )
+        .await
+        .expect("failed to run ANN query");
+
+    // Drop index on column v2
+    session
+        .query_unpaged("DROP INDEX idx2", ())
+        .await
+        .expect("failed to drop an index");
+
+    // Wait for the second index to be dropped
+    wait_for(
+        || async { client.indexes().await.is_empty() },
+        "Waiting for all indexes to be dropped",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Drop keyspace
+    session
+        .query_unpaged("DROP KEYSPACE ks2", ())
         .await
         .expect("failed to drop a keyspace");
 


### PR DESCRIPTION
Add test for CREATE, SELECT, DROP on indexes on different
vector columns of the same table.

Fixes: [VECTOR-51](https://scylladb.atlassian.net/browse/VECTOR-51)

[VECTOR-51]: https://scylladb.atlassian.net/browse/VECTOR-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ