### PR TITLE
vector_store: set default index options

### DIFF
--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -247,7 +247,6 @@ pub struct Dimensions(NonZeroUsize);
     Copy,
     Clone,
     Debug,
-    Default,
     PartialEq,
     Eq,
     Hash,
@@ -260,11 +259,16 @@ pub struct Dimensions(NonZeroUsize);
 /// Limit number of neighbors per graph node
 pub struct Connectivity(usize);
 
+impl Default for Connectivity {
+    fn default() -> Self {
+        Self(16)
+    }
+}
+
 #[derive(
     Copy,
     Clone,
     Debug,
-    Default,
     PartialEq,
     Eq,
     Hash,
@@ -278,11 +282,16 @@ pub struct Connectivity(usize);
 /// Control the recall of indexing
 pub struct ExpansionAdd(usize);
 
+impl Default for ExpansionAdd {
+    fn default() -> Self {
+        Self(128)
+    }
+}
+
 #[derive(
     Copy,
     Clone,
     Debug,
-    Default,
     PartialEq,
     Eq,
     Hash,
@@ -295,6 +304,12 @@ pub struct ExpansionAdd(usize);
 )]
 /// Control the quality of the search
 pub struct ExpansionSearch(usize);
+
+impl Default for ExpansionSearch {
+    fn default() -> Self {
+        Self(64)
+    }
+}
 
 #[derive(
     Copy,

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::Connectivity;
+use crate::ExpansionAdd;
+use crate::ExpansionSearch;
 use crate::IndexMetadata;
 use crate::SpaceType;
 use crate::db::Db;
@@ -143,7 +146,12 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             params
         } else {
             debug!("get_indexes: no params for index {idx:?}");
-            (0.into(), 0.into(), 0.into(), SpaceType::default())
+            (
+                Connectivity::default(),
+                ExpansionAdd::default(),
+                ExpansionSearch::default(),
+                SpaceType::default(),
+            )
         };
 
         let metadata = IndexMetadata {

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -16,8 +16,12 @@ use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
+use vector_store::Connectivity;
+use vector_store::ExpansionAdd;
+use vector_store::ExpansionSearch;
 use vector_store::IndexMetadata;
 use vector_store::Percentage;
+use vector_store::SpaceType;
 use vector_store::Vector;
 use vector_store::node_state::NodeState;
 
@@ -37,10 +41,10 @@ pub(crate) async fn setup_store() -> (
         index_name: "ann".to_string().into(),
         target_column: "embedding".to_string().into(),
         dimensions: NonZeroUsize::new(3).unwrap().into(),
-        connectivity: Default::default(),
-        expansion_add: Default::default(),
-        expansion_search: Default::default(),
-        space_type: Default::default(),
+        connectivity: Connectivity::default(),
+        expansion_add: ExpansionAdd::default(),
+        expansion_search: ExpansionSearch::default(),
+        space_type: SpaceType::default(),
         version: Uuid::new_v4().into(),
     };
 


### PR DESCRIPTION
Explicitly set the default usearch index parameters:
  - Connectivity    = 16
  - ExpansionAdd    = 128
  - ExpansionSearch = 64
  - SpaceType       = Cosine

Fixes: VECTOR-242