### PR TITLE
Bump scylla driver version to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3073,9 +3073,9 @@ checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "scylla"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3321054d79dc75f9f3ca449111983ddc3f59aff4561cddb860af884504b4fbc9"
+checksum = "7ab73aaea18839882f43c08bc6367dfd1d4e9d285a2ab6ac4335b9dc06b63c19"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3120,9 +3120,9 @@ dependencies = [
 
 [[package]]
 name = "scylla-cql"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54ff27320ff09e24c9edf2acef2fa4a2a9b60bfb5832454d1a1768f6c036b7"
+checksum = "87834c927e9336270725aac24fada6e86f9d14aa04a8c8f93223b002e86f3891"
 dependencies = [
  "byteorder",
  "bytes",
@@ -3141,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "scylla-macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c9e9660119726312cd6c7bd3e286ffc80fb06a9b6d0e214a16df00600829e9"
+checksum = "ad97e5f7ccd8a1d41e631e361c9851c21b093e15ff5dcd08861f6ac83215d434"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rand = "0.9.2"
 rcgen = "0.14.5"
 regex = "1.11.1"
 reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls"] }
-scylla = { version = "1.2.0", features = ["time-03", "rustls-023", "metrics"] }
+scylla = { version = "1.5.0", features = ["time-03", "rustls-023", "metrics"] }
 scylla-cdc = "0.6.1"
 scylla-proxy = "0.0.5"
 serde = { version = "1.0.219", features = ["derive"] }


### PR DESCRIPTION
Update the declared minimum from 1.2.0 to 1.5.0, since scylla-cdc 0.6.1 requires scylla >= 1.3.1, making the previous minimum unreachable by the resolver. The resolved version in Cargo.lock is updated from 1.4.1 to 1.5.0.

This change fixes VECTOR-564 issue as in 1.5.0 version of Scylla Rust Driver the `total_connections` metric has been changed to not include control connections and correctly measure the real number of connections, making the test not race condition dependent.

Fixes: VECTOR-564