### PR TITLE
generate-openapi: Fix missing trailing newline

### DIFF
--- a/crates/vector-store/src/bin/generate-openapi.rs
+++ b/crates/vector-store/src/bin/generate-openapi.rs
@@ -9,7 +9,8 @@ fn main() -> anyhow::Result<()> {
 
     let json = serde_json::to_string_pretty(&vector_store::httproutes::api())?;
 
-    fs::File::create(pathname)?.write(json.as_bytes())?;
+    let mut file = fs::File::create(pathname)?;
+    writeln!(file, "{}", json)?;
 
     println!("OpenAPI specification written to {}", pathname);
     Ok(())


### PR DESCRIPTION
The OpenAPI generator did not append a newline character to the end of the generated file.