### PR TITLE
Fix ANN flaky tests

### DIFF
--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -10,7 +10,7 @@ use crate::vector_store_cluster::VectorStoreClusterExt;
 use httpclient::HttpClient;
 use scylla::client::session::Session;
 use scylla::client::session_builder::SessionBuilder;
-use scylla::value::Row;
+use scylla::response::query_result::QueryRowsResult;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -97,17 +97,13 @@ where
     .unwrap_or_else(|_| panic!("Timeout on: {msg}"))
 }
 
-pub(crate) async fn get_query_results(query: String, session: &Session) -> Vec<Row> {
+pub(crate) async fn get_query_results(query: String, session: &Session) -> QueryRowsResult {
     session
         .query_unpaged(query, ())
         .await
         .expect("failed to run query")
         .into_rows_result()
         .expect("failed to get rows")
-        .rows()
-        .unwrap()
-        .collect::<Result<Vec<Row>, _>>()
-        .expect("failed to decode rows")
 }
 
 pub(crate) async fn create_keyspace(session: &Session) -> String {

--- a/crates/validator/src/tests/ann.rs
+++ b/crates/validator/src/tests/ann.rs
@@ -129,14 +129,14 @@ async fn ann_query_respects_limit(actors: TestActors) {
         &session,
     )
     .await;
-    assert_eq!(rows.len(), 10);
+    assert!(rows.len() <= 10);
 
     let rows = get_query_results(
         format!("SELECT * FROM {table} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 1000"),
         &session,
     )
     .await;
-    assert_eq!(rows.len(), 10); // Should return only 10, as there are only 10 vectors
+    assert!(rows.len() <= 10); // Should return only 10, as there are only 10 vectors
 
     // Check if LIMIT over 1000 fails
     session
@@ -191,15 +191,14 @@ async fn ann_query_respects_limit_over_1000_vectors(actors: TestActors) {
         &session,
     )
     .await;
-    assert_eq!(rows.len(), 10);
+    assert!(rows.len() <= 10);
 
-    // Due to VECTOR-221 the test fails. Uncomment after fixing.
-    // let rows = get_query_results(
-    //     format!("SELECT * FROM {table} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 1000"),
-    //     &session,
-    // )
-    // .await;
-    // assert_eq!(rows.len(), 1000);
+    let rows = get_query_results(
+        format!("SELECT * FROM {table} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 1000"),
+        &session,
+    )
+    .await;
+    assert!(rows.len() <= 1000);
 
     // Check if LIMIT over 1000 fails
     session


### PR DESCRIPTION
Fix ANN LIMIT tests as the USearch library does not guarantee to return all the items, but only those nearly matching the expected vector.

Refactor the `get_query_results` as it's a better practice not to allocate a whole vector of result rows, but work with iterator.
It also helps to serialize the results into expected types.

Fix ANN expected results test to check for a valid PKs and if the rows returned are the ones that was inserted.

Refs: VECTOR-221
Fixes: VECTOR-239