### PR TITLE
db: fix option parsing

### DIFF
--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -518,7 +518,7 @@ impl Statements {
                 .unwrap_or_default();
             let space_type = options
                 .remove("similarity_function")
-                .and_then(|s| s.parse().ok())
+                .and_then(|s| s.to_ascii_uppercase().parse().ok())
                 .unwrap_or_default();
             (connectivity, expansion_add, expansion_search, space_type)
         }))


### PR DESCRIPTION
We allowed lowercase similarity function names in Scylla, however we parsed them wrong in Vector Store. This patch makes it so it is converted to uppercase before parsing.

Fixes: VECTOR-235