### PR TITLE
ci: bump scylla-nightly version for tests

### DIFF
--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -36,5 +36,5 @@ jobs:
 
     - name: Run the Validator tests
 
-      run: ./scripts/run-validator-with-scylla-docker scylladb/scylla-nightly:2026.1.0-dev-0.20251117.f0039381d22c target/amd64/release/vector-store target/amd64/release/vector-search-validator --verbose
+      run: ./scripts/run-validator-with-scylla-docker scylladb/scylla-nightly:2026.1.0-dev-0.20251201.0ed34527215d target/amd64/release/vector-store target/amd64/release/vector-search-validator --verbose
 


### PR DESCRIPTION
Currently fixed scylla-nightly version in our CI environment does not yet fully support HA implemented on ScyllaDB side. Bumping the version to include newest updates on the topic.