### PR TITLE
Support 3 Vector Store nodes in Vector Store Validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,7 +3790,6 @@ dependencies = [
 name = "vector-search-validator-vector-store"
 version = "1.0.0"
 dependencies = [
- "httpclient",
  "scylla",
  "sysinfo",
  "tokio",

--- a/crates/validator-engine/src/scylla_cluster.rs
+++ b/crates/validator-engine/src/scylla_cluster.rs
@@ -371,14 +371,17 @@ async fn is_cql_port_ready(ip: Ipv4Addr) -> bool {
 /// Waits for ScyllaDB to be ready by checking the nodetool status.
 async fn wait_for_ready(state: &State) -> bool {
     if state.nodes.is_empty() {
-        tracing::error!("No nodes to wait for - nodes list is empty");
+        tracing::error!("No ScyllaDB nodes to wait for - nodes list is empty");
         return false;
     }
 
     for node in &state.nodes {
-        tracing::info!("Waiting for node at IP {} to be ready...", &node.db_ip);
+        tracing::info!(
+            "Waiting for ScyllaDB node at IP {} to be ready...",
+            &node.db_ip
+        );
         wait_for_node(state, node.db_ip).await;
-        tracing::info!("Node at IP {} is ready.", &node.db_ip);
+        tracing::info!("ScyllaDB node at IP {} is ready.", &node.db_ip);
     }
 
     true

--- a/crates/validator-tests/src/common.rs
+++ b/crates/validator-tests/src/common.rs
@@ -81,21 +81,21 @@ pub async fn get_default_scylla_node_configs(actors: &TestActors) -> Vec<ScyllaN
 pub async fn init(actors: TestActors) {
     info!("started");
 
-    let node_configs = get_default_scylla_node_configs(&actors).await;
-    init_with_config(actors, node_configs).await;
+    let scylla_configs = get_default_scylla_node_configs(&actors).await;
+    init_with_config(actors, scylla_configs).await;
 
     info!("finished");
 }
 
-pub async fn init_with_config(actors: TestActors, node_configs: Vec<ScyllaNodeConfig>) {
+pub async fn init_with_config(actors: TestActors, scylla_configs: Vec<ScyllaNodeConfig>) {
     let vs_ips = get_default_vs_ips(&actors);
     for (name, ip) in VS_NAMES.iter().zip(vs_ips.iter()) {
         actors.dns.upsert(name.to_string(), *ip).await;
     }
 
-    let db_ip = node_configs.first().unwrap().db_ip; // Use the first DB node for vector store connection
+    let db_ip = scylla_configs.first().unwrap().db_ip; // Use the first DB node for vector store connection
 
-    actors.db.start(node_configs, None).await;
+    actors.db.start(scylla_configs, None).await;
     assert!(actors.db.wait_for_ready().await);
     actors
         .vs

--- a/crates/validator-tests/src/lib.rs
+++ b/crates/validator-tests/src/lib.rs
@@ -32,6 +32,7 @@ use tracing::error_span;
 use tracing::info;
 pub use vector_store_cluster::VectorStoreCluster;
 pub use vector_store_cluster::VectorStoreClusterExt;
+pub use vector_store_cluster::VectorStoreNodeConfig;
 
 /// Represents a subnet for services, derived from a base IP address.
 pub struct ServicesSubnet([u8; 3]);

--- a/crates/validator-tests/src/vector_store_cluster.rs
+++ b/crates/validator-tests/src/vector_store_cluster.rs
@@ -4,20 +4,47 @@
  */
 
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+
+/// Configuration for a single Vector Store node in the test cluster.
+#[derive(Clone)]
+pub struct VectorStoreNodeConfig {
+    /// The IP address of this Vector Store node.
+    pub vs_ip: Ipv4Addr,
+    /// The IP address of the ScyllaDB node to connect to.
+    pub db_ip: Ipv4Addr,
+    /// Additional environment variables to pass to the Vector Store process.
+    pub envs: HashMap<String, String>,
+}
+
+impl VectorStoreNodeConfig {
+    pub fn vs_addr(&self) -> SocketAddr {
+        (self.vs_ip, crate::common::VS_PORT).into()
+    }
+
+    pub fn db_addr(&self) -> SocketAddr {
+        (self.db_ip, crate::common::DB_PORT).into()
+    }
+}
 
 pub enum VectorStoreCluster {
     Version {
         tx: oneshot::Sender<String>,
     },
     Start {
-        vs_addr: SocketAddr,
-        db_addr: SocketAddr,
-        envs: HashMap<String, String>,
+        node_configs: Vec<VectorStoreNodeConfig>,
+    },
+    StartNode {
+        node_config: VectorStoreNodeConfig,
     },
     Stop {
+        tx: oneshot::Sender<()>,
+    },
+    StopNode {
+        vs_ip: Ipv4Addr,
         tx: oneshot::Sender<()>,
     },
     WaitForReady {
@@ -29,19 +56,23 @@ pub trait VectorStoreClusterExt {
     /// Returns the version of the vector-store binary.
     fn version(&self) -> impl Future<Output = String>;
 
-    /// Starts the vector-store server with the given addresses.
-    fn start(
-        &self,
-        vs_addr: SocketAddr,
-        db_addr: SocketAddr,
-        envs: HashMap<String, String>,
-    ) -> impl Future<Output = ()>;
+    /// Starts the vector-store cluster with the given node configurations.
+    fn start(&self, node_configs: Vec<VectorStoreNodeConfig>) -> impl Future<Output = ()>;
 
-    /// Stops the vector-store server.
+    /// Starts a single vector-store instance.
+    fn start_node(&self, node_config: VectorStoreNodeConfig) -> impl Future<Output = ()>;
+
+    /// Stops the vector-store cluster.
     fn stop(&self) -> impl Future<Output = ()>;
 
-    /// Waits for the vector-store server to be ready.
+    /// Stops a single vector-store instance.
+    fn stop_node(&self, vs_ip: Ipv4Addr) -> impl Future<Output = ()>;
+
+    /// Waits for the vector-store cluster to be ready.
     fn wait_for_ready(&self) -> impl Future<Output = bool>;
+
+    /// Restarts a single vector-store instance.
+    fn restart(&self, node_config: &VectorStoreNodeConfig) -> impl Future<Output = ()>;
 }
 
 impl VectorStoreClusterExt for mpsc::Sender<VectorStoreCluster> {
@@ -54,14 +85,16 @@ impl VectorStoreClusterExt for mpsc::Sender<VectorStoreCluster> {
             .expect("VectorStoreClusterExt::version: internal actor should send response")
     }
 
-    async fn start(&self, vs_addr: SocketAddr, db_addr: SocketAddr, envs: HashMap<String, String>) {
-        self.send(VectorStoreCluster::Start {
-            vs_addr,
-            db_addr,
-            envs,
-        })
-        .await
-        .expect("VectorStoreClusterExt::start: internal actor should receive request");
+    async fn start(&self, node_configs: Vec<VectorStoreNodeConfig>) {
+        self.send(VectorStoreCluster::Start { node_configs })
+            .await
+            .expect("VectorStoreClusterExt::start: internal actor should receive request");
+    }
+
+    async fn start_node(&self, node_config: VectorStoreNodeConfig) {
+        self.send(VectorStoreCluster::StartNode { node_config })
+            .await
+            .expect("VectorStoreClusterExt::start_node: internal actor should receive request");
     }
 
     async fn stop(&self) {
@@ -73,6 +106,15 @@ impl VectorStoreClusterExt for mpsc::Sender<VectorStoreCluster> {
             .expect("VectorStoreClusterExt::stop: internal actor should send response");
     }
 
+    async fn stop_node(&self, vs_ip: Ipv4Addr) {
+        let (tx, rx) = oneshot::channel();
+        self.send(VectorStoreCluster::StopNode { vs_ip, tx })
+            .await
+            .expect("VectorStoreClusterExt::stop_node: internal actor should receive request");
+        rx.await
+            .expect("VectorStoreClusterExt::stop_node: internal actor should send response");
+    }
+
     async fn wait_for_ready(&self) -> bool {
         let (tx, rx) = oneshot::channel();
         self.send(VectorStoreCluster::WaitForReady { tx })
@@ -80,5 +122,11 @@ impl VectorStoreClusterExt for mpsc::Sender<VectorStoreCluster> {
             .expect("VectorStoreClusterExt::wait_for_ready: internal actor should receive request");
         rx.await
             .expect("VectorStoreClusterExt::wait_for_ready: internal actor should send response")
+    }
+
+    async fn restart(&self, node_config: &VectorStoreNodeConfig) {
+        self.stop_node(node_config.vs_ip).await;
+        self.start_node(node_config.clone()).await;
+        assert!(self.wait_for_ready().await);
     }
 }

--- a/crates/validator-vector-store/Cargo.toml
+++ b/crates/validator-vector-store/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-httpclient.workspace = true
 scylla.workspace = true
 sysinfo.workspace = true
 tokio.workspace = true

--- a/crates/validator-vector-store/src/high_availability.rs
+++ b/crates/validator-vector-store/src/high_availability.rs
@@ -23,7 +23,7 @@ async fn test_secondary_uri_works_correctly(actors: TestActors) {
     let vs_urls = get_default_vs_urls(&actors).await;
     let vs_url = &vs_urls[0];
 
-    let node_configs: Vec<ScyllaNodeConfig> = vec![
+    let scylla_configs: Vec<ScyllaNodeConfig> = vec![
         ScyllaNodeConfig {
             db_ip: actors.services_subnet.ip(DB_OCTET_1),
             primary_vs_uris: vec![vs_url.clone()],
@@ -40,9 +40,15 @@ async fn test_secondary_uri_works_correctly(actors: TestActors) {
             secondary_vs_uris: vec![vs_url.clone()],
         },
     ];
-    init_with_config(actors.clone(), node_configs).await;
+    let vs_configs = vec![VectorStoreNodeConfig {
+        vs_ip: actors.services_subnet.ip(VS_OCTET_1),
+        db_ip: actors.services_subnet.ip(DB_OCTET_1),
+        envs: Default::default(),
+    }];
+    init_with_config(actors.clone(), scylla_configs, vs_configs).await;
 
-    let (session, client) = prepare_connection(&actors).await;
+    let vs_ips = vec![actors.services_subnet.ip(VS_OCTET_1)];
+    let (session, clients) = prepare_connection_with_custom_vs_ips(&actors, vs_ips).await;
 
     let keyspace = create_keyspace(&session).await;
     let table = create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
@@ -59,14 +65,15 @@ async fn test_secondary_uri_works_correctly(actors: TestActors) {
             .expect("failed to insert data");
     }
 
-    let index = create_index(&session, &client, &table, "v").await;
+    let index = create_index(&session, &clients, &table, "v").await;
 
-    let index_status = wait_for_index(&client, &index).await;
-
-    assert_eq!(
-        index_status.count, 100,
-        "Expected 100 vectors to be indexed"
-    );
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(
+            index_status.count, 100,
+            "Expected 100 vectors to be indexed"
+        );
+    }
 
     // Down the first node with primary URI
     let first_node_ip = actors.services_subnet.ip(DB_OCTET_1);

--- a/crates/validator-vector-store/src/high_availability.rs
+++ b/crates/validator-vector-store/src/high_availability.rs
@@ -20,7 +20,9 @@ pub(crate) async fn new() -> TestCase {
 async fn test_secondary_uri_works_correctly(actors: TestActors) {
     info!("started");
 
-    let vs_url = get_default_vs_url(&actors).await;
+    let vs_urls = get_default_vs_urls(&actors).await;
+    let vs_url = &vs_urls[0];
+
     let node_configs: Vec<ScyllaNodeConfig> = vec![
         ScyllaNodeConfig {
             db_ip: actors.services_subnet.ip(DB_OCTET_1),

--- a/crates/validator-vector-store/src/memory_limit.rs
+++ b/crates/validator-vector-store/src/memory_limit.rs
@@ -35,8 +35,11 @@ async fn memory_limit_during_index_build(actors: TestActors) {
     info!("started");
 
     // Start DB
-    let vs_ip = actors.services_subnet.ip(common::VS_OCTET);
-    actors.dns.upsert(common::VS_NAME.to_string(), vs_ip).await;
+    let vs_ip = actors.services_subnet.ip(common::VS_OCTET_1);
+    actors
+        .dns
+        .upsert(common::VS_NAMES[0].to_string(), vs_ip)
+        .await;
     let node_configs = common::get_default_scylla_node_configs(&actors).await;
     let db_ip = node_configs.first().unwrap().db_ip;
     actors.db.start(node_configs.clone(), None).await;
@@ -104,8 +107,13 @@ async fn memory_limit_during_index_build(actors: TestActors) {
     assert!(actors.vs.wait_for_ready().await);
 
     // Create index
-    let client =
-        HttpClient::new((actors.services_subnet.ip(common::VS_OCTET), common::VS_PORT).into());
+    let client = HttpClient::new(
+        (
+            actors.services_subnet.ip(common::VS_OCTET_1),
+            common::VS_PORT,
+        )
+            .into(),
+    );
 
     let index = common::create_index(&session, &client, &table, "v").await;
 

--- a/crates/validator-vector-store/src/memory_limit.rs
+++ b/crates/validator-vector-store/src/memory_limit.rs
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use httpclient::HttpClient;
-use scylla::client::session_builder::SessionBuilder;
-use std::sync::Arc;
 use sysinfo::System;
 use tracing::info;
 use vector_search_validator_tests::common::IndexStatus;
@@ -14,6 +11,7 @@ use vector_search_validator_tests::*;
 pub(crate) async fn new() -> TestCase {
     let timeout = common::DEFAULT_TEST_TIMEOUT;
     TestCase::empty()
+        .with_init(timeout, common::init)
         .with_cleanup(timeout, common::cleanup)
         .with_test(
             "memory_limit_during_index_build",
@@ -33,26 +31,11 @@ pub(crate) async fn new() -> TestCase {
 /// - drop the keyspace
 async fn memory_limit_during_index_build(actors: TestActors) {
     info!("started");
+    actors.vs.stop().await;
 
-    // Start DB
     let vs_ip = actors.services_subnet.ip(common::VS_OCTET_1);
-    actors
-        .dns
-        .upsert(common::VS_NAMES[0].to_string(), vs_ip)
-        .await;
-    let node_configs = common::get_default_scylla_node_configs(&actors).await;
-    let db_ip = node_configs.first().unwrap().db_ip;
-    actors.db.start(node_configs.clone(), None).await;
-    assert!(actors.db.wait_for_ready().await);
-
-    // Create table
-    let session = Arc::new(
-        SessionBuilder::new()
-            .known_node(db_ip.to_string())
-            .build()
-            .await
-            .expect("failed to create session"),
-    );
+    let (session, clients) =
+        common::prepare_connection_with_custom_vs_ips(&actors, vec![vs_ip]).await;
 
     let keyspace = common::create_keyspace(&session).await;
     let table =
@@ -70,8 +53,9 @@ async fn memory_limit_during_index_build(actors: TestActors) {
             .expect("failed to insert data");
     }
 
-    // Start VS with memory limit
-    let system_info = System::new_all();
+    // Set memory limit for Vector Store
+    let mut system_info = System::new_all();
+    system_info.refresh_memory();
     let used_memory = if let Some(cgroup) = system_info.cgroup_limits() {
         cgroup.rss
     } else {
@@ -84,40 +68,28 @@ async fn memory_limit_during_index_build(actors: TestActors) {
         "Setting VS memory limit to {LIMIT_MEMORY} bytes, current used memory is {used_memory} bytes, "
     );
 
-    actors
-        .vs
-        .start(
-            (vs_ip, common::VS_PORT).into(),
-            (db_ip, common::DB_PORT).into(),
-            [
-                (
-                    "VECTOR_STORE_MEMORY_LIMIT".to_string(),
-                    limit_memory.to_string(),
-                ),
-                (
-                    "VECTOR_STORE_MEMORY_USAGE_CHECK_INTERVAL".to_string(),
-                    "10ms".to_string(),
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        )
-        .await;
+    let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
+    let vs_configs = vec![VectorStoreNodeConfig {
+        vs_ip,
+        db_ip,
+        envs: [
+            (
+                "VECTOR_STORE_MEMORY_LIMIT".to_string(),
+                limit_memory.to_string(),
+            ),
+            (
+                "VECTOR_STORE_MEMORY_USAGE_CHECK_INTERVAL".to_string(),
+                "10ms".to_string(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    }];
+    actors.vs.start(vs_configs).await;
 
-    assert!(actors.vs.wait_for_ready().await);
+    let index = common::create_index(&session, &clients, &table, "v").await;
 
-    // Create index
-    let client = HttpClient::new(
-        (
-            actors.services_subnet.ip(common::VS_OCTET_1),
-            common::VS_PORT,
-        )
-            .into(),
-    );
-
-    let index = common::create_index(&session, &client, &table, "v").await;
-
-    let index_status = common::wait_for_index(&client, &index).await;
+    let index_status = common::wait_for_index(clients.first().unwrap(), &index).await;
     assert_eq!(
         index_status.status,
         IndexStatus::Serving,

--- a/crates/validator-vector-store/src/reconnect.rs
+++ b/crates/validator-vector-store/src/reconnect.rs
@@ -30,6 +30,11 @@ pub(crate) async fn new() -> TestCase {
             timeout,
             restarting_all_nodes_doesnt_break_fullscan,
         )
+        .with_test(
+            "restarting_vs_cluster_does_not_break_setup",
+            timeout,
+            test_restarting_vs_cluster_does_not_break_setup,
+        )
 }
 
 async fn reconnect_doesnt_break_fullscan(actors: TestActors) {
@@ -268,5 +273,60 @@ async fn restarting_all_nodes_doesnt_break_fullscan(actors: TestActors) {
         .await
         .expect("failed to drop a keyspace");
 
+    info!("finished");
+}
+
+async fn test_restarting_vs_cluster_does_not_break_setup(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "id INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+
+    let stmt = session
+        .prepare(format!(
+            "INSERT INTO {table} (id, embedding) VALUES (?, [1.0, 2.0, 3.0])"
+        ))
+        .await
+        .expect("failed to prepare a statement");
+
+    for id in 0..1000 {
+        session
+            .execute_unpaged(&stmt, (id,))
+            .await
+            .expect("failed to insert a row");
+    }
+
+    let index = create_index(&session, &clients, &table, "embedding").await;
+
+    actors.vs.stop().await;
+    actors.vs.start(get_default_vs_node_configs(&actors)).await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(
+            index_status.count, 1000,
+            "Expected 1000 vectors to be indexed"
+        );
+    }
+
+    session
+        .query_unpaged(
+            format!("SELECT * FROM {table} ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT 5"),
+            (),
+        )
+        .await
+        .expect("failed to query ANN search");
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
     info!("finished");
 }


### PR DESCRIPTION
Add support for 3 Vector Store nodes for testing of more production alike environments.

Fixes: VECTOR-157