### PR TITLE
vector-store: move usearch cpu tasks into tokio threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,25 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,26 +1913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,7 +3012,6 @@ dependencies = [
  "ntest",
  "opensearch",
  "prometheus",
- "rayon",
  "regex",
  "reqwest",
  "scylla",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ opensearch = { version = "2.3.0", default-features = false, features = ["rustls-
 proc-macro2 = "1.0"
 prometheus = "0.14"
 quote = "1.0"
-rayon = "1.10.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls"] }
 scylla = { version = "1.2.0", features = ["time-03"] }

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -33,7 +33,6 @@ macros.workspace = true
 ntest.workspace = true
 opensearch.workspace = true
 prometheus.workspace = true
-rayon.workspace = true
 regex.workspace = true
 scylla.workspace = true
 scylla-cdc.workspace = true

--- a/crates/vector-store/tests/integration/info.rs
+++ b/crates/vector-store/tests/integration/info.rs
@@ -14,7 +14,6 @@ async fn run_vs(
     let (db_actor, _) = db_basic::new(node_state.clone());
     let (server, addr) = vector_store::run(
         SocketAddr::from(([127, 0, 0, 1], 0)).into(),
-        Some(1),
         node_state,
         db_actor,
         index_factory,

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -40,7 +40,6 @@ async fn simple_create_search_delete_index() {
 
     let (_server_actor, addr) = vector_store::run(
         SocketAddr::from(([127, 0, 0, 1], 0)).into(),
-        Some(1),
         node_state,
         db_actor,
         index_factory,

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -76,7 +76,6 @@ pub(crate) async fn setup_store() -> (
         async move {
             let (server, addr) = vector_store::run(
                 SocketAddr::from(([127, 0, 0, 1], 0)).into(),
-                Some(1),
                 node_state,
                 db_actor,
                 index_factory,
@@ -200,7 +199,6 @@ async fn failed_db_index_create() {
 
     let (_server_actor, addr) = vector_store::run(
         SocketAddr::from(([127, 0, 0, 1], 0)).into(),
-        Some(1),
         node_state,
         db_actor,
         index_factory,


### PR DESCRIPTION

The current thread layout is like this: 1 thread for io-intensive (async) tasks
with tokio runtime and all available threads for cpu-intensive (sync, usearch)
computation using rayon thread pool. It means that on one cpu there will be
fight for the same cpu resource. This change introduces usearch computation
using only tokio threads with deprioritized (moved to the end of async task
queue) usearch (cpu-intensive) tasks. According to the benchmarks (p99conf in
2025) this setup gives higher qps and lower latency.

Fixes: VECTOR-223

