### PR TITLE
validator/tests: add `test_` prefix to all tests

### DIFF
--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -151,13 +151,20 @@ pub(crate) async fn create_index(
     client: &HttpClient,
     table: &str,
     column: &str,
+    options: Option<&str>,
 ) -> IndexInfo {
     let index = format!("idx_{}", Uuid::new_v4().simple());
+
+    let extra = if let Some(options) = options {
+        format!("WITH OPTIONS = {options}")
+    } else {
+        String::new()
+    };
 
     // Create index
     session
         .query_unpaged(
-            format!("CREATE INDEX {index} ON {table}({column}) USING 'vector_index'"),
+            format!("CREATE INDEX {index} ON {table}({column}) USING 'vector_index' {extra}"),
             (),
         )
         .await

--- a/crates/validator/src/tests/ann.rs
+++ b/crates/validator/src/tests/ann.rs
@@ -61,7 +61,7 @@ async fn ann_query_returns_expected_results(actors: TestActors) {
             .expect("failed to insert data");
     }
 
-    let index = create_index(&session, &client, &table, "v").await;
+    let index = create_index(&session, &client, &table, "v", None).await;
 
     wait_for(
         || async { client.count(&index.keyspace, &index.index).await == Some(1000) },
@@ -121,7 +121,7 @@ async fn ann_query_respects_limit(actors: TestActors) {
     }
 
     // Create index
-    let index = create_index(&session, &client, &table, "v").await;
+    let index = create_index(&session, &client, &table, "v", None).await;
 
     wait_for(
         || async { client.count(&index.keyspace, &index.index).await == Some(10) },
@@ -189,7 +189,7 @@ async fn ann_query_respects_limit_over_1000_vectors(actors: TestActors) {
             .expect("failed to insert data");
     }
 
-    let index = create_index(&session, &client, &table, "v").await;
+    let index = create_index(&session, &client, &table, "v", None).await;
 
     wait_for(
         || async { client.count(&index.keyspace, &index.index).await == Some(1111) },

--- a/crates/validator/src/tests/ann.rs
+++ b/crates/validator/src/tests/ann.rs
@@ -17,21 +17,21 @@ pub(crate) async fn new() -> TestCase {
         .with_test(
             "ann_query_returns_expected_results",
             timeout,
-            ann_query_returns_expected_results,
+            test_ann_query_returns_expected_results,
         )
         .with_test(
             "ann_query_respects_limit",
             timeout,
-            ann_query_respects_limit,
+            test_ann_query_respects_limit,
         )
         .with_test(
             "ann_query_respects_limit_over_1000_vectors",
             timeout,
-            ann_query_respects_limit_over_1000_vectors,
+            test_ann_query_respects_limit_over_1000_vectors,
         )
 }
 
-async fn ann_query_returns_expected_results(actors: TestActors) {
+async fn test_ann_query_returns_expected_results(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;
@@ -100,7 +100,7 @@ async fn ann_query_returns_expected_results(actors: TestActors) {
     info!("finished");
 }
 
-async fn ann_query_respects_limit(actors: TestActors) {
+async fn test_ann_query_respects_limit(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;
@@ -169,7 +169,7 @@ async fn ann_query_respects_limit(actors: TestActors) {
     info!("finished");
 }
 
-async fn ann_query_respects_limit_over_1000_vectors(actors: TestActors) {
+async fn test_ann_query_respects_limit_over_1000_vectors(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;

--- a/crates/validator/src/tests/crud.rs
+++ b/crates/validator/src/tests/crud.rs
@@ -16,16 +16,16 @@ pub(crate) async fn new() -> TestCase {
         .with_test(
             "simple_create_drop_index",
             timeout,
-            simple_create_drop_index,
+            test_simple_create_drop_index,
         )
         .with_test(
             "simple_create_drop_multiple_indexes",
             timeout,
-            simple_create_drop_multiple_indexes,
+            test_simple_create_drop_multiple_indexes,
         )
 }
 
-async fn simple_create_drop_index(actors: TestActors) {
+async fn test_simple_create_drop_index(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;
@@ -57,7 +57,7 @@ async fn simple_create_drop_index(actors: TestActors) {
     info!("finished");
 }
 
-async fn simple_create_drop_multiple_indexes(actors: TestActors) {
+async fn test_simple_create_drop_multiple_indexes(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;

--- a/crates/validator/src/tests/crud.rs
+++ b/crates/validator/src/tests/crud.rs
@@ -38,7 +38,7 @@ async fn simple_create_drop_index(actors: TestActors) {
     )
     .await;
 
-    let index = create_index(&session, &client, &table, "embedding").await;
+    let index = create_index(&session, &client, &table, "embedding", None).await;
 
     assert_eq!(index.keyspace.as_ref(), &keyspace);
 
@@ -71,7 +71,7 @@ async fn simple_create_drop_multiple_indexes(actors: TestActors) {
     .await;
 
     // Create index on column v1
-    let index1 = create_index(&session, &client, &table, "v1").await;
+    let index1 = create_index(&session, &client, &table, "v1", None).await;
 
     // Wait for the full scan to complete and check if ANN query succeeds on v1
     wait_for(
@@ -99,7 +99,7 @@ async fn simple_create_drop_multiple_indexes(actors: TestActors) {
         .expect_err("ANN query should fail when index does not exist");
 
     // Create index on column v2
-    let index2 = create_index(&session, &client, &table, "v2").await;
+    let index2 = create_index(&session, &client, &table, "v2", None).await;
 
     // Check if ANN query on v1 still succeeds
     session

--- a/crates/validator/src/tests/full_scan.rs
+++ b/crates/validator/src/tests/full_scan.rs
@@ -44,7 +44,7 @@ async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors:
             .expect("failed to insert data");
     }
 
-    let index = create_index(&session, &client, &table, "embedding").await;
+    let index = create_index(&session, &client, &table, "embedding", None).await;
 
     let result = session
         .query_unpaged(

--- a/crates/validator/src/tests/full_scan.rs
+++ b/crates/validator/src/tests/full_scan.rs
@@ -16,11 +16,11 @@ pub(crate) async fn new() -> TestCase {
         .with_test(
             "full_scan_is_completed_when_responding_to_messages_concurrently",
             timeout,
-            full_scan_is_completed_when_responding_to_messages_concurrently,
+            test_full_scan_is_completed_when_responding_to_messages_concurrently,
         )
 }
 
-async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors: TestActors) {
+async fn test_full_scan_is_completed_when_responding_to_messages_concurrently(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;

--- a/crates/validator/src/tests/mod.rs
+++ b/crates/validator/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod crud;
 mod full_scan;
 mod reconnect;
 mod serde;
+mod vector_similarity;
 
 use crate::ServicesSubnet;
 use crate::dns::Dns;
@@ -221,6 +222,7 @@ pub(crate) async fn register() -> Vec<(String, TestCase)> {
         ("full_scan", full_scan::new().await),
         ("reconnect", reconnect::new().await),
         ("serde", serde::new().await),
+        ("vector_similarity", vector_similarity::new().await),
     ]
     .into_iter()
     .map(|(name, test_case)| (name.to_string(), test_case))

--- a/crates/validator/src/tests/reconnect.rs
+++ b/crates/validator/src/tests/reconnect.rs
@@ -49,7 +49,7 @@ async fn reconnect_doesnt_break_fullscan(actors: TestActors) {
             .expect("failed to insert a row");
     }
 
-    let index = create_index(&session, &client, &table, "embedding").await;
+    let index = create_index(&session, &client, &table, "embedding", None).await;
 
     let result = session
         .query_unpaged(

--- a/crates/validator/src/tests/reconnect.rs
+++ b/crates/validator/src/tests/reconnect.rs
@@ -18,11 +18,11 @@ pub(crate) async fn new() -> TestCase {
         .with_test(
             "reconnect_doesnt_break_fullscan",
             timeout,
-            reconnect_doesnt_break_fullscan,
+            test_reconnect_doesnt_break_fullscan,
         )
 }
 
-async fn reconnect_doesnt_break_fullscan(actors: TestActors) {
+async fn test_reconnect_doesnt_break_fullscan(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;

--- a/crates/validator/src/tests/serde.rs
+++ b/crates/validator/src/tests/serde.rs
@@ -13,7 +13,7 @@ pub(crate) async fn new() -> TestCase {
         .with_init(timeout, crate::common::init)
         .with_cleanup(timeout, crate::common::cleanup)
         .with_test(
-            "test_serialization_deserialization_all_types",
+            "serialization_deserialization_all_types",
             timeout,
             test_serialization_deserialization_all_types,
         )

--- a/crates/validator/src/tests/vector_similarity.rs
+++ b/crates/validator/src/tests/vector_similarity.rs
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::common::*;
+use crate::tests::*;
+use scylla::client::session::Session;
+use std::time::Duration;
+use tracing::info;
+
+pub(crate) async fn new() -> TestCase {
+    let timeout = Duration::from_secs(30);
+    TestCase::empty()
+        .with_init(timeout, init)
+        .with_cleanup(timeout, cleanup)
+        .with_test(
+            "vector_similarity_function_with_single_column_partition_key",
+            timeout,
+            vector_similarity_function_with_single_column_partition_key,
+        )
+        .with_test(
+            "vector_similarity_function_with_clustering_key",
+            timeout,
+            vector_similarity_function_with_clustering_key,
+        )
+        .with_test(
+            "vector_similarity_function_with_multi_column_partition_key",
+            timeout,
+            vector_similarity_function_with_multi_column_partition_key,
+        )
+}
+
+pub(crate) static EMBEDDINGS: [[f32; 3]; 3] = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]];
+
+async fn assert_similarity_function_results(session: &Session, table: &str, key_column: &str) {
+    let results = get_query_results(
+        format!(
+            "SELECT {key_column}, vector_similarity() FROM {table} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 5"
+        ),
+        session,
+    )
+    .await;
+    let rows = results.rows::<(i32, f32)>().expect("failed to get rows");
+    assert_eq!(rows.rows_remaining(), 3);
+
+    // Expected results are calculated using Euclidean distance formula
+    let expected_distances = [(0, 14.0), (1, 77.0), (2, 194.0)];
+    for (i, row) in rows.enumerate() {
+        let row = row.expect("failed to get row");
+        let (key, distance) = row;
+        assert_eq!(
+            (key, distance),
+            expected_distances[i],
+            "Row {i} does not match expected result"
+        );
+    }
+}
+
+async fn vector_similarity_function_with_single_column_partition_key(actors: TestActors) {
+    info!("started");
+
+    let (session, client) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+
+    // Insert test data
+    for (i, embedding) in EMBEDDINGS.into_iter().enumerate() {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, v) VALUES (?, ?)"),
+                (i as i32, embedding.as_slice()),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index = create_index(
+        &session,
+        &client,
+        &table,
+        "v",
+        Some("{'similarity_function' : 'EUCLIDEAN'}"),
+    )
+    .await;
+
+    wait_for(
+        || async { client.count(&index.keyspace, &index.index).await == Some(3) },
+        "Waiting for 3 vectors to be indexed",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Check if the query returns the expected distances
+    assert_similarity_function_results(&session, &table, "pk").await;
+
+    // Drop keyspace
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+async fn vector_similarity_function_with_clustering_key(actors: TestActors) {
+    info!("started");
+
+    let (session, client) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, ck INT, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk, ck)",
+        None,
+    )
+    .await;
+
+    // Insert test data
+    for (i, embedding) in EMBEDDINGS.into_iter().enumerate() {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)"),
+                (123, i as i32, &embedding.as_slice()),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index = create_index(
+        &session,
+        &client,
+        &table,
+        "v",
+        Some("{'similarity_function' : 'EUCLIDEAN'}"),
+    )
+    .await;
+
+    wait_for(
+        || async { client.count(&index.keyspace, &index.index).await == Some(3) },
+        "Waiting for 3 vectors to be indexed",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Check if the query returns the expected distances
+    assert_similarity_function_results(&session, &table, "ck").await;
+
+    // Drop keyspace
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+async fn vector_similarity_function_with_multi_column_partition_key(actors: TestActors) {
+    info!("started");
+
+    let (session, client) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk1 INT, pk2 INT, v VECTOR<FLOAT, 3>, PRIMARY KEY ((pk1, pk2))",
+        None,
+    )
+    .await;
+
+    // Insert test data
+    for (i, embedding) in EMBEDDINGS.into_iter().enumerate() {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk1, pk2, v) VALUES (?, ?, ?)"),
+                (123, i as i32, &embedding.as_slice()),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index = create_index(
+        &session,
+        &client,
+        &table,
+        "v",
+        Some("{'similarity_function' : 'EUCLIDEAN'}"),
+    )
+    .await;
+
+    wait_for(
+        || async { client.count(&index.keyspace, &index.index).await == Some(3) },
+        "Waiting for 3 vectors to be indexed",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    // Check if the query returns the expected distances
+    assert_similarity_function_results(&session, &table, "pk2").await;
+
+    // Drop keyspace
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}

--- a/crates/validator/src/tests/vector_similarity.rs
+++ b/crates/validator/src/tests/vector_similarity.rs
@@ -17,17 +17,17 @@ pub(crate) async fn new() -> TestCase {
         .with_test(
             "vector_similarity_function_with_single_column_partition_key",
             timeout,
-            vector_similarity_function_with_single_column_partition_key,
+            test_vector_similarity_function_with_single_column_partition_key,
         )
         .with_test(
             "vector_similarity_function_with_clustering_key",
             timeout,
-            vector_similarity_function_with_clustering_key,
+            test_vector_similarity_function_with_clustering_key,
         )
         .with_test(
             "vector_similarity_function_with_multi_column_partition_key",
             timeout,
-            vector_similarity_function_with_multi_column_partition_key,
+            test_vector_similarity_function_with_multi_column_partition_key,
         )
 }
 
@@ -57,7 +57,7 @@ async fn assert_similarity_function_results(session: &Session, table: &str, key_
     }
 }
 
-async fn vector_similarity_function_with_single_column_partition_key(actors: TestActors) {
+async fn test_vector_similarity_function_with_single_column_partition_key(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;
@@ -104,7 +104,7 @@ async fn vector_similarity_function_with_single_column_partition_key(actors: Tes
     info!("finished");
 }
 
-async fn vector_similarity_function_with_clustering_key(actors: TestActors) {
+async fn test_vector_similarity_function_with_clustering_key(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;
@@ -156,7 +156,7 @@ async fn vector_similarity_function_with_clustering_key(actors: TestActors) {
     info!("finished");
 }
 
-async fn vector_similarity_function_with_multi_column_partition_key(actors: TestActors) {
+async fn test_vector_similarity_function_with_multi_column_partition_key(actors: TestActors) {
     info!("started");
 
     let (session, client) = prepare_connection(&actors).await;


### PR DESCRIPTION
We need to be able to simply differ the test cases from the utility
functions implemented in a test file.
This patch introduces a conversion that each test should be named
with the `test_` prefix.
The test name should be the same as test function name but without
the `test_` prefix, as this would duplicate the test keywords in logs.

From this commit, let's keep the conversion for all future tests.