### PR TITLE
Implement eq, eq tuple, IN and IN tuple restriction with filtering api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
@@ -3107,9 +3107,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64",
  "chrono",
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ sysinfo = "0.37.2"
 tap = "1.0.1"
 tempfile = "3.20.0"
 thiserror = "2.0.12"
-time = { version = "0.3.41", features = ["formatting"] }
+time = { version = "0.3.41", features = ["formatting", "parsing"] }
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-stream = { version = "0.1.17", features = ["full"] }
 toml = "0.9.8"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -244,6 +244,10 @@
   },
   "components": {
     "schemas": {
+      "ColumnName": {
+        "type": "string",
+        "description": "Name of the column in a db table."
+      },
       "DataType": {
         "type": "string",
         "description": "Data type and precision used for storing and processing vectors in the index.",
@@ -360,12 +364,42 @@
           "The node has completed the initial database scan and built the indexes defined at that time. It is now monitoring the database for changes."
         ]
       },
+      "PostIndexAnnFilter": {
+        "type": "object",
+        "description": "A filter used in ANN search requests.",
+        "required": [
+          "restrictions"
+        ],
+        "properties": {
+          "allow_filtering": {
+            "type": "boolean",
+            "description": "Indicates whether 'ALLOW FILTERING' was specified in the Cql query."
+          },
+          "restrictions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PostIndexAnnRestriction"
+            },
+            "description": "A list of filter restrictions."
+          }
+        }
+      },
       "PostIndexAnnRequest": {
         "type": "object",
         "required": [
           "vector"
         ],
         "properties": {
+          "filter": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PostIndexAnnFilter"
+              }
+            ]
+          },
           "limit": {
             "$ref": "#/components/schemas/Limit"
           },
@@ -399,6 +433,293 @@
             }
           }
         }
+      },
+      "PostIndexAnnRestriction": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "$ref": "#/components/schemas/ColumnName"
+              },
+              "rhs": {},
+              "type": {
+                "type": "string",
+                "enum": [
+                  "=="
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "$ref": "#/components/schemas/ColumnName"
+              },
+              "rhs": {
+                "type": "array",
+                "items": {}
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "IN"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "$ref": "#/components/schemas/ColumnName"
+              },
+              "rhs": {},
+              "type": {
+                "type": "string",
+                "enum": [
+                  "<"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "$ref": "#/components/schemas/ColumnName"
+              },
+              "rhs": {},
+              "type": {
+                "type": "string",
+                "enum": [
+                  "<="
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "$ref": "#/components/schemas/ColumnName"
+              },
+              "rhs": {},
+              "type": {
+                "type": "string",
+                "enum": [
+                  ">"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "$ref": "#/components/schemas/ColumnName"
+              },
+              "rhs": {},
+              "type": {
+                "type": "string",
+                "enum": [
+                  ">="
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ColumnName"
+                }
+              },
+              "rhs": {
+                "type": "array",
+                "items": {}
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "()==()"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ColumnName"
+                }
+              },
+              "rhs": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {}
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "()IN()"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ColumnName"
+                }
+              },
+              "rhs": {
+                "type": "array",
+                "items": {}
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "()<()"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ColumnName"
+                }
+              },
+              "rhs": {
+                "type": "array",
+                "items": {}
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "()<=()"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ColumnName"
+                }
+              },
+              "rhs": {
+                "type": "array",
+                "items": {}
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "()>()"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "lhs",
+              "rhs",
+              "type"
+            ],
+            "properties": {
+              "lhs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ColumnName"
+                }
+              },
+              "rhs": {
+                "type": "array",
+                "items": {}
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "()>=()"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "A filter restriction used in ANN search requests."
       },
       "Vector": {
         "type": "array",

--- a/crates/benchmark/src/main.rs
+++ b/crates/benchmark/src/main.rs
@@ -444,6 +444,7 @@ async fn main() {
                                         &keyspace,
                                         &index,
                                         query.query.clone().into(),
+                                        None,
                                         NonZeroUsize::new(query.neighbors.len()).unwrap().into(),
                                     )
                                     .await

--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -19,6 +19,7 @@ pub use vector_store::httproutes::IndexStatus;
 use vector_store::httproutes::IndexStatusResponse;
 use vector_store::httproutes::InfoResponse;
 use vector_store::httproutes::NodeStatus;
+use vector_store::httproutes::PostIndexAnnFilter;
 use vector_store::httproutes::PostIndexAnnRequest;
 use vector_store::httproutes::PostIndexAnnResponse;
 
@@ -55,10 +56,11 @@ impl HttpClient {
         keyspace_name: &KeyspaceName,
         index_name: &IndexName,
         vector: Vector,
+        filter: Option<PostIndexAnnFilter>,
         limit: Limit,
     ) -> (HashMap<ColumnName, Vec<Value>>, Vec<Distance>) {
         let resp = self
-            .post_ann(keyspace_name, index_name, vector, limit)
+            .post_ann(keyspace_name, index_name, vector, filter, limit)
             .await
             .json::<PostIndexAnnResponse>()
             .await
@@ -71,9 +73,14 @@ impl HttpClient {
         keyspace_name: &KeyspaceName,
         index_name: &IndexName,
         vector: Vector,
+        filter: Option<PostIndexAnnFilter>,
         limit: Limit,
     ) -> reqwest::Response {
-        let request = PostIndexAnnRequest { vector, limit };
+        let request = PostIndexAnnRequest {
+            vector,
+            filter,
+            limit,
+        };
         self.post_ann_data(keyspace_name, index_name, &request)
             .await
     }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -506,7 +506,7 @@ async fn post_index_ann(
                             })
                             .map_ok(|primary_key| primary_key.0[idx_column].clone())
                             .map_ok(try_to_json)
-                            .flatten()
+                            .map(|primary_key| primary_key.flatten())
                             .collect();
                         primary_keys.map(|primary_keys| (column, primary_keys))
                     })

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -5,6 +5,7 @@
 
 use crate::ColumnName;
 use crate::Distance;
+use crate::Filter;
 use crate::IndexId;
 use crate::IndexName;
 use crate::KeyspaceName;
@@ -463,7 +464,9 @@ async fn post_index_ann(
         return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
     }
 
+    let primary_key_columns = db_index.get_primary_key_columns().await;
     let search_result = index.ann(request.vector, request.limit).await;
+
     // Record duration in Prometheus
     timer.observe_duration();
 
@@ -486,7 +489,6 @@ async fn post_index_ann(
                 debug!("post_index_ann: {msg}");
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
             } else {
-                let primary_key_columns = db_index.get_primary_key_columns().await;
                 let primary_keys: anyhow::Result<_> = primary_key_columns
                     .iter()
                     .cloned()

--- a/crates/vector-store/src/index/factory.rs
+++ b/crates/vector-store/src/index/factory.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::Connectivity;
 use crate::Dimensions;
 use crate::ExpansionAdd;
@@ -11,6 +12,7 @@ use crate::IndexId;
 use crate::SpaceType;
 use crate::index::actor::Index;
 use crate::memory::Memory;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
 pub struct IndexConfiguration {
@@ -26,6 +28,7 @@ pub trait IndexFactory {
     fn create_index(
         &self,
         index: IndexConfiguration,
+        primary_key_columns: Arc<Vec<ColumnName>>,
         memory: mpsc::Sender<Memory>,
     ) -> anyhow::Result<mpsc::Sender<Index>>;
     fn index_engine_version(&self) -> String;

--- a/crates/vector-store/src/index/opensearch.rs
+++ b/crates/vector-store/src/index/opensearch.rs
@@ -310,6 +310,7 @@ async fn process(
             limit,
             tx,
         } => ann(id, tx, keys, embedding, dimensions, limit, client).await,
+        Index::FilteredAnn { tx, .. } => filtered_ann(tx).await,
         Index::Count { tx } => count(id, tx, client).await,
     }
 }
@@ -482,6 +483,10 @@ async fn ann(
     tx_ann
         .send(Ok((keys, distances)))
         .unwrap_or_else(|_| trace!("ann: unable to send response"));
+}
+
+async fn filtered_ann(tx_ann: oneshot::Sender<AnnR>) {
+    _ = tx_ann.send(Err(anyhow!("Filtering not supported")));
 }
 
 async fn count(id: Arc<IndexId>, tx: oneshot::Sender<CountR>, client: Arc<OpenSearch>) {

--- a/crates/vector-store/src/index/opensearch.rs
+++ b/crates/vector-store/src/index/opensearch.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::Connectivity;
 use crate::Dimensions;
 use crate::Distance;
@@ -85,6 +86,7 @@ impl IndexFactory for OpenSearchIndexFactory {
     fn create_index(
         &self,
         index: IndexConfiguration,
+        _: Arc<Vec<ColumnName>>,
         _: mpsc::Sender<Memory>,
     ) -> anyhow::Result<mpsc::Sender<Index>> {
         new(

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -575,6 +575,9 @@ fn process<I: UsearchIndex + Send + Sync + 'static>(msg: Index, index: &IndexSta
                 limit,
             );
         }
+        Index::FilteredAnn { tx, .. } => {
+            filtered_ann(tx);
+        }
         Index::Count { tx } => {
             count(Arc::clone(&index.idx), tx);
         }
@@ -712,6 +715,10 @@ fn ann(
                 }),
         )
         .unwrap_or_else(|_| trace!("ann: unable to send response"));
+}
+
+fn filtered_ann(tx_ann: oneshot::Sender<AnnR>) {
+    _ = tx_ann.send(Err(anyhow!("Filtering not supported")));
 }
 
 fn count(idx: Arc<impl UsearchIndex>, tx: oneshot::Sender<CountR>) {

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -432,6 +432,67 @@ impl Default for Limit {
     }
 }
 
+/// A restriction provided in a CQL query for filtering ANN search results.
+#[derive(Debug)]
+pub enum Restriction {
+    Eq {
+        lhs: ColumnName,
+        rhs: CqlValue,
+    },
+    In {
+        lhs: ColumnName,
+        rhs: Vec<CqlValue>,
+    },
+    Lt {
+        lhs: ColumnName,
+        rhs: CqlValue,
+    },
+    Lte {
+        lhs: ColumnName,
+        rhs: CqlValue,
+    },
+    Gt {
+        lhs: ColumnName,
+        rhs: CqlValue,
+    },
+    Gte {
+        lhs: ColumnName,
+        rhs: CqlValue,
+    },
+    EqTuple {
+        lhs: Vec<ColumnName>,
+        rhs: Vec<CqlValue>,
+    },
+    InTuple {
+        lhs: Vec<ColumnName>,
+        rhs: Vec<Vec<CqlValue>>,
+    },
+    LtTuple {
+        lhs: Vec<ColumnName>,
+        rhs: Vec<CqlValue>,
+    },
+    LteTuple {
+        lhs: Vec<ColumnName>,
+        rhs: Vec<CqlValue>,
+    },
+    GtTuple {
+        lhs: Vec<ColumnName>,
+        rhs: Vec<CqlValue>,
+    },
+    GteTuple {
+        lhs: Vec<ColumnName>,
+        rhs: Vec<CqlValue>,
+    },
+}
+
+/// A filter to apply to an ANN search. It contains restrictions from a CQL query and a flag to
+/// indicate whether ALLOW FILTERING was specified in the CQL query.
+#[derive(Debug)]
+pub struct Filter {
+    pub restrictions: Vec<Restriction>,
+    pub allow_filtering: bool,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::From)]
 pub struct IndexVersion(Uuid);
 

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -57,6 +57,7 @@ use utoipa::openapi::schema::Type;
 use uuid::Uuid;
 
 #[derive(Clone, derive_more::From, derive_more::Display)]
+#[from(String, &str)]
 pub struct ScyllaDbUri(String);
 
 #[derive(Clone, Debug)]
@@ -141,6 +142,7 @@ impl SerializeValue for IndexId {
     serde::Serialize,
     utoipa::ToSchema,
 )]
+#[from(String, &str)]
 /// A keyspace name in a db.
 pub struct KeyspaceName(String);
 
@@ -167,6 +169,7 @@ impl SerializeValue for KeyspaceName {
     derive_more::Display,
     utoipa::ToSchema,
 )]
+#[from(String, &str)]
 /// A name of the vector index in a db.
 pub struct IndexName(String);
 
@@ -193,6 +196,7 @@ impl SerializeValue for IndexName {
     derive_more::Display,
     utoipa::ToSchema,
 )]
+#[from(String, &str)]
 /// A table name of the table with vectors in a db
 pub struct TableName(String);
 
@@ -219,6 +223,7 @@ impl SerializeValue for TableName {
     derive_more::Display,
     utoipa::ToSchema,
 )]
+#[from(String, &str)]
 /// Name of the column in a db table.
 pub struct ColumnName(String);
 

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -74,7 +74,7 @@ impl TableStore {
 }
 
 pub(crate) struct Table {
-    pub(crate) primary_keys: Vec<ColumnName>,
+    pub(crate) primary_keys: Arc<Vec<ColumnName>>,
     pub(crate) dimensions: HashMap<ColumnName, Dimensions>,
 }
 

--- a/crates/vector-store/tests/integration/https.rs
+++ b/crates/vector-store/tests/integration/https.rs
@@ -111,6 +111,7 @@ async fn test_https_server_responds() {
         .post(format!("http://{addr}/api/v1/indexes/table/index/ann"))
         .json(&PostIndexAnnRequest {
             vector: vec![1.0].into(),
+            filter: None,
             limit: NonZeroUsize::new(1).unwrap().into(),
         })
         .send()
@@ -122,6 +123,7 @@ async fn test_https_server_responds() {
         .post(format!("https://{addr}/api/v1/indexes/table/index/ann"))
         .json(&PostIndexAnnRequest {
             vector: vec![1.0].into(),
+            filter: None,
             limit: NonZeroUsize::new(1).unwrap().into(),
         })
         .send()

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -45,3 +45,16 @@ where
     .await
     .unwrap_or_else(|_| panic!("Timeout on: {msg}"))
 }
+
+async fn wait_for_value<T>(mut producer: impl AsyncFnMut() -> Option<T>, msg: &str) -> T {
+    time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(value) = producer().await {
+                break value;
+            }
+            task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("Timeout on: {msg}"))
+}

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -8,6 +8,7 @@ use crate::db_basic::Index;
 use crate::db_basic::Table;
 use ::time::OffsetDateTime;
 use httpclient::HttpClient;
+use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
@@ -59,6 +60,7 @@ async fn memory_limit_during_index_build() {
         index.table_name.clone(),
         Table {
             primary_keys: Arc::new(vec!["pk".into()]),
+            columns: Arc::new([("pk".into(), NativeType::Int)].into_iter().collect()),
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -58,7 +58,7 @@ async fn memory_limit_during_index_build() {
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".into()],
+            primary_keys: Arc::new(vec!["pk".into()]),
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -42,10 +42,10 @@ async fn memory_limit_during_index_build() {
     let (db_actor, db) = db_basic::new(node_state.clone());
 
     let index = IndexMetadata {
-        keyspace_name: "ksp".to_string().into(),
-        table_name: "tbl".to_string().into(),
-        index_name: "idx".to_string().into(),
-        target_column: "v".to_string().into(),
+        keyspace_name: "ksp".into(),
+        table_name: "tbl".into(),
+        index_name: "idx".into(),
+        target_column: "v".into(),
         dimensions: NonZeroUsize::new(3).unwrap().into(),
         connectivity: Connectivity::default(),
         expansion_add: ExpansionAdd::default(),
@@ -58,7 +58,7 @@ async fn memory_limit_during_index_build() {
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".to_string().into()],
+            primary_keys: vec!["pk".into()],
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -58,7 +58,7 @@ async fn simple_create_search_delete_index() {
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".into(), "ck".into()],
+            primary_keys: Arc::new(vec!["pk".into(), "ck".into()]),
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -25,10 +25,10 @@ async fn simple_create_search_delete_index() {
     let (db_actor, db) = db_basic::new(node_state.clone());
 
     let index = IndexMetadata {
-        keyspace_name: "vector".to_string().into(),
-        table_name: "items".to_string().into(),
-        index_name: "ann".to_string().into(),
-        target_column: "embedding".to_string().into(),
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: "ann".into(),
+        target_column: "embedding".into(),
         dimensions: NonZeroUsize::new(3).unwrap().into(),
         connectivity: Default::default(),
         expansion_add: Default::default(),
@@ -58,7 +58,7 @@ async fn simple_create_search_delete_index() {
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".to_string().into(), "ck".to_string().into()],
+            primary_keys: vec!["pk".into(), "ck".into()],
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),
@@ -128,8 +128,8 @@ async fn simple_create_search_delete_index() {
         )
         .await;
     assert_eq!(distances.len(), 1);
-    let primary_keys_pk = primary_keys.get(&"pk".to_string().into()).unwrap();
-    let primary_keys_ck = primary_keys.get(&"ck".to_string().into()).unwrap();
+    let primary_keys_pk = primary_keys.get(&"pk".into()).unwrap();
+    let primary_keys_ck = primary_keys.get(&"ck".into()).unwrap();
     assert_eq!(distances.len(), primary_keys_pk.len());
     assert_eq!(distances.len(), primary_keys_ck.len());
     assert_eq!(primary_keys_pk.first().unwrap().as_i64().unwrap(), 2);

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -133,6 +133,7 @@ async fn simple_create_search_delete_index() {
             &index.keyspace_name,
             &index.index_name,
             vec![2.1, -2., 2.].into(),
+            None,
             NonZeroUsize::new(1).unwrap().into(),
         )
         .await;

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -10,6 +10,7 @@ use crate::mock_opensearch;
 use crate::wait_for;
 use ::time::OffsetDateTime;
 use httpclient::HttpClient;
+use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
@@ -59,6 +60,14 @@ async fn simple_create_search_delete_index() {
         index.table_name.clone(),
         Table {
             primary_keys: Arc::new(vec!["pk".into(), "ck".into()]),
+            columns: Arc::new(
+                [
+                    ("pk".into(), NativeType::Int),
+                    ("ck".into(), NativeType::Text),
+                ]
+                .into_iter()
+                .collect(),
+            ),
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),

--- a/crates/vector-store/tests/integration/status.rs
+++ b/crates/vector-store/tests/integration/status.rs
@@ -12,7 +12,7 @@ use vector_store::httproutes::NodeStatus;
 async fn status_is_serving_after_creation() {
     crate::enable_tracing();
     let (_index, client, _db, _server, _node_state) =
-        usearch::setup_store_and_wait_for_index(["pk".into(), "ck".into()]).await;
+        usearch::setup_store_and_wait_for_index(["pk".into(), "ck".into()], []).await;
 
     let result = client.status().await;
     assert_eq!(result.unwrap(), NodeStatus::Serving);
@@ -22,7 +22,7 @@ async fn status_is_serving_after_creation() {
 async fn status_is_bootstrapping_while_discovering_indexes() {
     crate::enable_tracing();
     let (run, _index, db, _node_state) =
-        usearch::setup_store(Config::default(), ["pk".into(), "ck".into()]).await;
+        usearch::setup_store(Config::default(), ["pk".into(), "ck".into()], []).await;
     db.simulate_endless_get_indexes_processing();
     let (client, _server, _config_tx) = run.await;
 

--- a/crates/vector-store/tests/integration/status.rs
+++ b/crates/vector-store/tests/integration/status.rs
@@ -5,14 +5,22 @@
 
 use crate::usearch;
 use crate::wait_for;
+use scylla::cluster::metadata::NativeType;
 use vector_store::Config;
 use vector_store::httproutes::NodeStatus;
 
 #[tokio::test]
 async fn status_is_serving_after_creation() {
     crate::enable_tracing();
-    let (_index, client, _db, _server, _node_state) =
-        usearch::setup_store_and_wait_for_index(["pk".into(), "ck".into()], []).await;
+    let (_index, client, _db, _server, _node_state) = usearch::setup_store_and_wait_for_index(
+        ["pk".into(), "ck".into()],
+        [
+            ("pk".to_string().into(), NativeType::Int),
+            ("ck".to_string().into(), NativeType::Text),
+        ],
+        [],
+    )
+    .await;
 
     let result = client.status().await;
     assert_eq!(result.unwrap(), NodeStatus::Serving);
@@ -21,8 +29,16 @@ async fn status_is_serving_after_creation() {
 #[tokio::test]
 async fn status_is_bootstrapping_while_discovering_indexes() {
     crate::enable_tracing();
-    let (run, _index, db, _node_state) =
-        usearch::setup_store(Config::default(), ["pk".into(), "ck".into()], []).await;
+    let (run, _index, db, _node_state) = usearch::setup_store(
+        Config::default(),
+        ["pk".into(), "ck".into()],
+        [
+            ("pk".to_string().into(), NativeType::Int),
+            ("ck".to_string().into(), NativeType::Text),
+        ],
+        [],
+    )
+    .await;
     db.simulate_endless_get_indexes_processing();
     let (client, _server, _config_tx) = run.await;
 

--- a/crates/vector-store/tests/integration/status.rs
+++ b/crates/vector-store/tests/integration/status.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::usearch::{setup_store, setup_store_and_wait_for_index};
+use crate::usearch;
 use crate::wait_for;
 use vector_store::Config;
 use vector_store::httproutes::NodeStatus;
@@ -11,7 +11,8 @@ use vector_store::httproutes::NodeStatus;
 #[tokio::test]
 async fn status_is_serving_after_creation() {
     crate::enable_tracing();
-    let (_index, client, _db, _server, _node_state) = setup_store_and_wait_for_index().await;
+    let (_index, client, _db, _server, _node_state) =
+        usearch::setup_store_and_wait_for_index(["pk".into(), "ck".into()]).await;
 
     let result = client.status().await;
     assert_eq!(result.unwrap(), NodeStatus::Serving);
@@ -20,7 +21,8 @@ async fn status_is_serving_after_creation() {
 #[tokio::test]
 async fn status_is_bootstrapping_while_discovering_indexes() {
     crate::enable_tracing();
-    let (run, _index, db, _node_state) = setup_store(Config::default()).await;
+    let (run, _index, db, _node_state) =
+        usearch::setup_store(Config::default(), ["pk".into(), "ck".into()]).await;
     db.simulate_endless_get_indexes_processing();
     let (client, _server, _config_tx) = run.await;
 

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -42,10 +42,10 @@ pub(crate) async fn setup_store(
     let (db_actor, db) = db_basic::new(node_state.clone());
 
     let index = IndexMetadata {
-        keyspace_name: "vector".to_string().into(),
-        table_name: "items".to_string().into(),
-        index_name: "ann".to_string().into(),
-        target_column: "embedding".to_string().into(),
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: "ann".into(),
+        target_column: "embedding".into(),
         dimensions: NonZeroUsize::new(3).unwrap().into(),
         connectivity: Connectivity::default(),
         expansion_add: ExpansionAdd::default(),
@@ -58,7 +58,7 @@ pub(crate) async fn setup_store(
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".to_string().into(), "ck".to_string().into()],
+            primary_keys: vec!["pk".into(), "ck".into()],
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),
@@ -180,8 +180,8 @@ async fn simple_create_search_delete_index() {
         )
         .await;
     assert_eq!(distances.len(), 1);
-    let primary_keys_pk = primary_keys.get(&"pk".to_string().into()).unwrap();
-    let primary_keys_ck = primary_keys.get(&"ck".to_string().into()).unwrap();
+    let primary_keys_pk = primary_keys.get(&"pk".into()).unwrap();
+    let primary_keys_ck = primary_keys.get(&"ck".into()).unwrap();
     assert_eq!(distances.len(), primary_keys_pk.len());
     assert_eq!(distances.len(), primary_keys_ck.len());
     assert_eq!(primary_keys_pk.first().unwrap().as_i64().unwrap(), 2);
@@ -205,10 +205,10 @@ async fn failed_db_index_create() {
     let (db_actor, db) = db_basic::new(node_state.clone());
 
     let index = IndexMetadata {
-        keyspace_name: "vector".to_string().into(),
-        table_name: "items".to_string().into(),
-        index_name: "ann".to_string().into(),
-        target_column: "embedding".to_string().into(),
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: "ann".into(),
+        target_column: "embedding".into(),
         dimensions: NonZeroUsize::new(3).unwrap().into(),
         connectivity: Default::default(),
         expansion_add: Default::default(),
@@ -238,7 +238,7 @@ async fn failed_db_index_create() {
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".to_string().into(), "ck".to_string().into()],
+            primary_keys: vec!["pk".into(), "ck".into()],
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),
@@ -267,7 +267,7 @@ async fn failed_db_index_create() {
 
     db.add_index(
         &index.keyspace_name,
-        "ann2".to_string().into(),
+        "ann2".into(),
         Index {
             table_name: index.table_name.clone(),
             target_column: index.target_column.clone(),
@@ -292,7 +292,7 @@ async fn failed_db_index_create() {
 
     db.add_index(
         &index.keyspace_name,
-        "ann3".to_string().into(),
+        "ann3".into(),
         Index {
             table_name: index.table_name.clone(),
             target_column: index.target_column.clone(),
@@ -316,8 +316,7 @@ async fn failed_db_index_create() {
     assert!(indexes.contains(&vector_store::IndexInfo::new("vector", "ann2")));
     assert!(indexes.contains(&vector_store::IndexInfo::new("vector", "ann3")));
 
-    db.del_index(&index.keyspace_name, &"ann2".to_string().into())
-        .unwrap();
+    db.del_index(&index.keyspace_name, &"ann2".into()).unwrap();
 
     wait_for(
         || async { client.indexes().await.len() == 2 },

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -58,7 +58,7 @@ pub(crate) async fn setup_store(
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".into(), "ck".into()],
+            primary_keys: Arc::new(vec!["pk".into(), "ck".into()]),
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),
@@ -238,7 +238,7 @@ async fn failed_db_index_create() {
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: vec!["pk".into(), "ck".into()],
+            primary_keys: Arc::new(vec!["pk".into(), "ck".into()]),
             dimensions: [(index.target_column.clone(), index.dimensions)]
                 .into_iter()
                 .collect(),

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -202,6 +202,7 @@ async fn simple_create_search_delete_index() {
             &index.keyspace_name,
             &index.index_name,
             vec![2.1, -2., 2.].into(),
+            None,
             NonZeroUsize::new(1).unwrap().into(),
         )
         .await;
@@ -382,6 +383,7 @@ async fn ann_returns_bad_request_when_provided_vector_size_is_not_eq_index_dimen
             &index.keyspace_name,
             &index.index_name,
             vec![1.0, 2.0].into(), // Only 2 dimensions, should be 3 (index.dimensions)
+            None,
             NonZeroUsize::new(1).unwrap().into(),
         )
         .await;
@@ -415,6 +417,7 @@ async fn ann_fail_while_building() {
             &index.keyspace_name,
             &index.index_name,
             vec![1.0, 2.0, 3.0].into(),
+            None,
             NonZeroUsize::new(1).unwrap().into(),
         )
         .await;
@@ -476,6 +479,7 @@ async fn ann_failed_when_wrong_number_of_primary_keys() {
             &index.keyspace_name,
             &index.index_name,
             vec![1.0, 2.0, 3.0].into(),
+            None,
             NonZeroUsize::new(1).unwrap().into(),
         )
         .await;


### PR DESCRIPTION
This is the proposition of the vector-store api for filtering and it implements eq, eq tuple, IN and IN tuple restrictions. The new api is an optional filter parameter for ANN json object, which provide a list of restrictions. Sample json object from tests:

```
{                                                               
 "restrictions": [                                              
     { "type": "==", "lhs": "pk", "rhs": 1 },                   
     { "type": "IN", "lhs": "pk", "rhs": [2, 3] },              
     { "type": "<", "lhs": "ck", "rhs": 4 },                    
     { "type": "<=", "lhs": "ck", "rhs": 5 },                   
     { "type": ">", "lhs": "pk", "rhs": 6 },                    
     { "type": ">=", "lhs": "pk", "rhs": 7 },                   
     { "type": "()==()", "lhs": ["pk", "ck"], "rhs": [10, 20] },
     { "type": "()IN()", "lhs": ["pk", "ck"], "rhs": [[100, 200], [300, 400]] },
     { "type": "()<()", "lhs": ["pk", "ck"], "rhs": [30, 40] }, 
     { "type": "()<=()", "lhs": ["pk", "ck"], "rhs": [50, 60] },
     { "type": "()>()", "lhs": ["pk", "ck"], "rhs": [70, 80] }, 
     { "type": "()>=()", "lhs": ["pk", "ck"], "rhs": [90, 0] }  
 ],                                                             
 "allow_filtering": true                                        
}
```

The change adds HTTP json structures for a filter and a restriction and also internal type Filter and Restriction. It adds support for usearch filter search using that filter - it filter using global index. In the future we will consider using separate indexes for each partition key.

The change adds some refactoring of tests and types needed for this change. It also contains a fix of ann request conversion bug for primary key columns and a fix for db_basic mock.

 Fixes VECTOR-409