### PR TITLE
vector-store: make index updates faster with additional CDC listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ service supports also `.env` files.
 | `VECTOR_STORE_CQL_KEEPALIVE_TIMEOUT`       | CQL Driver's keepalive timeout. The value is in human readable value (ie. `30s`)                                         | (driver default)  |
 | `VECTOR_STORE_CQL_TCP_KEEPALIVE_INTERVAL`  | CQL Driver's TCP keepalive interval. The value is in human readable value (ie. `20s`)                                    | (driver default)  |
 | `VECTOR_STORE_CQL_URI_TRANSLATION_MAP`     | For testing. Use specific translation map for cql cluster addresses. (`{"ip_src:port": "ip_dst:port"}`).                 |                   | 
-| `VECTOR_STORE_CDC_SAFETY_INTERVAL`         | CDC Driver's safety interval. The value is in human readable value (ie. `30s`)                                           | (driver default)  |
-| `VECTOR_STORE_CDC_SLEEP_INTERVAL`          | CDC Driver's sleep interval. The value is in human readable value (ie. `10s`)                                            | (driver default)  |
+| `VECTOR_STORE_CDC_SAFETY_INTERVAL`         | Wide-framed CDC reader's safety interval. The value is in human readable value (ie. `30s`)                               | `30s`             |
+| `VECTOR_STORE_CDC_SLEEP_INTERVAL`          | Wide-framed CDC reader's sleep interval. The value is in human readable value (ie. `10s`)                                | `10s`             |
+| `VECTOR_STORE_CDC_FINE_SAFETY_INTERVAL`    | Fine-grained CDC reader's safety interval for low-latency updates (ie. `100ms`)                                          | `100ms`           |
+| `VECTOR_STORE_CDC_FINE_SLEEP_INTERVAL`     | Fine-grained CDC reader's sleep interval for low-latency updates (ie. `500ms`)                                           | `500ms`           |
 | `VECTOR_STORE_USEARCH_SIMULATOR`           | Enable simulator for USearch. Provides human readable delays for simulated operations (`search:add-remove:reserve`).     |                   | 
 
 ## Development builds

--- a/crates/validator-engine/src/vector_store_cluster.rs
+++ b/crates/validator-engine/src/vector_store_cluster.rs
@@ -159,7 +159,9 @@ async fn run_node(node_config: &VectorStoreNodeConfig, state: &State, workdir: &
         .env("VECTOR_STORE_CQL_KEEPALIVE_TIMEOUT", "10s")
         .env("VECTOR_STORE_CQL_TCP_KEEPALIVE_INTERVAL", "1s")
         .env("VECTOR_STORE_CDC_SAFETY_INTERVAL", "3s")
-        .env("VECTOR_STORE_CDC_SLEEP_INTERVAL", "1s");
+        .env("VECTOR_STORE_CDC_SLEEP_INTERVAL", "1s")
+        .env("VECTOR_STORE_CDC_FINE_SAFETY_INTERVAL", "100ms")
+        .env("VECTOR_STORE_CDC_FINE_SLEEP_INTERVAL", "500ms");
 
     if let Some(u) = node_config.user.as_deref()
         && let Some(p) = node_config.password.as_deref()

--- a/crates/validator-vector-store/src/cdc.rs
+++ b/crates/validator-vector-store/src/cdc.rs
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use async_backtrace::framed;
+use std::time::Duration;
+use tracing::info;
+use vector_search_validator_tests::common::*;
+use vector_search_validator_tests::*;
+
+const FINE_GRAINED_CDC_MAX_LATENCY: Duration = Duration::from_secs(2);
+
+#[framed]
+pub(crate) async fn new() -> TestCase {
+    let timeout = DEFAULT_TEST_TIMEOUT;
+    TestCase::empty()
+        .with_init(timeout, init)
+        .with_cleanup(timeout, cleanup)
+        .with_test(
+            "cdc_insert_visible_immediately",
+            timeout,
+            cdc_insert_visible_immediately,
+        )
+        .with_test(
+            "cdc_update_visible_immediately",
+            timeout,
+            cdc_update_visible_immediately,
+        )
+        .with_test(
+            "cdc_delete_visible_immediately",
+            timeout,
+            cdc_delete_visible_immediately,
+        )
+}
+
+#[framed]
+async fn cdc_insert_visible_immediately(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs(&actors).await;
+    let client = clients.first().unwrap();
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    let status = wait_for_index(client, &index).await;
+    assert_eq!(status.count, 0, "Index should start empty");
+
+    // Insert after index creation - this should be picked up by the fine-grained CDC reader
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, v) VALUES (1, [1.0, 2.0, 3.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert data");
+
+    // Should timeout only when using wide-framed CDC reader
+    wait_for(
+        || async {
+            let status = client.index_status(&index.keyspace, &index.index).await;
+            matches!(status, Ok(s) if s.count == 1)
+        },
+        "Waiting for CDC insert",
+        FINE_GRAINED_CDC_MAX_LATENCY,
+    )
+    .await;
+
+    // Verify ANN query returns the inserted row
+    let result = get_query_results(
+        format!("SELECT pk FROM {table} ORDER BY v ANN OF [1.0, 2.0, 3.0] LIMIT 1"),
+        &session,
+    )
+    .await;
+    assert_eq!(result.rows_num(), 1, "Expected 1 row from ANN query");
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+#[framed]
+async fn cdc_update_visible_immediately(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs(&actors).await;
+    let client = clients.first().unwrap();
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, v) VALUES (1, [0.0, 0.0, 0.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert data");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, v) VALUES (2, [5.0, 5.0, 5.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert data");
+
+    let index = create_index(
+        CreateIndexQuery::new(&session, &clients, &table, "v")
+            .options([("similarity_function", "euclidean")]),
+    )
+    .await;
+
+    let status = wait_for_index(client, &index).await;
+    assert_eq!(
+        status.count, 2,
+        "Index should have 2 vectors after full scan"
+    );
+
+    // Verify ANN query for [10,10,10] returns pk=2 (closer than pk=1)
+    let result = get_query_results(
+        format!("SELECT pk FROM {table} ORDER BY v ANN OF [10.0, 10.0, 10.0] LIMIT 1"),
+        &session,
+    )
+    .await;
+    let rows: Vec<(i32,)> = result
+        .rows::<(i32,)>()
+        .expect("failed to get rows")
+        .map(|r| r.expect("failed to get row"))
+        .collect();
+    assert_eq!(rows.len(), 1, "Expected 1 row");
+    assert_eq!(
+        rows[0].0, 2,
+        "Before update: pk=2 should be closest to [10,10,10]"
+    );
+
+    // Update pk=1 vector to [10,10,10] (closer than pk=2) - fine-grained CDC reader should pick this up
+    session
+        .query_unpaged(
+            format!("UPDATE {table} SET v = [10.0, 10.0, 10.0] WHERE pk = 1"),
+            (),
+        )
+        .await
+        .expect("failed to update data");
+
+    // Should timeout only when using wide-framed CDC reader
+    wait_for(
+        || async {
+            let result = get_opt_query_results(
+                format!("SELECT pk FROM {table} ORDER BY v ANN OF [10.0, 10.0, 10.0] LIMIT 1"),
+                &session,
+            )
+            .await;
+            result.is_some_and(|result| {
+                let rows: Vec<(i32,)> = result
+                    .rows::<(i32,)>()
+                    .expect("failed to get rows")
+                    .map(|r| r.expect("failed to get row"))
+                    .collect();
+                rows.len() == 1 && rows[0].0 == 1
+            })
+        },
+        "Waiting for CDC update",
+        FINE_GRAINED_CDC_MAX_LATENCY,
+    )
+    .await;
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+#[framed]
+async fn cdc_delete_visible_immediately(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs(&actors).await;
+    let client = clients.first().unwrap();
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+
+    for pk in 1..=3 {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, v) VALUES ({pk}, [1.0, 1.0, 1.0])"),
+                (),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    let status = wait_for_index(client, &index).await;
+    assert_eq!(status.count, 3, "Index should have 3 vectors");
+
+    // Delete one row - fine-grained CDC reader should pick this up
+    session
+        .query_unpaged(format!("DELETE FROM {table} WHERE pk = 2"), ())
+        .await
+        .expect("failed to delete data");
+
+    // Check that count decreases to 2 within fine-grained CDC latency
+    wait_for(
+        || async {
+            let status = client.index_status(&index.keyspace, &index.index).await;
+            matches!(status, Ok(s) if s.count == 2)
+        },
+        "Waiting for CDC delete",
+        FINE_GRAINED_CDC_MAX_LATENCY,
+    )
+    .await;
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}

--- a/crates/validator-vector-store/src/lib.rs
+++ b/crates/validator-vector-store/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod ann;
 mod auth;
+mod cdc;
 mod crud;
 mod db_timeout;
 mod full_scan;
@@ -24,6 +25,7 @@ pub async fn test_cases() -> impl Iterator<Item = (String, TestCase)> {
     vec![
         ("ann", ann::new().await),
         ("auth", auth::new().await),
+        ("cdc", cdc::new().await),
         ("crud", crud::new().await),
         ("db_timeout", db_timeout::new().await),
         ("full_scan", full_scan::new().await),

--- a/crates/vector-store/src/config_manager.rs
+++ b/crates/vector-store/src/config_manager.rs
@@ -330,6 +330,18 @@ where
         .transpose()?
         .map(|v| v.into());
 
+    config.cdc_fine_safety_interval = env("VECTOR_STORE_CDC_FINE_SAFETY_INTERVAL")
+        .ok()
+        .map(|v| v.parse::<humantime::Duration>())
+        .transpose()?
+        .map(|v| v.into());
+
+    config.cdc_fine_sleep_interval = env("VECTOR_STORE_CDC_FINE_SLEEP_INTERVAL")
+        .ok()
+        .map(|v| v.parse::<humantime::Duration>())
+        .transpose()?
+        .map(|v| v.into());
+
     config.cql_uri_translation_map = env("VECTOR_STORE_CQL_URI_TRANSLATION_MAP")
         .ok()
         .map(|v| serde_json::from_str(&v))
@@ -527,6 +539,8 @@ mod tests {
             cql_uri_translation_map: None,
             cdc_safety_interval: None,
             cdc_sleep_interval: None,
+            cdc_fine_safety_interval: None,
+            cdc_fine_sleep_interval: None,
         };
 
         let (config_manager, mut config_rx) = ConfigManager::new(initial_config);

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::AsyncInProgress;
+use crate::ColumnName;
+use crate::Config;
+use crate::DbEmbedding;
+use crate::IndexMetadata;
+use crate::internals::Internals;
+use crate::internals::InternalsExt;
+use ::time::Date;
+use ::time::Month;
+use ::time::OffsetDateTime;
+use ::time::PrimitiveDateTime;
+use ::time::Time;
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::bail;
+use async_trait::async_trait;
+use scylla::client::session::Session;
+use scylla::value::CqlValue;
+use scylla_cdc::consumer::CDCRow;
+use scylla_cdc::consumer::Consumer;
+use scylla_cdc::consumer::ConsumerFactory;
+use scylla_cdc::log_reader::CDCLogReaderBuilder;
+use std::pin::pin;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::SystemTime;
+use tap::Pipe;
+use tokio::sync::Notify;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
+use tokio::time;
+use tracing::Instrument;
+use tracing::debug;
+use tracing::error;
+use tracing::error_span;
+use tracing::info;
+use tracing::warn;
+
+const CHECKPOINT_TIMESTAMP_OFFSET: Duration = Duration::from_mins(10);
+
+pub(crate) enum DbCdc {}
+
+/// Spawns a CDC actor that watches for session changes and manages a CDC reader.
+pub(crate) fn new(
+    config_rx: watch::Receiver<Arc<Config>>,
+    mut session_rx: watch::Receiver<Option<Arc<Session>>>,
+    metadata: IndexMetadata,
+    internals: Sender<Internals>,
+    tx_embeddings: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+) -> mpsc::Sender<DbCdc> {
+    // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
+    let (tx, mut rx) = mpsc::channel::<DbCdc>(10);
+
+    // Mark the receiver to ensure first session update is visible
+    session_rx.mark_changed();
+
+    let mut reader = CdcReaderState::new();
+    let actor_key = metadata.key();
+    tokio::spawn(
+        async move {
+            debug!("starting");
+
+            loop {
+                tokio::select! {
+                    // Shut down when all senders are dropped
+                    _ = rx.recv() => { break; }
+
+                    // Wait for session changes
+                    result = session_rx.changed() => {
+                        if result.is_err() {
+                            break;
+                        }
+
+                        let session_opt = session_rx.borrow_and_update().clone();
+                        reader.handle_session_change(
+                            session_opt, &config_rx, &metadata,
+                            &tx_embeddings, &internals,
+                        ).await;
+                    }
+
+                    _ = reader.error_notify.notified() => {
+                        break;
+                    }
+                }
+            }
+
+            // Cleanup
+            reader.stop().await;
+
+            debug!("finished");
+        }
+        .instrument(error_span!("db_cdc", "{}", actor_key)),
+    );
+
+    tx
+}
+
+/// State for managing a CDC reader's lifecycle.
+struct CdcReaderState {
+    reader: Option<scylla_cdc::log_reader::CDCLogReader>,
+    handler_task: Option<tokio::task::JoinHandle<Duration>>,
+    shutdown_notify: Arc<Notify>,
+    error_notify: Arc<Notify>,
+    start: Duration,
+}
+
+impl CdcReaderState {
+    fn new() -> Self {
+        Self {
+            reader: None,
+            handler_task: None,
+            shutdown_notify: Arc::new(Notify::new()),
+            error_notify: Arc::new(Notify::new()),
+            start: cdc_now(),
+        }
+    }
+
+    /// Stops the current CDC reader and handler task, preserving the last checkpoint.
+    async fn stop(&mut self) {
+        if let Some(mut reader) = self.reader.take() {
+            reader.stop();
+        }
+        if let Some(task) = self.handler_task.take() {
+            self.shutdown_notify.notify_one();
+            self.start = task.await.unwrap_or(cdc_now());
+        }
+    }
+
+    /// Stops the current reader, drains stale notifications, and starts a new reader with the given parameters.
+    async fn restart(
+        &mut self,
+        config: &Arc<Config>,
+        session: &Arc<Session>,
+        metadata: &IndexMetadata,
+        tx_embeddings: &mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+        internals: &Sender<Internals>,
+    ) {
+        self.stop().await;
+        drain_pending_notifications(&self.shutdown_notify).await;
+
+        match create_cdc_reader(
+            self.start,
+            Arc::clone(config),
+            Arc::clone(session),
+            metadata.clone(),
+            tx_embeddings.clone(),
+        )
+        .await
+        {
+            Ok((reader, handler)) => {
+                self.reader = Some(reader);
+                self.handler_task = Some(spawn_handler_task(
+                    handler,
+                    Arc::clone(&self.shutdown_notify),
+                    Arc::clone(&self.error_notify),
+                    internals.clone(),
+                    metadata,
+                ));
+
+                info!(
+                    "CDC reader created successfully for {} (safety: {:?}, sleep: {:?})",
+                    metadata.key(),
+                    config.cdc_safety_interval,
+                    config.cdc_sleep_interval
+                );
+            }
+            Err(e) => {
+                error!("Failed to create CDC reader: {e}");
+            }
+        }
+    }
+
+    /// Handles a session change by restarting or stopping the CDC reader.
+    async fn handle_session_change(
+        &mut self,
+        session: Option<Arc<Session>>,
+        config_rx: &watch::Receiver<Arc<Config>>,
+        metadata: &IndexMetadata,
+        tx_embeddings: &mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+        internals: &Sender<Internals>,
+    ) {
+        match session {
+            Some(session) => {
+                info!(
+                    "Session available, creating CDC reader for {}",
+                    metadata.key()
+                );
+
+                let config = config_rx.borrow().clone();
+
+                self.restart(&config, &session, metadata, tx_embeddings, internals)
+                    .await;
+            }
+            None => {
+                info!(
+                    "Session became None, stopping CDC reader for {}",
+                    metadata.key()
+                );
+
+                self.stop().await;
+            }
+        }
+    }
+}
+
+fn cdc_now() -> Duration {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+}
+
+/// Drains any pending shutdown notifications to avoid stale wakeups.
+async fn drain_pending_notifications(notify: &Notify) {
+    if pin!(notify.notified()).enable() {
+        while pin!(notify.notified()).enable() {
+            error!("Internal error: unable to cleanup CDC reader. Retrying.");
+            time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+}
+
+/// Creates a CDC log reader and its handler future.
+async fn create_cdc_reader(
+    cdc_start: Duration,
+    config: Arc<Config>,
+    session: Arc<Session>,
+    metadata: IndexMetadata,
+    tx_embeddings: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+) -> anyhow::Result<(
+    scylla_cdc::log_reader::CDCLogReader,
+    impl std::future::Future<Output = anyhow::Result<()>>,
+)> {
+    let consumer_factory = CdcConsumerFactory::new(Arc::clone(&session), &metadata, tx_embeddings)?;
+
+    let cdc_start = cdc_start - CHECKPOINT_TIMESTAMP_OFFSET;
+    info!(
+        "Creating CDC log reader for {} starting from {:?}",
+        metadata.key(),
+        OffsetDateTime::UNIX_EPOCH + cdc_start
+    );
+    CDCLogReaderBuilder::new()
+        .session(session)
+        .keyspace(metadata.keyspace_name.as_ref())
+        .table_name(metadata.table_name.as_ref())
+        .consumer_factory(Arc::new(consumer_factory))
+        .start_timestamp(chrono::Duration::from_std(cdc_start)?)
+        .pipe(|builder| {
+            if let Some(interval) = config.cdc_safety_interval {
+                info!("Setting CDC safety interval to {interval:?}");
+                builder.safety_interval(interval)
+            } else {
+                builder
+            }
+        })
+        .pipe(|builder| {
+            if let Some(interval) = config.cdc_sleep_interval {
+                info!("Setting CDC sleep interval to {interval:?}");
+                builder.sleep_interval(interval)
+            } else {
+                builder
+            }
+        })
+        .build()
+        .await
+        .context("Failed to build CDC log reader")
+}
+
+/// Spawns a task that runs the CDC handler future until completion or shutdown.
+fn spawn_handler_task(
+    handler: impl std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
+    shutdown_notify: Arc<Notify>,
+    cdc_error_notify: Arc<Notify>,
+    internals: Sender<Internals>,
+    metadata: &IndexMetadata,
+) -> tokio::task::JoinHandle<Duration> {
+    let handler_key = metadata.key();
+    let span_name = format!("cdc_handler");
+    let counter_name = format!("{handler_key}-cdc-handler-errors");
+
+    tokio::spawn(
+        async move {
+            tokio::select! {
+                result = handler => {
+                    if let Err(err) = result {
+                        warn!("CDC handler error: {err}");
+                        internals.increment_counter(counter_name).await;
+                        cdc_error_notify.notify_one();
+                    }
+                }
+                _ = shutdown_notify.notified() => {
+                    debug!("CDC handler: shutdown requested");
+                }
+            }
+            debug!("CDC handler finished");
+            cdc_now()
+        }
+        .instrument(error_span!("cdc_handler", "{}", span_name)),
+    )
+}
+
+struct CdcConsumerData {
+    primary_key_columns: Vec<ColumnName>,
+    target_column: ColumnName,
+    tx: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+    gregorian_epoch: PrimitiveDateTime,
+}
+
+struct CdcConsumer(Arc<CdcConsumerData>);
+
+#[async_trait]
+impl Consumer for CdcConsumer {
+    async fn consume_cdc(&mut self, mut row: CDCRow<'_>) -> anyhow::Result<()> {
+        if self.0.tx.is_closed() {
+            // a consumer should be closed now, some concurrent tasks could stay in a pipeline
+            return Ok(());
+        }
+
+        let target_column = self.0.target_column.as_ref();
+        if !row.column_deletable(target_column) {
+            bail!("CDC error: target column {target_column} should be deletable");
+        }
+
+        let embedding = row
+            .take_value(target_column)
+            .map(|value| {
+                let CqlValue::Vector(value) = value else {
+                    bail!("CDC error: target column {target_column} should be VECTOR type");
+                };
+                value
+                    .into_iter()
+                    .map(|value| {
+                        value.as_float().ok_or(anyhow!(
+                            "CDC error: target column {target_column} should be VECTOR<float> type"
+                        ))
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()
+            })
+            .transpose()?
+            .map(|embedding| embedding.into());
+
+        let primary_key = self
+            .0
+            .primary_key_columns
+            .iter()
+            .map(|column| {
+                if !row.column_exists(column.as_ref()) {
+                    bail!("CDC error: primary key column {column} should exist");
+                }
+                if row.column_deletable(column.as_ref()) {
+                    bail!("CDC error: primary key column {column} should not be deletable");
+                }
+                row.take_value(column.as_ref()).ok_or(anyhow!(
+                    "CDC error: primary key column {column} value should exist"
+                ))
+            })
+            .collect::<anyhow::Result<_>>()?;
+
+        const HUNDREDS_NANOS_TO_MICROS: u64 = 10;
+        let timestamp = (self.0.gregorian_epoch
+            + Duration::from_micros(
+                row.time
+                    .get_timestamp()
+                    .ok_or(anyhow!("CDC error: time has no timestamp"))?
+                    .to_gregorian()
+                    .0
+                    / HUNDREDS_NANOS_TO_MICROS,
+            ))
+        .into();
+
+        _ = self
+            .0
+            .tx
+            .send((
+                DbEmbedding {
+                    primary_key,
+                    embedding,
+                    timestamp,
+                },
+                None,
+            ))
+            .await;
+        Ok(())
+    }
+}
+
+struct CdcConsumerFactory(Arc<CdcConsumerData>);
+
+#[async_trait]
+impl ConsumerFactory for CdcConsumerFactory {
+    async fn new_consumer(&self) -> Box<dyn Consumer> {
+        Box::new(CdcConsumer(Arc::clone(&self.0)))
+    }
+}
+
+impl CdcConsumerFactory {
+    fn new(
+        session: Arc<Session>,
+        metadata: &IndexMetadata,
+        tx: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+    ) -> anyhow::Result<Self> {
+        let cluster_state = session.get_cluster_state();
+        let table = cluster_state
+            .get_keyspace(metadata.keyspace_name.as_ref())
+            .ok_or_else(|| anyhow!("keyspace {} does not exist", metadata.keyspace_name))?
+            .tables
+            .get(metadata.table_name.as_ref())
+            .ok_or_else(|| anyhow!("table {} does not exist", metadata.table_name))?;
+
+        let primary_key_columns = table
+            .partition_key
+            .iter()
+            .chain(table.clustering_key.iter())
+            .cloned()
+            .map(ColumnName::from)
+            .collect();
+
+        let gregorian_epoch = PrimitiveDateTime::new(
+            Date::from_calendar_date(1582, Month::October, 15)?,
+            Time::MIDNIGHT,
+        );
+
+        Ok(Self(Arc::new(CdcConsumerData {
+            primary_key_columns,
+            target_column: metadata.target_column.clone(),
+            tx,
+            gregorian_epoch,
+        })))
+    }
+}

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -19,13 +19,13 @@ use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
 use async_trait::async_trait;
+use futures::FutureExt;
 use scylla::client::session::Session;
 use scylla::value::CqlValue;
 use scylla_cdc::consumer::CDCRow;
 use scylla_cdc::consumer::Consumer;
 use scylla_cdc::consumer::ConsumerFactory;
 use scylla_cdc::log_reader::CDCLogReaderBuilder;
-use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -251,7 +251,7 @@ impl CdcReaderState {
     /// Drains stale error notifications, cancels any pending backoff,
     /// and resets the consecutive error counter.
     fn reset_on_session_change(&mut self) {
-        let _ = pin!(self.error_notify.notified()).enable();
+        drain_pending_notifications(&self.error_notify);
         self.backoff_deadline = None;
         if let CdcErrorPolicy::BackoffAndRetry {
             consecutive_errors, ..
@@ -271,7 +271,7 @@ impl CdcReaderState {
         internals: &Sender<Internals>,
     ) {
         self.stop().await;
-        drain_pending_notifications(&self.shutdown_notify).await;
+        drain_pending_notifications(&self.shutdown_notify);
 
         match create_cdc_reader(
             self.start,
@@ -410,13 +410,8 @@ async fn select_backoff(deadline: Option<time::Instant>) -> Option<()> {
 }
 
 /// Drains any pending shutdown notifications to avoid stale wakeups.
-async fn drain_pending_notifications(notify: &Notify) {
-    if pin!(notify.notified()).enable() {
-        while pin!(notify.notified()).enable() {
-            error!("Internal error: unable to cleanup CDC reader. Retrying.");
-            time::sleep(Duration::from_secs(1)).await;
-        }
-    }
+fn drain_pending_notifications(notify: &Notify) {
+    while notify.notified().now_or_never().is_some() {}
 }
 
 /// Creates a CDC log reader with the given parameters.

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -29,7 +29,6 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
-use tap::Pipe;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
@@ -44,7 +43,65 @@ use tracing::warn;
 
 const CHECKPOINT_TIMESTAMP_OFFSET: Duration = Duration::from_mins(10);
 
+// Default parameters for the wide-framed CDC reader (consistency-focused).
+const DEFAULT_CONSISTENT_SAFETY_INTERVAL: Duration = Duration::from_secs(30);
+const DEFAULT_CONSISTENT_SLEEP_INTERVAL: Duration = Duration::from_secs(10);
+
+// Default parameters for the fine-grained CDC reader (latency-focused).
+const DEFAULT_REALTIME_SAFETY_INTERVAL: Duration = Duration::from_millis(100);
+const DEFAULT_REALTIME_SLEEP_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Parameters for a CDC reader instance.
+#[derive(Clone, Debug)]
+struct CdcReaderParams {
+    /// Safety interval: how far behind "now" to read CDC log.
+    /// Higher values ensure data consistency but increase latency.
+    safety_interval: Duration,
+    /// Sleep interval: how often to poll for new CDC data.
+    /// Lower values reduce latency but increase system load.
+    sleep_interval: Duration,
+}
+
+impl CdcReaderParams {
+    fn wide(config: &Config) -> Self {
+        Self {
+            safety_interval: config
+                .cdc_safety_interval
+                .unwrap_or(DEFAULT_CONSISTENT_SAFETY_INTERVAL),
+            sleep_interval: config
+                .cdc_sleep_interval
+                .unwrap_or(DEFAULT_CONSISTENT_SLEEP_INTERVAL),
+        }
+    }
+
+    fn fine(config: &Config) -> Self {
+        Self {
+            safety_interval: config
+                .cdc_fine_safety_interval
+                .unwrap_or(DEFAULT_REALTIME_SAFETY_INTERVAL),
+            sleep_interval: config
+                .cdc_fine_sleep_interval
+                .unwrap_or(DEFAULT_REALTIME_SLEEP_INTERVAL),
+        }
+    }
+}
+
 pub(crate) enum DbCdc {}
+
+/// Preset configurations for CDC reader actors.
+pub(crate) enum CdcReaderConfig {
+    Wide,
+    Fine,
+}
+
+impl From<CdcReaderConfig> for CdcReaderState {
+    fn from(config: CdcReaderConfig) -> Self {
+        match config {
+            CdcReaderConfig::Wide => Self::new("wide", CdcReaderParams::wide),
+            CdcReaderConfig::Fine => Self::new("fine", CdcReaderParams::fine),
+        }
+    }
+}
 
 /// Spawns a CDC actor that watches for session changes and manages a CDC reader.
 pub(crate) fn new(
@@ -53,6 +110,7 @@ pub(crate) fn new(
     metadata: IndexMetadata,
     internals: Sender<Internals>,
     tx_embeddings: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+    config: CdcReaderConfig,
 ) -> mpsc::Sender<DbCdc> {
     // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
     let (tx, mut rx) = mpsc::channel::<DbCdc>(10);
@@ -60,7 +118,8 @@ pub(crate) fn new(
     // Mark the receiver to ensure first session update is visible
     session_rx.mark_changed();
 
-    let mut reader = CdcReaderState::new();
+    let mut reader: CdcReaderState = config.into();
+    let name = reader.name;
     let actor_key = metadata.key();
     tokio::spawn(
         async move {
@@ -95,7 +154,7 @@ pub(crate) fn new(
 
             debug!("finished");
         }
-        .instrument(error_span!("db_cdc", "{}", actor_key)),
+        .instrument(error_span!("db_cdc", "{}-{}", actor_key, name)),
     );
 
     tx
@@ -108,16 +167,20 @@ struct CdcReaderState {
     shutdown_notify: Arc<Notify>,
     error_notify: Arc<Notify>,
     start: Duration,
+    name: &'static str,
+    params_fn: fn(&Config) -> CdcReaderParams,
 }
 
 impl CdcReaderState {
-    fn new() -> Self {
+    fn new(name: &'static str, params_fn: fn(&Config) -> CdcReaderParams) -> Self {
         Self {
             reader: None,
             handler_task: None,
             shutdown_notify: Arc::new(Notify::new()),
             error_notify: Arc::new(Notify::new()),
             start: cdc_now(),
+            name,
+            params_fn,
         }
     }
 
@@ -135,7 +198,7 @@ impl CdcReaderState {
     /// Stops the current reader, drains stale notifications, and starts a new reader with the given parameters.
     async fn restart(
         &mut self,
-        config: &Arc<Config>,
+        params: CdcReaderParams,
         session: &Arc<Session>,
         metadata: &IndexMetadata,
         tx_embeddings: &mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
@@ -146,10 +209,11 @@ impl CdcReaderState {
 
         match create_cdc_reader(
             self.start,
-            Arc::clone(config),
+            params.clone(),
             Arc::clone(session),
             metadata.clone(),
             tx_embeddings.clone(),
+            self.name,
         )
         .await
         {
@@ -161,17 +225,19 @@ impl CdcReaderState {
                     Arc::clone(&self.error_notify),
                     internals.clone(),
                     metadata,
+                    self.name,
                 ));
 
                 info!(
-                    "CDC reader created successfully for {} (safety: {:?}, sleep: {:?})",
+                    "{} CDC reader created successfully for {} (safety: {:?}, sleep: {:?})",
+                    self.name,
                     metadata.key(),
-                    config.cdc_safety_interval,
-                    config.cdc_sleep_interval
+                    params.safety_interval,
+                    params.sleep_interval
                 );
             }
             Err(e) => {
-                error!("Failed to create CDC reader: {e}");
+                error!("Failed to create {} CDC reader: {e}", self.name);
             }
         }
     }
@@ -188,18 +254,21 @@ impl CdcReaderState {
         match session {
             Some(session) => {
                 info!(
-                    "Session available, creating CDC reader for {}",
+                    "Session available, creating {} CDC reader for {}",
+                    self.name,
                     metadata.key()
                 );
 
                 let config = config_rx.borrow().clone();
 
-                self.restart(&config, &session, metadata, tx_embeddings, internals)
+                let params = (self.params_fn)(&config);
+                self.restart(params, &session, metadata, tx_embeddings, internals)
                     .await;
             }
             None => {
                 info!(
-                    "Session became None, stopping CDC reader for {}",
+                    "Session became None, stopping {} CDC reader for {}",
+                    self.name,
                     metadata.key()
                 );
 
@@ -225,50 +294,38 @@ async fn drain_pending_notifications(notify: &Notify) {
     }
 }
 
-/// Creates a CDC log reader and its handler future.
+/// Creates a CDC log reader with the given parameters.
 async fn create_cdc_reader(
-    cdc_start: Duration,
-    config: Arc<Config>,
+    start: Duration,
+    params: CdcReaderParams,
     session: Arc<Session>,
     metadata: IndexMetadata,
     tx_embeddings: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+    reader_name: &str,
 ) -> anyhow::Result<(
     scylla_cdc::log_reader::CDCLogReader,
     impl std::future::Future<Output = anyhow::Result<()>>,
 )> {
     let consumer_factory = CdcConsumerFactory::new(Arc::clone(&session), &metadata, tx_embeddings)?;
 
-    let cdc_start = cdc_start - CHECKPOINT_TIMESTAMP_OFFSET;
+    let cdc_start = start - CHECKPOINT_TIMESTAMP_OFFSET;
     info!(
-        "Creating CDC log reader for {} starting from {:?}",
+        "Creating {reader_name} CDC log reader for {} starting from {:?}",
         metadata.key(),
         OffsetDateTime::UNIX_EPOCH + cdc_start
     );
+
     CDCLogReaderBuilder::new()
         .session(session)
         .keyspace(metadata.keyspace_name.as_ref())
         .table_name(metadata.table_name.as_ref())
         .consumer_factory(Arc::new(consumer_factory))
         .start_timestamp(chrono::Duration::from_std(cdc_start)?)
-        .pipe(|builder| {
-            if let Some(interval) = config.cdc_safety_interval {
-                info!("Setting CDC safety interval to {interval:?}");
-                builder.safety_interval(interval)
-            } else {
-                builder
-            }
-        })
-        .pipe(|builder| {
-            if let Some(interval) = config.cdc_sleep_interval {
-                info!("Setting CDC sleep interval to {interval:?}");
-                builder.sleep_interval(interval)
-            } else {
-                builder
-            }
-        })
+        .safety_interval(params.safety_interval)
+        .sleep_interval(params.sleep_interval)
         .build()
         .await
-        .context("Failed to build CDC log reader")
+        .context(format!("Failed to build {reader_name} CDC log reader"))
 }
 
 /// Spawns a task that runs the CDC handler future until completion or shutdown.
@@ -278,10 +335,11 @@ fn spawn_handler_task(
     cdc_error_notify: Arc<Notify>,
     internals: Sender<Internals>,
     metadata: &IndexMetadata,
+    reader_name: &str,
 ) -> tokio::task::JoinHandle<Duration> {
     let handler_key = metadata.key();
-    let span_name = format!("cdc_handler");
-    let counter_name = format!("{handler_key}-cdc-handler-errors");
+    let span_name = format!("{reader_name}_cdc_handler");
+    let counter_name = format!("{handler_key}-{reader_name}-cdc-handler-errors");
 
     tokio::spawn(
         async move {

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -51,6 +51,13 @@ const DEFAULT_CONSISTENT_SLEEP_INTERVAL: Duration = Duration::from_secs(10);
 const DEFAULT_REALTIME_SAFETY_INTERVAL: Duration = Duration::from_millis(100);
 const DEFAULT_REALTIME_SLEEP_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Maximum consecutive errors before a CDC reader with Backoff policy escalates to session teardown.
+const DEFAULT_MAX_CONSECUTIVE_ERRORS: u32 = 3;
+
+/// Base backoff duration for CDC reader restarts after errors.
+/// The actual backoff is `DEFAULT_BACKOFF_BASE * consecutive_error_count`.
+const DEFAULT_BACKOFF_BASE: Duration = Duration::from_secs(5);
+
 /// Parameters for a CDC reader instance.
 #[derive(Clone, Debug)]
 struct CdcReaderParams {
@@ -97,8 +104,14 @@ pub(crate) enum CdcReaderConfig {
 impl From<CdcReaderConfig> for CdcReaderState {
     fn from(config: CdcReaderConfig) -> Self {
         match config {
-            CdcReaderConfig::Wide => Self::new("wide", CdcReaderParams::wide),
-            CdcReaderConfig::Fine => Self::new("fine", CdcReaderParams::fine),
+            CdcReaderConfig::Wide => {
+                Self::new("wide", CdcErrorPolicy::Propagate, CdcReaderParams::wide)
+            }
+            CdcReaderConfig::Fine => Self::new(
+                "fine",
+                CdcErrorPolicy::backoff_and_retry(),
+                CdcReaderParams::fine,
+            ),
         }
     }
 }
@@ -144,7 +157,16 @@ pub(crate) fn new(
                     }
 
                     _ = reader.error_notify.notified() => {
-                        break;
+                        if reader.handle_error() {
+                            break;
+                        }
+                    }
+
+                    Some(()) = select_backoff(reader.backoff_deadline) => {
+                        reader.restart_after_backoff(
+                            &session_rx, &config_rx, &metadata,
+                            &tx_embeddings, &internals,
+                        ).await;
                     }
                 }
             }
@@ -160,26 +182,57 @@ pub(crate) fn new(
     tx
 }
 
+/// Defines how a CDC reader handles errors from its handler task.
+enum CdcErrorPolicy {
+    /// Propagate errors immediately by closing the channel.
+    Propagate,
+    /// Handle errors locally with backoff and retry.
+    /// After `max_consecutive_errors` consecutive failures, close the channel.
+    BackoffAndRetry {
+        max_consecutive_errors: u32,
+        backoff_base: Duration,
+        consecutive_errors: u32,
+    },
+}
+
+impl CdcErrorPolicy {
+    fn backoff_and_retry() -> Self {
+        Self::BackoffAndRetry {
+            max_consecutive_errors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
+            backoff_base: DEFAULT_BACKOFF_BASE,
+            consecutive_errors: 0,
+        }
+    }
+}
+
 /// State for managing a CDC reader's lifecycle.
 struct CdcReaderState {
     reader: Option<scylla_cdc::log_reader::CDCLogReader>,
     handler_task: Option<tokio::task::JoinHandle<Duration>>,
     shutdown_notify: Arc<Notify>,
+    backoff_deadline: Option<time::Instant>,
     error_notify: Arc<Notify>,
     start: Duration,
     name: &'static str,
+    error_policy: CdcErrorPolicy,
     params_fn: fn(&Config) -> CdcReaderParams,
 }
 
 impl CdcReaderState {
-    fn new(name: &'static str, params_fn: fn(&Config) -> CdcReaderParams) -> Self {
+    fn new(
+        name: &'static str,
+        error_policy: CdcErrorPolicy,
+        params_fn: fn(&Config) -> CdcReaderParams,
+    ) -> Self {
         Self {
             reader: None,
             handler_task: None,
             shutdown_notify: Arc::new(Notify::new()),
             error_notify: Arc::new(Notify::new()),
+            backoff_deadline: None,
             start: cdc_now(),
             name,
+            error_policy,
             params_fn,
         }
     }
@@ -192,6 +245,19 @@ impl CdcReaderState {
         if let Some(task) = self.handler_task.take() {
             self.shutdown_notify.notify_one();
             self.start = task.await.unwrap_or(cdc_now());
+        }
+    }
+
+    /// Drains stale error notifications, cancels any pending backoff,
+    /// and resets the consecutive error counter.
+    fn reset_on_session_change(&mut self) {
+        let _ = pin!(self.error_notify.notified()).enable();
+        self.backoff_deadline = None;
+        if let CdcErrorPolicy::BackoffAndRetry {
+            consecutive_errors, ..
+        } = &mut self.error_policy
+        {
+            *consecutive_errors = 0;
         }
     }
 
@@ -261,6 +327,7 @@ impl CdcReaderState {
 
                 let config = config_rx.borrow().clone();
 
+                self.reset_on_session_change();
                 let params = (self.params_fn)(&config);
                 self.restart(params, &session, metadata, tx_embeddings, internals)
                     .await;
@@ -276,12 +343,70 @@ impl CdcReaderState {
             }
         }
     }
+
+    /// Handles an error according to the reader's [`CdcErrorPolicy`].
+    /// Returns `true` if the error should be propagated by closing the channel.
+    fn handle_error(&mut self) -> bool {
+        match &mut self.error_policy {
+            CdcErrorPolicy::Propagate => true,
+            CdcErrorPolicy::BackoffAndRetry {
+                max_consecutive_errors,
+                backoff_base,
+                consecutive_errors,
+            } => {
+                *consecutive_errors += 1;
+                let count = *consecutive_errors;
+                let limit = *max_consecutive_errors;
+
+                if count >= limit {
+                    warn!(
+                        "{} CDC reader failed {count} consecutive times, closing channel",
+                        self.name
+                    );
+                    true
+                } else {
+                    let backoff = *backoff_base * count;
+                    warn!(
+                        "{} CDC reader error ({count}/{limit}), restarting after {backoff:?} backoff",
+                        self.name,
+                    );
+                    self.backoff_deadline = Some(time::Instant::now() + backoff);
+                    false
+                }
+            }
+        }
+    }
+
+    /// Completes a pending backoff by restarting the CDC reader.
+    async fn restart_after_backoff(
+        &mut self,
+        session_rx: &watch::Receiver<Option<Arc<Session>>>,
+        config_rx: &watch::Receiver<Arc<Config>>,
+        metadata: &IndexMetadata,
+        tx_embeddings: &mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
+        internals: &Sender<Internals>,
+    ) {
+        self.backoff_deadline = None;
+        let session = session_rx.borrow().clone();
+        if let Some(session) = session {
+            let config = config_rx.borrow().clone();
+            let params = (self.params_fn)(&config);
+            self.restart(params, &session, metadata, tx_embeddings, internals)
+                .await;
+        }
+    }
 }
 
 fn cdc_now() -> Duration {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
+}
+
+/// Waits for the backoff deadline to expire, returning `None` if no deadline is set.
+async fn select_backoff(deadline: Option<time::Instant>) -> Option<()> {
+    time::sleep_until(deadline?).await;
+    Some(())
 }
 
 /// Drains any pending shutdown notifications to avoid stale wakeups.

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -14,6 +14,7 @@ use crate::Progress;
 use crate::TableName;
 use crate::Timestamp;
 use crate::db_cdc;
+use crate::db_cdc::CdcReaderConfig;
 use crate::internals::Internals;
 use crate::invariant_key::InvariantKey;
 use crate::node_state::Event;
@@ -144,18 +145,32 @@ pub(crate) async fn new(
     let (tx_index, mut rx_index) = mpsc::channel(CHANNEL_SIZE);
     let (tx_embeddings, rx_embeddings) = mpsc::channel(CHANNEL_SIZE);
 
-    // Create CDC actor
-    let cdc = db_cdc::new(
+    // Create wide-framed CDC actor
+    let cdc_wide = db_cdc::new(
         config_rx.clone(),
         session_rx.clone(),
         metadata.clone(),
         internals.clone(),
         tx_embeddings.clone(),
+        CdcReaderConfig::Wide,
+    );
+
+    // Create fine-grained CDC actor
+    let cdc_fine = db_cdc::new(
+        config_rx,
+        session_rx.clone(),
+        metadata.clone(),
+        internals,
+        tx_embeddings.clone(),
+        CdcReaderConfig::Fine,
     );
 
     // Monitor CDC actor channels for closure to notify about errors
     tokio::spawn(async move {
-        cdc.closed().await;
+        tokio::select! {
+            _ = cdc_wide.closed() => {},
+            _ = cdc_fine.closed() => {},
+        }
         cdc_error_notify.notify_one();
     });
 

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -13,21 +13,15 @@ use crate::Percentage;
 use crate::Progress;
 use crate::TableName;
 use crate::Timestamp;
+use crate::db_cdc;
 use crate::internals::Internals;
-use crate::internals::InternalsExt;
 use crate::invariant_key::InvariantKey;
 use crate::node_state::Event;
 use crate::node_state::NodeState;
 use crate::node_state::NodeStateExt;
-use ::time::Date;
-use ::time::Month;
-use ::time::OffsetDateTime;
-use ::time::PrimitiveDateTime;
-use ::time::Time;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
-use async_trait::async_trait;
 use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -41,19 +35,13 @@ use scylla::routing::Token;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
 use scylla::value::Row;
-use scylla_cdc::consumer::CDCRow;
-use scylla_cdc::consumer::Consumer;
-use scylla_cdc::consumer::ConsumerFactory;
-use scylla_cdc::log_reader::CDCLogReaderBuilder;
 use std::collections::HashMap;
 use std::iter;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
-use std::pin::pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::time::Duration;
-use std::time::SystemTime;
 use tap::Pipe;
 use tokio::sync::Notify;
 use tokio::sync::Semaphore;
@@ -61,7 +49,6 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
-use tokio::time;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::error;
@@ -75,7 +62,6 @@ type GetTableColumnsR = Arc<HashMap<ColumnName, NativeType>>;
 type RangeScanResult =
     anyhow::Result<Pin<Box<dyn Stream<Item = DbEmbedding> + std::marker::Send>>, anyhow::Error>;
 
-const CHECKPOINT_TIMESTAMP_OFFSET: Duration = Duration::from_mins(10);
 const START_RETRY_TIMEOUT: Duration = Duration::from_millis(100);
 const RETRY_TIMEOUT_LIMIT: Duration = Duration::from_secs(16);
 const INCREASE_RATE: u32 = 2;
@@ -141,8 +127,8 @@ impl DbIndexExt for mpsc::Sender<DbIndex> {
 }
 
 pub(crate) async fn new(
-    mut config_rx: watch::Receiver<Arc<Config>>,
-    mut session_rx: watch::Receiver<Option<Arc<Session>>>,
+    config_rx: watch::Receiver<Arc<Config>>,
+    session_rx: watch::Receiver<Option<Arc<Session>>>,
     metadata: IndexMetadata,
     node_state: Sender<NodeState>,
     internals: Sender<Internals>,
@@ -158,138 +144,23 @@ pub(crate) async fn new(
     let (tx_index, mut rx_index) = mpsc::channel(CHANNEL_SIZE);
     let (tx_embeddings, rx_embeddings) = mpsc::channel(CHANNEL_SIZE);
 
-    // Mark the receiver to ensure first session update is visible
-    session_rx.mark_changed();
-
-    let mut statements_session_rx = session_rx.clone();
-    let cdc_metadata = metadata.clone();
-    let cdc_tx_embeddings = tx_embeddings.clone();
-    let cdc_key = key.clone();
-    let cdc_manager_key = key.clone();
-
-    // Spawn CDC management task - handles session changes and CDC reader lifecycle
-    tokio::spawn(
-        async move {
-            debug!("CDC manager starting");
-
-            let cdc_now = || SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap();
-            let mut cdc_start = cdc_now();
-            let mut cdc_reader: Option<scylla_cdc::log_reader::CDCLogReader> = None;
-            let mut cdc_handler_task: Option<tokio::task::JoinHandle<Duration>> = None;
-            let shutdown_notify = Arc::new(Notify::new());
-
-            loop {
-                // Wait for session changes
-                if session_rx.changed().await.is_err() {
-                    // Session sender dropped, cleanup and exit
-                    if let Some(mut reader) = cdc_reader {
-                        reader.stop();
-                    }
-                    if let Some(task) = cdc_handler_task {
-                        shutdown_notify.notify_one();
-                        _ = task.await;
-                    }
-                    break;
-                }
-
-                let session_opt = session_rx.borrow_and_update().clone();
-
-                match session_opt {
-                    Some(session) => {
-                        info!(
-                            "Session available, creating CDC reader for {}",
-                            cdc_metadata.key()
-                        );
-
-                        // Stop old CDC reader if exists
-                        if let Some(mut reader) = cdc_reader.take() {
-                            reader.stop();
-                        }
-                        if let Some(task) = cdc_handler_task.take() {
-                            shutdown_notify.notify_one();
-                            cdc_start = task.await.unwrap_or(cdc_now());
-                        }
-
-                        // Disable pending shutdown notifications
-                        if pin!(shutdown_notify.notified()).enable() {
-                            while pin!(shutdown_notify.notified()).enable() {
-                                error!("Internal error: unable to cleanup CDC reader. Lets retry again.");
-                                time::sleep(Duration::from_secs(1)).await;
-                            }
-                        }
-
-                        // Create new CDC reader
-                        let config = config_rx.borrow_and_update().clone();
-                        match create_cdc_reader(
-                            cdc_start,
-                            config,
-                            session,
-                            cdc_metadata.clone(),
-                            cdc_tx_embeddings.clone(),
-                        )
-                        .await
-                        {
-                            Ok((reader, handler)) => {
-                                cdc_reader = Some(reader);
-
-                                // Spawn CDC handler task
-                                let shutdown_notify = Arc::clone(&shutdown_notify);
-                                let cdc_error_notify = Arc::clone(&cdc_error_notify);
-                                let handler_key = cdc_key.clone();
-                                let internals = internals.clone();
-                                cdc_handler_task = Some(tokio::spawn(
-                                    async move {
-                                        tokio::select! {
-                                            result = handler => {
-                                                if let Err(err) = result {
-                                                    warn!("CDC handler error: {err}");
-                                                    internals
-                                                        .increment_counter(format!("{handler_key}-cdc-handler-errors"))
-                                                        .await;
-                                                    cdc_error_notify.notify_one();
-                                                }
-                                            }
-                                            _ = shutdown_notify.notified() => {
-                                                debug!("CDC handler: shutdown requested");
-                                            }
-                                        }
-                                        debug!("CDC handler finished");
-                                        cdc_now()
-                                    }
-                                    .instrument(error_span!("cdc", "{cdc_key}")),
-                                ));
-
-                                info!("CDC reader created successfully for {}", cdc_metadata.key());
-                            }
-                            Err(e) => {
-                                error!("Failed to create CDC reader: {}", e);
-                            }
-                        }
-                    }
-                    None => {
-                        info!(
-                            "Session became None, stopping CDC reader for {}",
-                            cdc_metadata.key()
-                        );
-
-                        // Stop CDC reader
-                        if let Some(mut reader) = cdc_reader.take() {
-                            reader.stop();
-                        }
-                        if let Some(task) = cdc_handler_task.take() {
-                            shutdown_notify.notify_one();
-                            cdc_start = task.await.unwrap_or(cdc_now());
-                        }
-                    }
-                }
-            }
-
-            debug!("CDC manager finished");
-        }
-        .instrument(error_span!("cdc_manager", "{}", cdc_manager_key)),
+    // Create CDC actor
+    let cdc = db_cdc::new(
+        config_rx.clone(),
+        session_rx.clone(),
+        metadata.clone(),
+        internals.clone(),
+        tx_embeddings.clone(),
     );
 
+    // Monitor CDC actor channels for closure to notify about errors
+    tokio::spawn(async move {
+        cdc.closed().await;
+        cdc_error_notify.notify_one();
+    });
+
     // Wait for initial session to create statements
+    let mut statements_session_rx = session_rx.clone();
     while statements_session_rx.borrow().is_none() {
         if statements_session_rx.changed().await.is_err() {
             return Err(anyhow::anyhow!(
@@ -349,52 +220,6 @@ pub(crate) async fn new(
     );
 
     Ok((tx_index, rx_embeddings))
-}
-
-// Helper function to create CDC reader - extracted to avoid duplication
-async fn create_cdc_reader(
-    cdc_start: Duration,
-    config: Arc<Config>,
-    session: Arc<Session>,
-    metadata: IndexMetadata,
-    tx_embeddings: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
-) -> anyhow::Result<(
-    scylla_cdc::log_reader::CDCLogReader,
-    impl std::future::Future<Output = anyhow::Result<()>>,
-)> {
-    let consumer_factory = CdcConsumerFactory::new(Arc::clone(&session), &metadata, tx_embeddings)?;
-
-    let cdc_start = cdc_start - CHECKPOINT_TIMESTAMP_OFFSET;
-    info!(
-        "Creating CDC log reader for {} starting from {:?}",
-        metadata.key(),
-        OffsetDateTime::UNIX_EPOCH + cdc_start
-    );
-    CDCLogReaderBuilder::new()
-        .session(session)
-        .keyspace(metadata.keyspace_name.as_ref())
-        .table_name(metadata.table_name.as_ref())
-        .consumer_factory(Arc::new(consumer_factory))
-        .start_timestamp(chrono::Duration::from_std(cdc_start)?)
-        .pipe(|builder| {
-            if let Some(interval) = config.cdc_safety_interval {
-                info!("Setting CDC safety interval to {interval:?}");
-                builder.safety_interval(interval)
-            } else {
-                builder
-            }
-        })
-        .pipe(|builder| {
-            if let Some(interval) = config.cdc_sleep_interval {
-                info!("Setting CDC sleep interval to {interval:?}");
-                builder.sleep_interval(interval)
-            } else {
-                builder
-            }
-        })
-        .build()
-        .await
-        .context("Failed to build CDC log reader")
 }
 
 async fn process(statements: Arc<Statements>, msg: DbIndex, completed_scan_length: Arc<AtomicU64>) {
@@ -777,136 +602,6 @@ impl Statements {
                     .flatten()
             })
             .boxed())
-    }
-}
-
-struct CdcConsumerData {
-    primary_key_columns: Vec<ColumnName>,
-    target_column: ColumnName,
-    tx: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
-    gregorian_epoch: PrimitiveDateTime,
-}
-
-struct CdcConsumer(Arc<CdcConsumerData>);
-
-#[async_trait]
-impl Consumer for CdcConsumer {
-    async fn consume_cdc(&mut self, mut row: CDCRow<'_>) -> anyhow::Result<()> {
-        if self.0.tx.is_closed() {
-            // a consumer should be closed now, some concurrent tasks could stay in a pipeline
-            return Ok(());
-        }
-
-        let target_column = self.0.target_column.as_ref();
-        if !row.column_deletable(target_column) {
-            bail!("CDC error: target column {target_column} should be deletable");
-        }
-
-        let embedding = row
-            .take_value(target_column)
-            .map(|value| {
-                let CqlValue::Vector(value) = value else {
-                    bail!("CDC error: target column {target_column} should be VECTOR type");
-                };
-                value
-                    .into_iter()
-                    .map(|value| {
-                        value.as_float().ok_or(anyhow!(
-                            "CDC error: target column {target_column} should be VECTOR<float> type"
-                        ))
-                    })
-                    .collect::<anyhow::Result<Vec<_>>>()
-            })
-            .transpose()?
-            .map(|embedding| embedding.into());
-
-        let primary_key = self
-            .0
-            .primary_key_columns
-            .iter()
-            .map(|column| {
-                if !row.column_exists(column.as_ref()) {
-                    bail!("CDC error: primary key column {column} should exist");
-                }
-                if row.column_deletable(column.as_ref()) {
-                    bail!("CDC error: primary key column {column} should not be deletable");
-                }
-                row.take_value(column.as_ref()).ok_or(anyhow!(
-                    "CDC error: primary key column {column} value should exist"
-                ))
-            })
-            .collect::<anyhow::Result<_>>()?;
-
-        const HUNDREDS_NANOS_TO_MICROS: u64 = 10;
-        let timestamp = (self.0.gregorian_epoch
-            + Duration::from_micros(
-                row.time
-                    .get_timestamp()
-                    .ok_or(anyhow!("CDC error: time has no timestamp"))?
-                    .to_gregorian()
-                    .0
-                    / HUNDREDS_NANOS_TO_MICROS,
-            ))
-        .into();
-
-        _ = self
-            .0
-            .tx
-            .send((
-                DbEmbedding {
-                    primary_key,
-                    embedding,
-                    timestamp,
-                },
-                None,
-            ))
-            .await;
-        Ok(())
-    }
-}
-
-struct CdcConsumerFactory(Arc<CdcConsumerData>);
-
-#[async_trait]
-impl ConsumerFactory for CdcConsumerFactory {
-    async fn new_consumer(&self) -> Box<dyn Consumer> {
-        Box::new(CdcConsumer(Arc::clone(&self.0)))
-    }
-}
-
-impl CdcConsumerFactory {
-    fn new(
-        session: Arc<Session>,
-        metadata: &IndexMetadata,
-        tx: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
-    ) -> anyhow::Result<Self> {
-        let cluster_state = session.get_cluster_state();
-        let table = cluster_state
-            .get_keyspace(metadata.keyspace_name.as_ref())
-            .ok_or_else(|| anyhow!("keyspace {} does not exist", metadata.keyspace_name))?
-            .tables
-            .get(metadata.table_name.as_ref())
-            .ok_or_else(|| anyhow!("table {} does not exist", metadata.table_name))?;
-
-        let primary_key_columns = table
-            .partition_key
-            .iter()
-            .chain(table.clustering_key.iter())
-            .cloned()
-            .map(ColumnName::from)
-            .collect();
-
-        let gregorian_epoch = PrimitiveDateTime::new(
-            Date::from_calendar_date(1582, Month::October, 15)?,
-            Time::MIDNIGHT,
-        );
-
-        Ok(Self(Arc::new(CdcConsumerData {
-            primary_key_columns,
-            target_column: metadata.target_column.clone(),
-            tx,
-            gregorian_epoch,
-        })))
     }
 }
 

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -4,6 +4,7 @@
  */
 
 pub mod db;
+mod db_cdc;
 pub mod db_index;
 mod distance;
 mod engine;

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -90,6 +90,8 @@ pub struct Config {
     pub cql_uri_translation_map: Option<HashMap<SocketAddr, SocketAddr>>,
     pub cdc_safety_interval: Option<Duration>,
     pub cdc_sleep_interval: Option<Duration>,
+    pub cdc_fine_safety_interval: Option<Duration>,
+    pub cdc_fine_sleep_interval: Option<Duration>,
     pub disable_colors: bool,
     pub tls_cert_path: Option<std::path::PathBuf>,
     pub tls_key_path: Option<std::path::PathBuf>,
@@ -115,6 +117,8 @@ impl Default for Config {
             cql_uri_translation_map: None,
             cdc_safety_interval: None,
             cdc_sleep_interval: None,
+            cdc_fine_safety_interval: None,
+            cdc_fine_sleep_interval: None,
         }
     }
 }


### PR DESCRIPTION
## Motivation

The current single CDC reader is insufficient because new vectors can be delayed up to 40 seconds (30s safety interval + 10s sleep interval). The limits are set based on the default CDC driver intervals. This conflicts with our goal of real-time AI support, where vectors should be available to the Vector Store service immediately after writing.

To address this, we propose a trade-off: add a CDC reader with shorter intervals (e.g., sub-second safety and sleep), reducing end-to-end latency but increasing network and system load.

As this may cause data loss in case of cluster overload, we retain the existing CDC reader with longer intervals as a correctness backup to ensure no vectors are missed.

## Implementation

Refactor CDC reader into a new `db_cdc` actor.
This allows us to manage the CDC reader(s) with different configuration of safety and sleep intervals.
Having it in separate module makes a logical split, which clarifies the design.

## CDC readers default parameters

**Wide-framed CDC reader:**
- Safety interval: 30 s 
- Sleep interval: 10 s 
- Purpose: Provides consistent, reliable updates

**Fine-grained CDC reader:**
- Safety interval: 100 ms
- Sleep interval: 500 ms 
- Purpose: Provides low-latency updates

---

References: [Design Document](https://scylladb.atlassian.net/wiki/spaces/RND/pages/256344351/Vector+Store+Real-Time+CDC+Reader+Design+Document)

Fixes: VECTOR-485