### PR TITLE
validator/scylla_cluster: fix Vector Store URI parameter

### DIFF
--- a/crates/validator/src/scylla_cluster.rs
+++ b/crates/validator/src/scylla_cluster.rs
@@ -244,7 +244,7 @@ async fn run_cluster(
             .arg(db_ip.to_string())
             .arg("--seed-provider-parameters")
             .arg(format!("seeds={db_ip}"))
-            .arg("--vector-store-uri")
+            .arg("--vector-store-primary-uri")
             .arg(vs_uri)
             .arg("--developer-mode")
             .arg("true")


### PR DESCRIPTION
Since scylladb/scylladb#26033 renamed the Vector Store URI parameter from `--vector-store-uri` to `--vector-store-primary-uri` we need to change the naming also in the validator Scylla Cluster.