### PR TITLE
validator: Alternator API test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +404,325 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d2214c2ad3a175d3ece5a5af26916c29caa3e12e9e05b3cb8ed5e837b54b67"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699da1961a289b23842d88fe2984c6ff68735fdf9bdcbc69ceaeb2491c9bf434"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e3a4cb3b124833eafea9afd1a6cc5f8ddf3efefffc6651ef76a03cbc6b4981"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c4f19655ab0856375e169865c91264de965bd74c407c7f1e403184b1049409"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cba48474f1d6807384d06fec085b909f5807e16653c5af5c45dfe89539f0b70"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576b0d6991c9c32bc14fc340582ef148311f924d41815f641a308b5d11e8e7cd"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,8 +733,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -403,8 +764,8 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -435,8 +796,8 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "hyper-util",
  "pin-project-lite",
@@ -454,7 +815,7 @@ source = "git+https://github.com/vinchona/axum-server-dual-protocol?rev=ca6db055
 dependencies = [
  "axum-server",
  "bytes",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "pin-project",
  "rustls",
@@ -477,7 +838,7 @@ dependencies = [
  "bytesize",
  "cookie",
  "expect-json",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -504,6 +865,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bcrypt"
@@ -600,6 +971,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytesize"
@@ -908,6 +1289,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1288,6 +1679,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1800,7 +2192,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.12.0",
  "slab",
  "tokio",
@@ -1957,6 +2349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hotpath"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2399,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2008,12 +2420,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2024,8 +2447,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2086,8 +2509,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2103,10 +2526,11 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2137,8 +2561,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -3024,6 +3448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,6 +3461,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "page_size"
@@ -3153,6 +3589,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3671,6 +4113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,8 +4135,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3783,7 +4231,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "mime",
  "rand 0.10.1",
  "thiserror 2.0.18",
@@ -3840,6 +4288,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +4340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4033,6 +4502,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4665,8 +5157,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -4725,8 +5217,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -4949,6 +5441,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "usearch"
 version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,6 +5576,11 @@ name = "vector-search-validator"
 version = "0.0.0-dev"
 dependencies = [
  "async-backtrace",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bcrypt",
  "clap",
  "derive_more",
@@ -5088,6 +5591,7 @@ dependencies = [
  "e2etest-scylla-proxy-cluster",
  "e2etest-tls",
  "e2etest-vector-store-cluster",
+ "http 1.4.0",
  "httpapi",
  "httpclient",
  "itertools 0.14.0",
@@ -5175,6 +5679,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -5815,6 +6325,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ license = "LicenseRef-ScyllaDB-Source-Available-1.0"
 
 [workspace.dependencies]
 anyhow = "1.0.97"
+aws-config = "1.8.14"
+aws-credential-types = "1.2.12"
+aws-sdk-dynamodb = { version = "1.105.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-smithy-runtime-api = "1.11.4"
+aws-smithy-types = "1.4.4"
 arrow-array = "56.0.0"
 async-backtrace = "0.2.7"
 async-channel = "2.5.0"
@@ -40,6 +45,7 @@ e2etest-tls = { git = "https://github.com/scylladb/e2etest-rs", rev = "f9c261c" 
 e2etest-vector-store-cluster = { git = "https://github.com/scylladb/e2etest-rs", rev = "f9c261c" }
 futures = "0.3.31"
 hotpath = { version = "0.15.0", features = ["tokio", "futures", "async-channel"] }
+http = "1.4.0"
 httpapi = { path = "crates/httpapi" }
 httpclient = { path = "crates/httpclient" }
 humantime = "2.2.0"

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -9,6 +9,11 @@ license.workspace = true
 
 [dependencies]
 async-backtrace.workspace = true
+aws-config.workspace = true
+aws-credential-types.workspace = true
+aws-sdk-dynamodb.workspace = true
+aws-smithy-runtime-api.workspace = true
+aws-smithy-types.workspace = true
 bcrypt.workspace = true
 clap.workspace = true
 derive_more.workspace = true
@@ -19,6 +24,7 @@ e2etest-scylla-cluster.workspace = true
 e2etest-scylla-proxy-cluster.workspace = true
 e2etest-tls.workspace = true
 e2etest-vector-store-cluster.workspace = true
+http.workspace = true
 httpapi.workspace = true
 httpclient.workspace = true
 itertools.workspace = true

--- a/crates/validator/src/alternator/auth.rs
+++ b/crates/validator/src/alternator/auth.rs
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+//! Integration test: Alternator with authorization enabled (`--alternator-enforce-authorization=true`).
+//!
+//! Verifies that:
+//! 1. A DynamoDB client with wrong credentials is rejected with `UnrecognizedClientException`.
+//! 2. A role with only `CREATE ON ALL KEYSPACES` can create a table with a vector index and
+//!    write items (which are auto-granted `MODIFY` at `CreateTable` time).
+//! 3. The same limited role **cannot** delete a vector index (needs `ALTER`, which was not
+//!    granted), and Alternator returns `AccessDeniedException`.
+//! 4. Vector Store successfully indexes data written by the limited-permission role.
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_config::BehaviorVersion;
+use aws_credential_types::Credentials;
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::config::Region;
+use e2etest::TestCase;
+use e2etest_scylla_cluster::ScyllaClusterExt;
+use e2etest_vector_store_cluster::VectorStoreClusterExt;
+use scylla::client::session::Session;
+use std::net::Ipv4Addr;
+use std::sync::LazyLock;
+use tracing::info;
+use uuid::Uuid;
+
+use super::ALTERNATOR_PORT;
+use super::JsonBodyInjectInterceptor;
+use super::alternator_keyspace;
+use super::assert_service_error;
+use super::create_alternator_table;
+use super::dynamo_float_list;
+use super::unique_alternator_index_name;
+use super::unique_alternator_table_name;
+use super::wait_for_index_count;
+
+static SUPERUSER_NAME: LazyLock<String> = LazyLock::new(|| Uuid::new_v4().simple().to_string());
+static SUPERUSER_PASSWORD: LazyLock<String> = LazyLock::new(|| Uuid::new_v4().simple().to_string());
+static SUPERUSER_SALTED_PASSWORD: LazyLock<String> = LazyLock::new(|| {
+    bcrypt::hash(&*SUPERUSER_PASSWORD, bcrypt::DEFAULT_COST)
+        .expect("failed to hash superuser password")
+});
+
+/// Builds the ScyllaDB extra-config YAML that enables password authentication,
+/// CQL authorization, and sets the superuser credentials.
+fn scylla_auth_config() -> Vec<u8> {
+    let name = &*SUPERUSER_NAME;
+    let salted = &*SUPERUSER_SALTED_PASSWORD;
+    format!(
+        "authenticator: PasswordAuthenticator\n\
+         authorizer: CassandraAuthorizer\n\
+         auth_superuser_name: '{name}'\n\
+         auth_superuser_salted_password: '{salted}'"
+    )
+    .into_bytes()
+}
+
+/// Builds a DynamoDB client that authenticates with the given SigV4 credentials.
+async fn make_dynamodb_client_with_creds(
+    db_ip: Ipv4Addr,
+    access_key_id: &str,
+    secret_access_key: &str,
+) -> Client {
+    let creds = Credentials::new(access_key_id, secret_access_key, None, None, "test");
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .credentials_provider(creds)
+        .endpoint_url(format!("http://{db_ip}:{ALTERNATOR_PORT}"))
+        .region(Region::new("us-east-1"))
+        .load()
+        .await;
+    Client::new(&config)
+}
+
+/// Polls the Alternator endpoint with the given credentials until it responds
+/// successfully.  With `--alternator-enforce-authorization=true`, the standard
+/// `wait_for_alternator` (which uses dummy `"any"/"any"` creds) would loop
+/// forever because every request returns `UnrecognizedClientException`.
+async fn wait_for_alternator_with_creds(
+    db_ip: Ipv4Addr,
+    access_key_id: &str,
+    secret_access_key: &str,
+) {
+    let client = make_dynamodb_client_with_creds(db_ip, access_key_id, secret_access_key).await;
+    common::wait_for(
+        || {
+            let c = client.clone();
+            async move { c.list_tables().limit(1).send().await.is_ok() }
+        },
+        format!("Alternator endpoint at http://{db_ip}:{ALTERNATOR_PORT} to be ready"),
+        common::DEFAULT_TEST_TIMEOUT,
+    )
+    .await;
+}
+
+/// Queries ScyllaDB for the `salted_hash` of the given role.
+///
+/// Newer ScyllaDB versions store roles in `system.roles`; older releases used
+/// `system_auth_v2.roles` or `system_auth.roles`.  We try all three in order.
+async fn get_salted_hash(session: &Session, role_name: &str) -> String {
+    for keyspace in ["system", "system_auth_v2", "system_auth"] {
+        let query = format!("SELECT salted_hash FROM {keyspace}.roles WHERE role = ?");
+        if let Ok(result) = session.query_unpaged(query, (role_name,)).await
+            && let Ok(rows) = result.into_rows_result()
+            && let Ok((Some(hash),)) = rows.first_row::<(Option<String>,)>()
+        {
+            return hash;
+        }
+    }
+    panic!("Could not find salted_hash for role '{role_name}' in any known keyspace");
+}
+
+/// Verifies correct authorization behaviour for Alternator with enforcement enabled.
+///
+/// See the module-level doc for the full scenario description.
+#[framed]
+async fn alternator_with_auth_enabled(actors: TestActors) {
+    info!("started");
+    let mut scylla_configs = common::get_default_scylla_node_configs(&actors).await;
+    let auth_config = scylla_auth_config();
+    for config in &mut scylla_configs {
+        let node_ip = config.db_ip;
+        config.args.extend([
+            format!("--alternator-port={ALTERNATOR_PORT}"),
+            format!("--alternator-address={node_ip}"),
+            "--alternator-write-isolation=only_rmw_uses_lwt".to_string(),
+            "--alternator-enforce-authorization=true".to_string(),
+        ]);
+        config.extra_config = Some(auth_config.clone());
+    }
+    let mut vs_configs = common::get_default_vs_node_configs(&actors).await;
+    for config in &mut vs_configs {
+        config.user = Some(SUPERUSER_NAME.clone());
+        config.password = Some(SUPERUSER_PASSWORD.clone());
+    }
+
+    let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
+
+    info!("Initializing cluster with Alternator auth enforcement enabled");
+    common::init_dns(&actors).await;
+    actors.db.start(scylla_configs).await;
+    assert!(actors.db.wait_for_ready().await);
+    actors.vs.start(vs_configs).await;
+    assert!(actors.vs.wait_for_ready().await);
+    info!("Connecting to ScyllaDB as superuser");
+    let (session, vs_clients) =
+        common::prepare_connection_with_auth(&actors, &SUPERUSER_NAME, &SUPERUSER_PASSWORD).await;
+    let vs_client = vs_clients
+        .into_iter()
+        .next()
+        .expect("need at least one VS client");
+
+    let role_name = Uuid::new_v4().simple().to_string();
+    let role_password = Uuid::new_v4().simple().to_string();
+
+    info!("Creating limited role '{role_name}' with only CREATE ON ALL KEYSPACES");
+    session
+        .query_unpaged(
+            format!(
+                "CREATE ROLE \"{role_name}\" WITH PASSWORD = '{role_password}' AND LOGIN = true"
+            ),
+            (),
+        )
+        .await
+        .expect("failed to create limited role");
+
+    session
+        .query_unpaged(
+            format!("GRANT CREATE ON ALL KEYSPACES TO \"{role_name}\""),
+            (),
+        )
+        .await
+        .expect("failed to grant CREATE to limited role");
+
+    // Alternator credentials: access_key_id = role name,
+    // secret_access_key = salted_hash from system.roles.
+    info!("Fetching salted_hash for limited role '{role_name}'");
+    let limited_salted_hash = get_salted_hash(&session, &role_name).await;
+
+    let superuser_salted_hash = get_salted_hash(&session, &SUPERUSER_NAME).await;
+
+    wait_for_alternator_with_creds(db_ip, &SUPERUSER_NAME, &superuser_salted_hash).await;
+
+    let limited_client =
+        make_dynamodb_client_with_creds(db_ip, &role_name, &limited_salted_hash).await;
+    info!("Asserting wrong credentials yield UnrecognizedClientException");
+    let bad_client =
+        make_dynamodb_client_with_creds(db_ip, "nonexistent-role", "wrong-secret").await;
+    assert_service_error(
+        bad_client.list_tables().limit(1).send().await,
+        "UnrecognizedClientException",
+    );
+    let table_name = unique_alternator_table_name();
+    let index_name = unique_alternator_index_name();
+    let vec_attr = "vec";
+
+    info!(
+        "Asserting CreateTable with VectorIndexes succeeds for limited role (table '{table_name}')"
+    );
+    create_alternator_table(
+        &limited_client,
+        &table_name,
+        "pk",
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(index_name.as_ref(), vec_attr, 3)],
+    )
+    .await
+    .expect("CreateTable with VectorIndexes should succeed for role with CREATE permission");
+
+    let index = httpapi::IndexInfo::new(
+        alternator_keyspace(&table_name).as_ref(),
+        index_name.as_ref(),
+    );
+    info!("Writing items as limited role");
+    for (pk_val, vec_vals) in [("item-a", [1.0_f32, 1.0, 1.0]), ("item-b", [1.0, 2.0, 4.0])] {
+        limited_client
+            .put_item()
+            .table_name(&table_name)
+            .item(
+                "pk",
+                aws_sdk_dynamodb::types::AttributeValue::S(pk_val.into()),
+            )
+            .item(vec_attr, dynamo_float_list(vec_vals))
+            .send()
+            .await
+            .expect("PutItem should succeed for role with auto-granted MODIFY");
+    }
+    info!("Waiting for VS to index 2 items written by limited role");
+    common::wait_for_index(&vs_client, &index).await;
+    wait_for_index_count(&vs_client, &index, 2).await;
+    info!("VS successfully indexed 2 items");
+
+    // CreateTable auto-grants ALTER to the creator. Revoke it so we can
+    // verify that UpdateTable (delete-index) is gated on ALTER.
+    info!("Revoking ALTER on table '{table_name}' from limited role");
+    session
+        .query_unpaged(
+            format!(
+                "REVOKE ALTER ON TABLE \"alternator_{table_name}\".\"{table_name}\" FROM \"{role_name}\""
+            ),
+            (),
+        )
+        .await
+        .expect("failed to revoke ALTER from limited role");
+    info!("Waiting for UpdateTable delete-index to yield AccessDeniedException for limited role");
+    let delete_update = serde_json::json!([{
+        "Delete": {
+            "IndexName": index_name.as_ref()
+        }
+    }]);
+    common::wait_for(
+        || {
+            let client = limited_client.clone();
+            let table = table_name.clone();
+            let update = delete_update.clone();
+            let index_name_str = index_name.to_string();
+            async move {
+                let result = client
+                    .update_table()
+                    .table_name(&table)
+                    .customize()
+                    .interceptor(JsonBodyInjectInterceptor::new([(
+                        "VectorIndexUpdates",
+                        update,
+                    )]))
+                    .send()
+                    .await;
+                match result {
+                    Err(ref e) => {
+                        use aws_sdk_dynamodb::error::ProvideErrorMetadata as _;
+                        let code = e.code().unwrap_or("");
+                        let msg = e.message().unwrap_or("");
+                        if code.contains("AccessDeniedException")
+                            || msg.contains("AccessDeniedException")
+                        {
+                            return true;
+                        }
+                        // Any other error is unexpected - surface it.
+                        panic!("UpdateTable returned unexpected error: code={code:?} msg={msg:?}");
+                    }
+                    Ok(_) => {
+                        // Permission cache not yet invalidated - retry.
+                        // Re-create the index first so it exists for the next attempt.
+                        // (UpdateTable delete succeeded, so the index is gone; we
+                        //  must re-add it before the next delete attempt.)
+                        client
+                            .update_table()
+                            .table_name(&table)
+                            .customize()
+                            .interceptor(JsonBodyInjectInterceptor::new([(
+                                "VectorIndexUpdates",
+                                serde_json::json!([{
+                                    "Create": {
+                                        "IndexName": index_name_str,
+                                        "VectorAttribute": {
+                                            "AttributeName": "vec",
+                                            "Dimensions": 3
+                                        }
+                                    }
+                                }]),
+                            )]))
+                            .send()
+                            .await
+                            .expect("re-creating index for next retry should succeed");
+                        false
+                    }
+                }
+            }
+        },
+        "UpdateTable delete-index to be rejected with AccessDeniedException",
+        common::DEFAULT_TEST_TIMEOUT,
+    )
+    .await;
+    info!("AccessDeniedException confirmed for UpdateTable after ALTER revoked");
+    info!("Confirming index is still serving after rejected delete");
+    common::wait_for_index(&vs_client, &index).await;
+    info!("Permission boundary verified: index intact");
+
+    info!("Cleaning up");
+    // Drop the CQL session before shutting down Scylla nodes.  The scylla
+    // driver's background topology-refresh task is cancelled when the last
+    // Arc<Session> is dropped, but the cancellation is not processed until the
+    // tokio runtime gets a scheduling turn.  yield_now() gives it that turn so
+    // the task is gone before the nodes disappear and we avoid spurious
+    // "Failed to fetch metadata" warnings.
+    drop(session);
+    tokio::task::yield_now().await;
+    common::cleanup(actors).await;
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "alternator_with_auth_enabled",
+            common::DEFAULT_TEST_TIMEOUT,
+            alternator_with_auth_enabled,
+        )
+}

--- a/crates/validator/src/alternator/batch_write_item.rs
+++ b/crates/validator/src/alternator/batch_write_item.rs
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemError;
+use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemOutput;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+use super::dynamo_float_list;
+
+fn build_put_requests(items: &[Item]) -> Vec<aws_sdk_dynamodb::types::WriteRequest> {
+    items
+        .iter()
+        .map(|item| {
+            let mut builder = aws_sdk_dynamodb::types::PutRequest::builder();
+            for (attr_name, attr_val) in &item.0 {
+                builder = builder.item(attr_name, attr_val.clone());
+            }
+            aws_sdk_dynamodb::types::WriteRequest::builder()
+                .put_request(builder.build().expect("failed to build PutRequest"))
+                .build()
+        })
+        .collect()
+}
+
+async fn batch_write_items(
+    ctx: &TableContext,
+    puts: &[Item],
+    deletes: &[Item],
+) -> Result<BatchWriteItemOutput, SdkError<BatchWriteItemError>> {
+    let mut write_requests = build_put_requests(puts);
+
+    write_requests.extend(deletes.iter().map(|item| {
+        let mut builder = aws_sdk_dynamodb::types::DeleteRequest::builder();
+        let key_attrs: Vec<&str> = std::iter::once(ctx.shape.pk())
+            .chain(ctx.shape.sk())
+            .collect();
+        for attr_name in key_attrs {
+            if let Some(attr_val) = item.0.get(attr_name) {
+                builder = builder.key(attr_name, attr_val.clone());
+            }
+        }
+        aws_sdk_dynamodb::types::WriteRequest::builder()
+            .delete_request(builder.build().expect("failed to build DeleteRequest"))
+            .build()
+    }));
+
+    ctx.client
+        .batch_write_item()
+        .request_items(&ctx.table_name, write_requests)
+        .send()
+        .await
+}
+
+/// Exercises `BatchWriteItem` (puts, replaces, mixed put+delete, delete-only)
+/// and verifies the VS index is updated correctly.
+///
+/// Loops [`NAME_PATTERNS`](super::NAME_PATTERNS) to cover all key schema and
+/// naming combinations.
+#[framed]
+async fn batch_write_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &super::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let ctx = TableContext::create(&actors, shape).await;
+        let vec_attr = ctx.shape.vec().expect("TableContext has no vec_attr");
+
+        let a = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]);
+        let b = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let c = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]);
+
+        info!(
+            "Batch writing initial put requests into '{}'",
+            ctx.table_name
+        );
+        batch_write_items(&ctx, &[a.clone(), b.clone(), c.clone()], &[])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[a.clone(), b.clone(), c.clone()])
+            .await;
+
+        // Replace a with a_replaced=[-1,-1,-1] - same key, vector points in the
+        // opposite direction so it falls to last position in ANN results.
+        // b=[1,2,4] and c=[1,4,8] retain their order.
+        let a_replaced =
+            Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [-1.0, -1.0, -1.0]);
+        batch_write_items(&ctx, std::slice::from_ref(&a_replaced), &[])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b.clone(), c.clone(), a_replaced.clone()])
+            .await;
+
+        // Mixed put + delete - add d, remove a (using a_replaced which holds the
+        // current state of that key).
+        info!(
+            "Batch writing mixed put and delete requests into '{}'",
+            ctx.table_name
+        );
+        let d = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "d").vec(vec_attr, [1.0, 1.0, 1.0]);
+        batch_write_items(&ctx, std::slice::from_ref(&d), &[a_replaced])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[d.clone(), b.clone(), c.clone()])
+            .await;
+
+        info!("Batch writing delete requests into '{}'", ctx.table_name);
+        batch_write_items(&ctx, &[], &[b, c])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_count(1).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&d))
+            .await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Tests that `BatchWriteItem` containing an item with an invalid vector type
+/// is rejected by Scylla and does not update the VS index. Covers string
+/// values, mixed-type lists, NULL elements, and wrong dimensions.
+#[framed]
+async fn batch_write_item_with_invalid_vector(actors: TestActors) {
+    info!("started");
+
+    let shape = &super::name_patterns()[0]; // plain names, HASH-only
+    let ctx = TableContext::create(&actors, shape).await;
+    let vec_attr = ctx.shape.vec().expect("TableContext has no vec_attr");
+
+    let pk = shape.pk();
+
+    let vec_with_string_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::S("3.0".into()),
+    ]);
+    let vec_with_null_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::Null(true),
+    ]);
+
+    info!(
+        "Scenario 1: batch put valid + no_vec into '{}'",
+        ctx.table_name
+    );
+    let valid = Item::key(pk, None, "pk", "valid").vec(vec_attr, [1.0, 1.0, 1.0]);
+    let no_vec = Item::key(pk, None, "pk", "no-vec");
+    batch_write_items(&ctx, &[valid.clone(), no_vec], &[])
+        .await
+        .expect("BatchWriteItem should succeed");
+    ctx.wait_for_count(1).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&valid))
+        .await;
+
+    info!(
+        "Scenario 2: batch put valid2 + wrong_type(String) into '{}'",
+        ctx.table_name
+    );
+    let valid2 = Item::key(pk, None, "pk", "valid2").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let wrong_type_string = Item::key(pk, None, "pk", "wrong-type-string")
+        .attr(vec_attr, AttributeValue::S("bad".into()));
+    super::assert_service_error(
+        batch_write_items(&ctx, &[valid2, wrong_type_string], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 3: batch put valid3 + wrong_type(mostly-float, one S) into '{}'",
+        ctx.table_name
+    );
+    let valid3 = Item::key(pk, None, "pk", "valid3").vec(vec_attr, [1.0, 4.0, 8.0]);
+    let wrong_type_mostly_float_one_s = Item::key(pk, None, "pk", "wrong-type-mostly-float-one-s")
+        .attr(vec_attr, vec_with_string_elem);
+    super::assert_service_error(
+        batch_write_items(&ctx, &[valid3, wrong_type_mostly_float_one_s], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 4: batch put valid4 + wrong_type(mostly-float, one NULL) into '{}'",
+        ctx.table_name
+    );
+    let valid4 = Item::key(pk, None, "pk", "valid4").vec(vec_attr, [-1.0, -1.0, -1.0]);
+    let wrong_type_mostly_float_one_null =
+        Item::key(pk, None, "pk", "wrong-type-mostly-float-one-null")
+            .attr(vec_attr, vec_with_null_elem);
+    super::assert_service_error(
+        batch_write_items(&ctx, &[valid4, wrong_type_mostly_float_one_null], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 5: batch put valid5 + wrong_type(too-short) into '{}'",
+        ctx.table_name
+    );
+    let valid5 = Item::key(pk, None, "pk", "valid5").vec(vec_attr, [1.0, 1.0, 2.0]);
+    let wrong_type_too_short = Item::key(pk, None, "pk", "wrong-type-too-short")
+        .attr(vec_attr, dynamo_float_list([1.0_f32, 1.0]));
+    super::assert_service_error(
+        batch_write_items(&ctx, &[valid5, wrong_type_too_short], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 6: batch put valid6 + wrong_type(too-long) into '{}'",
+        ctx.table_name
+    );
+    let valid6 = Item::key(pk, None, "pk", "valid6").vec(vec_attr, [2.0, 1.0, 1.0]);
+    let wrong_type_too_long = Item::key(pk, None, "pk", "wrong-type-too-long")
+        .attr(vec_attr, dynamo_float_list([1.0_f32, 1.0, 1.0, 1.0]));
+    super::assert_service_error(
+        batch_write_items(&ctx, &[valid6, wrong_type_too_long], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    ctx.done().await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "batch_write_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            batch_write_item_updates_index,
+        )
+        .with_test(
+            "batch_write_item_with_invalid_vector",
+            common::DEFAULT_TEST_TIMEOUT,
+            batch_write_item_with_invalid_vector,
+        )
+}

--- a/crates/validator/src/alternator/create_table.rs
+++ b/crates/validator/src/alternator/create_table.rs
@@ -1,0 +1,527 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use crate::common::wait_for_no_index;
+use async_backtrace::framed;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::context::AfterDeserializationInterceptorContextRef;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::config_bag::ConfigBag;
+use e2etest::TestCase;
+use httpapi::IndexInfo;
+use httpapi::IndexName;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tracing::info;
+
+use super::alternator_keyspace;
+use super::make_clients;
+use super::resolve_table_names;
+use super::unique_alternator_index_name;
+use super::unique_alternator_table_name;
+/// An SDK interceptor that captures the `VectorIndexes` extension field from
+/// the raw `DescribeTable` JSON response as a [`serde_json::Value`].  The
+/// caller retrieves it via [`into_captured`] after the SDK call completes and
+/// performs the assertions explicitly.
+///
+/// Attach this to a `client.describe_table().customize().interceptor(...)` call.
+/// It fires in [`read_after_deserialization`], at which point the response body
+/// has already been buffered by the SDK (via its internal `read_body()` call
+/// that precedes deserialization of non-streaming operations).
+///
+/// [`into_captured`]: VectorIndexesCaptureInterceptor::into_captured
+/// [`read_after_deserialization`]: Intercept::read_after_deserialization
+#[derive(Debug, Clone)]
+struct VectorIndexesCaptureInterceptor {
+    captured: Arc<Mutex<Option<serde_json::Value>>>,
+}
+
+impl VectorIndexesCaptureInterceptor {
+    fn new() -> Self {
+        Self {
+            captured: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Consume the interceptor and return the `VectorIndexes` JSON value
+    /// captured during the last `DescribeTable` call.  Returns `None` if
+    /// `read_after_deserialization` has not fired yet (i.e. the call has not
+    /// completed or failed before the response body was available).
+    fn into_captured(self) -> Option<serde_json::Value> {
+        // `unwrap`: poisoning here means a panic already occurred in the
+        // interceptor thread, which would surface as a test failure anyway.
+        Arc::try_unwrap(self.captured)
+            .expect("no other Arc clones should remain after the SDK call")
+            .into_inner()
+            .unwrap()
+    }
+}
+
+impl Intercept for VectorIndexesCaptureInterceptor {
+    fn name(&self) -> &'static str {
+        "VectorIndexesCaptureInterceptor"
+    }
+
+    fn read_after_deserialization(
+        &self,
+        context: &AfterDeserializationInterceptorContextRef<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let bytes = context
+            .response()
+            .body()
+            .bytes()
+            .ok_or("expected buffered response body for DescribeTable")?;
+
+        let json: serde_json::Value = serde_json::from_slice(bytes)?;
+
+        let table = json
+            .get("Table")
+            .ok_or("raw DescribeTable should contain 'Table' key")?;
+
+        // `VectorIndexes` is our extension field - capture it as-is so the
+        // test can assert on the full value.  Absence is stored as None and
+        // surfaced by the test assertion rather than aborting the SDK call.
+        *self.captured.lock().unwrap() = table.get("VectorIndexes").cloned();
+
+        Ok(())
+    }
+}
+
+/// Asserts that `actual` JSON contains all fields from `expected`, allowing
+/// additional attributes in objects. Arrays must match in length and each
+/// element is checked recursively. Scalar values must be exactly equal.
+fn assert_json_includes(actual: &serde_json::Value, expected: &serde_json::Value, ctx: &str) {
+    match (actual, expected) {
+        (serde_json::Value::Object(a), serde_json::Value::Object(e)) => {
+            for (k, v) in e {
+                let a_v = a
+                    .get(k)
+                    .unwrap_or_else(|| panic!("{ctx}: missing key {k:?}"));
+                assert_json_includes(a_v, v, &format!("{ctx}.{k}"));
+            }
+        }
+        (serde_json::Value::Array(a), serde_json::Value::Array(e)) => {
+            assert_eq!(a.len(), e.len(), "{ctx}: array length mismatch");
+            for (i, (a_v, e_v)) in a.iter().zip(e.iter()).enumerate() {
+                assert_json_includes(a_v, e_v, &format!("{ctx}[{i}]"));
+            }
+        }
+        _ => assert_eq!(actual, expected, "{ctx}: value mismatch"),
+    }
+}
+
+/// Creates, describes, and deletes Alternator tables for every entry in
+/// [`super::NAME_PATTERNS`] (the 2x2 matrix of plain/special x HASH-only/HASH+RANGE).
+/// For each shape the test:
+/// 1. Calls `CreateTable` with a vector index.
+/// 2. Waits for Vector Store to discover the index.
+/// 3. Calls `DescribeTable` and verifies the `VectorIndexes` extension field.
+/// 4. Calls `DeleteTable` and waits for Vector Store to drop the index.
+#[framed]
+async fn create_describe_and_delete_table_with_vector_index(actors: TestActors) {
+    info!("started");
+
+    let (client, vs_clients) = make_clients(&actors).await;
+
+    let patterns = super::name_patterns();
+    for (i, shape) in patterns.iter().enumerate() {
+        info!("NAME_PATTERNS[{i}]: {shape:?}");
+
+        let vec_attr = shape.vec().expect("NAME_PATTERNS entries always have vec");
+        let (table_name, index_name, index) = resolve_table_names(shape);
+
+        info!("Creating Alternator table '{table_name}' with VectorIndex '{index_name}'");
+        super::create_alternator_table(
+            &client,
+            &table_name,
+            shape.pk(),
+            aws_sdk_dynamodb::types::ScalarAttributeType::S,
+            shape.sk(),
+            &[(index.index.as_ref(), vec_attr, 3)],
+        )
+        .await
+        .expect("CreateTable with VectorIndex should succeed");
+
+        info!(
+            "Waiting for Vector Store to discover index '{}/{}'",
+            index.keyspace, index.index
+        );
+        common::wait_for_index(&vs_clients[0], &index).await;
+
+        info!("Describing Alternator table '{table_name}' and asserting VectorIndexes");
+        let interceptor = VectorIndexesCaptureInterceptor::new();
+        client
+            .describe_table()
+            .table_name(&table_name)
+            .customize()
+            .interceptor(interceptor.clone())
+            .send()
+            .await
+            .expect("DescribeTable should succeed");
+
+        let ctx = format!("NAME_PATTERNS[{i}]");
+        let captured = interceptor
+            .into_captured()
+            .expect("VectorIndexesCaptureInterceptor should have fired");
+        assert_json_includes(
+            &captured,
+            &serde_json::json!([{
+                "IndexName": index.index.as_ref(),
+                "VectorAttribute": { "AttributeName": vec_attr, "Dimensions": 3 },
+                "IndexStatus": "ACTIVE",
+                "Projection": { "ProjectionType": "KEYS_ONLY" }
+            }]),
+            &ctx,
+        );
+
+        info!("Deleting Alternator table '{table_name}'");
+        super::delete_alternator_table(&client, &table_name).await;
+
+        info!(
+            "Waiting for Vector Store to drop index '{}/{}'",
+            index.keyspace, index.index
+        );
+        wait_for_no_index(&vs_clients[0], &index).await;
+
+        info!("NAME_PATTERNS[{i}] passed");
+    }
+
+    info!("finished");
+}
+
+#[framed]
+async fn create_table_with_two_case_distinct_vector_indexes(actors: TestActors) {
+    info!("started");
+
+    let (client, vs_clients) = make_clients(&actors).await;
+
+    let table_name = unique_alternator_table_name();
+    let partition_key_name = "Pk-Case";
+    let unique_index_name = unique_alternator_index_name();
+    let lower_index_name: IndexName = unique_index_name.as_ref().to_ascii_lowercase().into();
+    let upper_index_name: IndexName = unique_index_name.as_ref().to_ascii_uppercase().into();
+    let lower_vector_attribute_name = "samevector";
+    let upper_vector_attribute_name = "SAMEVECTOR";
+    let lower_index = IndexInfo::new(
+        alternator_keyspace(&table_name).as_ref(),
+        lower_index_name.as_ref(),
+    );
+    let upper_index = IndexInfo::new(
+        alternator_keyspace(&table_name).as_ref(),
+        upper_index_name.as_ref(),
+    );
+
+    info!(
+        "Creating Alternator table '{table_name}' with case-distinct VectorIndexes '{}' and '{}'",
+        lower_index.index, upper_index.index
+    );
+    super::create_alternator_table(
+        &client,
+        &table_name,
+        partition_key_name,
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[
+            (lower_index.index.as_ref(), lower_vector_attribute_name, 3),
+            (upper_index.index.as_ref(), upper_vector_attribute_name, 3),
+        ],
+    )
+    .await
+    .expect("CreateTable with case-distinct VectorIndexes should succeed");
+    info!(
+        "Created Alternator table '{table_name}' with case-distinct VectorIndexes '{}' and '{}'",
+        lower_index.index, upper_index.index
+    );
+
+    common::wait_for_index(&vs_clients[0], &lower_index).await;
+    common::wait_for_index(&vs_clients[0], &upper_index).await;
+
+    super::delete_alternator_table(&client, &table_name).await;
+
+    wait_for_no_index(&vs_clients[0], &lower_index).await;
+    wait_for_no_index(&vs_clients[0], &upper_index).await;
+
+    info!("finished");
+}
+
+/// Verifies that two tables whose names differ **only in letter case** can
+/// each carry a vector index with the **same `IndexName`** string.
+///
+/// In Alternator every table lives in its own CQL keyspace
+/// (`alternator_<table>`), so index names are scoped to their table.  Two
+/// indexes with the same name on case-distinct tables are therefore fully
+/// independent, and both should be discovered and served by Vector Store.
+///
+/// This also confirms that Alternator table names are case-sensitive (i.e.
+/// `MyTable` and `mytable` are two separate tables).
+#[framed]
+async fn create_table_with_same_index_name_on_case_distinct_tables(actors: TestActors) {
+    info!("started");
+
+    let (client, vs_clients) = make_clients(&actors).await;
+
+    let base_name = unique_alternator_table_name();
+    let table_a = base_name.to_uppercase();
+    let table_b = base_name.to_lowercase();
+    let shared_index_name = unique_alternator_index_name();
+    let vec_attr = "vec";
+
+    let index_a = IndexInfo::new(
+        alternator_keyspace(&table_a).as_ref(),
+        shared_index_name.as_ref(),
+    );
+    let index_b = IndexInfo::new(
+        alternator_keyspace(&table_b).as_ref(),
+        shared_index_name.as_ref(),
+    );
+
+    info!(
+        "Creating table '{table_a}' with index '{}'",
+        shared_index_name
+    );
+    super::create_alternator_table(
+        &client,
+        &table_a,
+        "pk",
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(shared_index_name.as_ref(), vec_attr, 3)],
+    )
+    .await
+    .expect("CreateTable for table_a should succeed");
+
+    info!(
+        "Creating table '{table_b}' with the same index name '{}'",
+        shared_index_name
+    );
+    super::create_alternator_table(
+        &client,
+        &table_b,
+        "pk",
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(shared_index_name.as_ref(), vec_attr, 3)],
+    )
+    .await
+    .expect("CreateTable for table_b with same index name should succeed");
+
+    common::wait_for_index(&vs_clients[0], &index_a).await;
+    common::wait_for_index(&vs_clients[0], &index_b).await;
+
+    super::delete_alternator_table(&client, &table_a).await;
+    super::delete_alternator_table(&client, &table_b).await;
+
+    wait_for_no_index(&vs_clients[0], &index_a).await;
+    wait_for_no_index(&vs_clients[0], &index_b).await;
+
+    info!("finished");
+}
+
+/// Verifies that Alternator rejects a `CreateTable` request that specifies
+/// **two vector indexes both pointing at the same vector attribute** (same
+/// `AttributeName` and `Dimensions`, different `IndexName`).
+///
+/// The positive case - two indexes on *distinct* vector columns - is covered by
+/// `create_table_with_two_case_distinct_vector_indexes`.
+#[framed]
+async fn create_table_with_two_indexes_on_same_vector_column(actors: TestActors) {
+    info!("started");
+
+    let (client, _vs_clients) = make_clients(&actors).await;
+
+    let table_name = unique_alternator_table_name();
+    let index_a_name = unique_alternator_index_name();
+    let index_b_name = unique_alternator_index_name();
+    let vec_attr = "vec";
+
+    info!(
+        "Attempting CreateTable '{table_name}' with two indexes ('{}', '{}') on the same \
+         column '{vec_attr}' (expecting failure)",
+        index_a_name, index_b_name
+    );
+    let result = super::create_alternator_table(
+        &client,
+        &table_name,
+        "pk",
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[
+            (index_a_name.as_ref(), vec_attr, 3),
+            (index_b_name.as_ref(), vec_attr, 3),
+        ],
+    )
+    .await;
+
+    match result {
+        Err(err) => {
+            info!("CreateTable with two indexes on the same column correctly rejected: {err}");
+        }
+        Ok(_) => {
+            super::delete_alternator_table(&client, &table_name).await;
+            panic!(
+                "Expected CreateTable with two indexes on the same vector column to fail, \
+                 but it succeeded - Alternator now allows this; convert to a positive test."
+            );
+        }
+    }
+
+    info!("finished");
+}
+
+/// Verifies that Alternator rejects an index name exactly one character longer
+/// than the maximum allowed length.  The maximum is
+/// [`MAX_ALTERNATOR_INDEX_NAME_LEN`] (192 chars); a 193-char index name must be
+/// rejected.
+///
+/// The positive side (192-char index name succeeds) is covered by the special
+/// entries in [`super::NAME_PATTERNS`], exercised via
+/// `create_describe_and_delete_table_with_vector_index`.
+#[framed]
+async fn create_table_with_over_max_length_index_name(actors: TestActors) {
+    info!("started");
+
+    let (client, _vs_clients) = make_clients(&actors).await;
+
+    let table_name = unique_alternator_table_name();
+    let over_len = super::MAX_ALTERNATOR_INDEX_NAME_LEN + 1;
+    let index_name = super::pad_to_len(unique_alternator_index_name().as_ref(), over_len, 'X');
+    assert_eq!(index_name.len(), over_len);
+
+    info!("Creating table with {over_len}-char index name (should be rejected)");
+    let result = super::create_alternator_table(
+        &client,
+        &table_name,
+        "pk",
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(&index_name, "vec", 3)],
+    )
+    .await;
+
+    match result {
+        Err(err) => {
+            info!("CreateTable with {over_len}-char index name correctly rejected: {err}");
+        }
+        Ok(_) => {
+            super::delete_alternator_table(&client, &table_name).await;
+            panic!(
+                "Expected CreateTable with {over_len}-char index name to fail, but it succeeded. \
+                 The actual Alternator index name limit may be higher than {}.",
+                super::MAX_ALTERNATOR_INDEX_NAME_LEN
+            );
+        }
+    }
+
+    info!("finished");
+}
+
+/// The maximum supported vector dimension is 16000.  This test verifies:
+/// 1. `Dimensions=16001` is rejected (negative case).
+/// 2. `Dimensions=16000` is accepted using the same table/index names (positive case).
+#[framed]
+async fn create_table_with_boundary_dimensions(actors: TestActors) {
+    info!("started");
+
+    let (client, vs_clients) = make_clients(&actors).await;
+
+    let table_name = unique_alternator_table_name();
+    let index_name = unique_alternator_index_name();
+
+    let max_dimensions: usize = 16_000;
+
+    // -- Negative: max_dimensions + 1 must be rejected --------------------------
+    info!(
+        "Attempting CreateTable '{table_name}' with Dimensions={} (expecting failure)",
+        max_dimensions + 1
+    );
+    let result = super::create_alternator_table(
+        &client,
+        &table_name,
+        "pk",
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(index_name.as_ref(), "vec", max_dimensions + 1)],
+    )
+    .await;
+
+    match result {
+        Err(err) => {
+            info!(
+                "CreateTable with Dimensions={} was correctly rejected: {err}",
+                max_dimensions + 1
+            );
+        }
+        Ok(_) => {
+            super::delete_alternator_table(&client, &table_name).await;
+            panic!(
+                "Expected CreateTable with Dimensions={} to fail, but it succeeded.",
+                max_dimensions + 1
+            );
+        }
+    }
+
+    // -- Positive: max_dimensions must succeed (same table/index names) ----------
+    info!("Retrying with Dimensions={max_dimensions} (expecting success)");
+    super::create_alternator_table(
+        &client,
+        &table_name,
+        "pk",
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(index_name.as_ref(), "vec", max_dimensions)],
+    )
+    .await
+    .expect("CreateTable with Dimensions=16000 should succeed");
+
+    let index = super::IndexInfo::new(
+        super::alternator_keyspace(&table_name).as_ref(),
+        index_name.as_ref(),
+    );
+    crate::common::wait_for_index(&vs_clients[0], &index).await;
+
+    super::delete_alternator_table(&client, &table_name).await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "create_describe_and_delete_table_with_vector_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_describe_and_delete_table_with_vector_index,
+        )
+        .with_test(
+            "create_table_with_two_case_distinct_vector_indexes",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_table_with_two_case_distinct_vector_indexes,
+        )
+        .with_test(
+            "create_table_with_same_index_name_on_case_distinct_tables",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_table_with_same_index_name_on_case_distinct_tables,
+        )
+        .with_test(
+            "create_table_with_two_indexes_on_same_vector_column",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_table_with_two_indexes_on_same_vector_column,
+        )
+        .with_test(
+            "create_table_with_boundary_dimensions",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_table_with_boundary_dimensions,
+        )
+        .with_test(
+            "create_table_with_over_max_length_index_name",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_table_with_over_max_length_index_name,
+        )
+}

--- a/crates/validator/src/alternator/delete_item.rs
+++ b/crates/validator/src/alternator/delete_item.rs
@@ -54,6 +54,28 @@ async fn delete_item_updates_index(actors: TestActors) {
         ctx.wait_for_count(2).await;
         ctx.wait_for_ann([1.0, 1.0, 1.0], &[b.clone(), c]).await;
 
+        // Conditional DeleteItem exercises the LWT/Paxos path under
+        // `only_rmw_uses_lwt` (ConditionExpression makes it RMW).
+        info!(
+            "Step 2: conditional DeleteItem (passing condition) in '{}'",
+            ctx.table_name
+        );
+        let mut req = ctx
+            .client
+            .delete_item()
+            .table_name(&ctx.table_name)
+            .condition_expression("attribute_exists(#pk)")
+            .expression_attribute_names("#pk", ctx.shape.pk());
+        for attr_name in std::iter::once(ctx.shape.pk()).chain(ctx.shape.sk()) {
+            if let Some(attr_val) = b.0.get(attr_name) {
+                req = req.key(attr_name, attr_val.clone());
+            }
+        }
+        req.send()
+            .await
+            .expect("conditional DeleteItem with passing condition should succeed");
+        ctx.wait_for_count(1).await;
+
         ctx.done().await;
         info!("Shape {shape:?} passed");
     }

--- a/crates/validator/src/alternator/delete_item.rs
+++ b/crates/validator/src/alternator/delete_item.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use e2etest::TestCase;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+
+async fn delete_item(ctx: &TableContext, item: &Item) {
+    let mut req = ctx.client.delete_item().table_name(&ctx.table_name);
+    let key_attrs: Vec<&str> = std::iter::once(ctx.shape.pk())
+        .chain(ctx.shape.sk())
+        .collect();
+    for attr_name in key_attrs {
+        if let Some(attr_val) = item.0.get(attr_name) {
+            req = req.key(attr_name, attr_val.clone());
+        }
+    }
+    req.send().await.expect("DeleteItem should succeed");
+}
+
+/// Inserts items, deletes one via `DeleteItem`, and verifies the VS index
+/// reflects the deletion.
+///
+/// Loops [`NAME_PATTERNS`](super::NAME_PATTERNS) so that every combination
+/// of key schema (HASH-only / HASH+RANGE) and naming style (plain /
+/// special) is covered.
+#[framed]
+async fn delete_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &super::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let vec_attr = shape.vec().expect("NAME_PATTERNS entries always have vec");
+
+        let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]);
+        let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let c = Item::key(shape.pk(), shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]);
+
+        let ctx =
+            TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone(), c.clone()])
+                .await;
+
+        info!("Deleting item from '{}'", ctx.table_name);
+        delete_item(&ctx, &a).await;
+
+        ctx.wait_for_count(2).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b.clone(), c]).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "delete_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            delete_item_updates_index,
+        )
+}

--- a/crates/validator/src/alternator/lwt.rs
+++ b/crates/validator/src/alternator/lwt.rs
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+//! Integration test: Alternator with `--alternator-write-isolation=always_use_lwt`.
+//!
+//! Under `always_use_lwt` every write is routed through the LWT/Paxos path.
+//! The test verifies that Vector Store correctly indexes items written through
+//! this path by exercising `PutItem`, `DeleteItem`, `UpdateItem`, and
+//! `BatchWriteItem` (put-only, mixed put+delete, delete-only).
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use httpapi::IndexInfo;
+use tracing::info;
+
+use super::ALTERNATOR_PORT;
+use super::Item;
+use super::alternator_keyspace;
+use super::create_alternator_table;
+use super::dynamo_float_list;
+use super::make_clients;
+use super::unique_alternator_index_name;
+use super::unique_alternator_table_name;
+use super::wait_for_alternator;
+use super::wait_for_ann;
+use super::wait_for_index_count;
+
+/// Helper: build a PutItem `WriteRequest` from an `Item`.
+fn put_write_request(item: &Item) -> aws_sdk_dynamodb::types::WriteRequest {
+    let mut builder = aws_sdk_dynamodb::types::PutRequest::builder();
+    for (attr_name, attr_val) in &item.0 {
+        builder = builder.item(attr_name, attr_val.clone());
+    }
+    aws_sdk_dynamodb::types::WriteRequest::builder()
+        .put_request(builder.build().expect("failed to build PutRequest"))
+        .build()
+}
+
+/// Helper: build a DeleteItem `WriteRequest` from a pk attribute.
+fn delete_write_request(
+    pk_attr: &str,
+    pk_val: AttributeValue,
+) -> aws_sdk_dynamodb::types::WriteRequest {
+    aws_sdk_dynamodb::types::WriteRequest::builder()
+        .delete_request(
+            aws_sdk_dynamodb::types::DeleteRequest::builder()
+                .key(pk_attr, pk_val)
+                .build()
+                .expect("failed to build DeleteRequest"),
+        )
+        .build()
+}
+
+/// Verifies that VS correctly indexes writes made through the LWT path when
+/// `--alternator-write-isolation=always_use_lwt` is active.
+#[framed]
+async fn alternator_with_always_use_lwt(actors: TestActors) {
+    info!("started");
+
+    let mut scylla_configs = common::get_default_scylla_node_configs(&actors).await;
+    for config in &mut scylla_configs {
+        let node_ip = config.db_ip;
+        config.args.extend([
+            format!("--alternator-port={ALTERNATOR_PORT}"),
+            format!("--alternator-address={node_ip}"),
+            "--alternator-write-isolation=always_use_lwt".to_string(),
+            "--alternator-enforce-authorization=false".to_string(),
+        ]);
+    }
+
+    let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
+
+    info!("Initializing cluster with always_use_lwt write isolation");
+    let vs_configs = common::get_default_vs_node_configs(&actors).await;
+    common::init_with_config(actors.clone(), scylla_configs, vs_configs).await;
+
+    wait_for_alternator(db_ip).await;
+
+    let (client, vs_clients) = make_clients(&actors).await;
+    let vs_client = vs_clients
+        .into_iter()
+        .next()
+        .expect("need at least one VS client");
+
+    let table_name = unique_alternator_table_name();
+    let index_name = unique_alternator_index_name();
+    let pk_attr = "pk";
+    let vec_attr = "vec";
+
+    info!("Creating table '{table_name}' with index '{index_name}'");
+    create_alternator_table(
+        &client,
+        &table_name,
+        pk_attr,
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(index_name.as_ref(), vec_attr, 3)],
+    )
+    .await
+    .expect("CreateTable with vector index should succeed");
+
+    let index = IndexInfo::new(
+        alternator_keyspace(&table_name).as_ref(),
+        index_name.as_ref(),
+    );
+
+    common::wait_for_index(&vs_client, &index).await;
+    info!("VS discovered index '{index_name}'");
+
+    info!("Writing item-a and item-b via PutItem (LWT path)");
+    client
+        .put_item()
+        .table_name(&table_name)
+        .item(pk_attr, AttributeValue::S("item-a".into()))
+        .item(vec_attr, dynamo_float_list([1.0_f32, 2.0, 4.0]))
+        .send()
+        .await
+        .expect("PutItem item-a should succeed");
+
+    client
+        .put_item()
+        .table_name(&table_name)
+        .item(pk_attr, AttributeValue::S("item-b".into()))
+        .item(vec_attr, dynamo_float_list([4.0_f32, 2.0, 1.0]))
+        .send()
+        .await
+        .expect("PutItem item-b should succeed");
+
+    wait_for_index_count(&vs_client, &index, 2).await;
+    info!("VS indexed 2 items via PutItem LWT path");
+
+    info!("Deleting item-b via DeleteItem (LWT path)");
+    client
+        .delete_item()
+        .table_name(&table_name)
+        .key(pk_attr, AttributeValue::S("item-b".into()))
+        .send()
+        .await
+        .expect("DeleteItem item-b should succeed");
+
+    wait_for_index_count(&vs_client, &index, 1).await;
+    info!("VS correctly removed deleted item from index");
+
+    // Count doesn't change, so we verify via ANN ordering.
+    info!("Updating item-a vector via UpdateItem SET (LWT path)");
+    client
+        .update_item()
+        .table_name(&table_name)
+        .key(pk_attr, AttributeValue::S("item-a".into()))
+        .update_expression("SET #vec = :vec")
+        .expression_attribute_names("#vec", vec_attr)
+        .expression_attribute_values(":vec", dynamo_float_list([1.0_f32, 1.0, 1.0]))
+        .send()
+        .await
+        .expect("UpdateItem item-a should succeed");
+
+    wait_for_ann(
+        &vs_client,
+        &index,
+        pk_attr,
+        None,
+        [1.0, 1.0, 1.0],
+        &[Item::new(pk_attr, AttributeValue::S("item-a".into()))],
+    )
+    .await;
+    info!("VS correctly reflects UpdateItem vector change via LWT path");
+
+    let batch_a =
+        Item::new(pk_attr, AttributeValue::S("batch-a".into())).vec(vec_attr, [1.0_f32, 2.0, 4.0]);
+    let batch_b =
+        Item::new(pk_attr, AttributeValue::S("batch-b".into())).vec(vec_attr, [4.0_f32, 2.0, 1.0]);
+
+    info!("Writing batch-a and batch-b via BatchWriteItem (LWT path)");
+    client
+        .batch_write_item()
+        .request_items(
+            &table_name,
+            vec![put_write_request(&batch_a), put_write_request(&batch_b)],
+        )
+        .send()
+        .await
+        .expect("BatchWriteItem (put batch-a, batch-b) should succeed");
+
+    wait_for_index_count(&vs_client, &index, 3).await;
+    info!("VS indexed BatchWriteItem puts via LWT path");
+
+    // ANN([-1,-1,-1], limit=3): batch-c first, batch-b second, item-a last.
+    let batch_c = Item::new(pk_attr, AttributeValue::S("batch-c".into()))
+        .vec(vec_attr, [-1.0_f32, -1.0, -1.0]);
+
+    info!("Mixed BatchWriteItem (put batch-c, delete batch-a) via LWT path");
+    client
+        .batch_write_item()
+        .request_items(
+            &table_name,
+            vec![
+                put_write_request(&batch_c),
+                delete_write_request(pk_attr, AttributeValue::S("batch-a".into())),
+            ],
+        )
+        .send()
+        .await
+        .expect("BatchWriteItem (put batch-c, delete batch-a) should succeed");
+
+    wait_for_index_count(&vs_client, &index, 3).await;
+
+    wait_for_ann(
+        &vs_client,
+        &index,
+        pk_attr,
+        None,
+        [-1.0, -1.0, -1.0],
+        &[
+            Item::new(pk_attr, AttributeValue::S("batch-c".into())),
+            Item::new(pk_attr, AttributeValue::S("batch-b".into())),
+            Item::new(pk_attr, AttributeValue::S("item-a".into())),
+        ],
+    )
+    .await;
+    info!("VS correctly reflects mixed BatchWriteItem via LWT path");
+
+    info!("Delete-only BatchWriteItem (delete batch-b, batch-c) via LWT path");
+    client
+        .batch_write_item()
+        .request_items(
+            &table_name,
+            vec![
+                delete_write_request(pk_attr, AttributeValue::S("batch-b".into())),
+                delete_write_request(pk_attr, AttributeValue::S("batch-c".into())),
+            ],
+        )
+        .send()
+        .await
+        .expect("BatchWriteItem (delete batch-b, batch-c) should succeed");
+
+    wait_for_index_count(&vs_client, &index, 1).await;
+    info!("VS correctly reflects delete-only BatchWriteItem via LWT path");
+
+    info!("Cleaning up");
+    common::cleanup(actors).await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "alternator_with_always_use_lwt",
+            common::DEFAULT_TEST_TIMEOUT,
+            alternator_with_always_use_lwt,
+        )
+}

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -6,6 +6,7 @@
 mod batch_write_item;
 mod create_table;
 mod delete_item;
+mod lwt;
 mod put_item;
 mod query;
 mod ttl;
@@ -106,6 +107,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
         ("alternator_ttl".into(), ttl::new().await),
         ("alternator_query".into(), query::new().await),
         ("alternator_types".into(), types::new().await),
+        ("alternator_lwt".into(), lwt::new().await),
     ]
 }
 

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -7,6 +7,7 @@ mod batch_write_item;
 mod create_table;
 mod delete_item;
 mod put_item;
+mod query;
 mod ttl;
 mod update_item;
 mod update_table;
@@ -102,6 +103,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
             batch_write_item::new().await,
         ),
         ("alternator_ttl".into(), ttl::new().await),
+        ("alternator_query".into(), query::new().await),
     ]
 }
 
@@ -281,6 +283,14 @@ impl Item {
     fn sk(mut self, sk_attr: &str, sk_val: AttributeValue) -> Self {
         self.0.insert(sk_attr.to_string(), sk_val);
         self
+    }
+
+    fn maybe_sk(self, sk_attr: Option<&str>, sk_val: AttributeValue) -> Self {
+        if let Some(sk) = sk_attr {
+            self.sk(sk, sk_val)
+        } else {
+            self
+        }
     }
 
     fn vec(mut self, vec_attr: &str, v: [f32; 3]) -> Self {

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -1,0 +1,852 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+mod create_table;
+mod update_table;
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_config::BehaviorVersion;
+use aws_credential_types::Credentials;
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::config::Region;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::create_table::CreateTableError;
+use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
+use aws_sdk_dynamodb::operation::delete_table::DeleteTableError;
+use aws_sdk_dynamodb::types::AttributeDefinition;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::BillingMode;
+use aws_sdk_dynamodb::types::KeySchemaElement;
+use aws_sdk_dynamodb::types::KeyType;
+use aws_sdk_dynamodb::types::ScalarAttributeType;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::config_bag::ConfigBag;
+use e2etest::TestCase;
+use http::HeaderValue;
+use http::header::CONTENT_LENGTH;
+use httpapi::ColumnName;
+use httpapi::IndexInfo;
+use httpapi::IndexName;
+use httpapi::KeyspaceName;
+use httpapi::Limit;
+use httpapi::Vector;
+use httpclient::HttpClient;
+use serde_json::Map;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::net::Ipv4Addr;
+use std::num::NonZeroUsize;
+use std::sync::atomic::AtomicUsize;
+use std::time::Duration;
+use tracing::info;
+use tracing::warn;
+static TABLE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static INDEX_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_alternator_table_name() -> String {
+    common::unique_name("Alt-Tbl", &TABLE_COUNTER)
+}
+
+fn unique_alternator_index_name() -> IndexName {
+    common::unique_name("Alt-Idx", &INDEX_COUNTER).into()
+}
+
+/// Maximum DynamoDB table name length accepted by ScyllaDB Alternator.
+///
+/// DynamoDB allows up to 255 characters, but ScyllaDB lowers this:
+/// Scylla stores each table in a directory named `<table>-<UUID>` (33 extra
+/// bytes), and Linux limits directory names to 255 bytes, capping CQL names
+/// at 222. Alternator then lowers it further to 192 to leave room for the
+/// `_scylla_cdc_log` suffix (15 chars) added when CDC/streams are enabled.
+/// See ScyllaDB `alternator/executor_util.hh`: `max_table_name_length = 192`.
+const MAX_ALTERNATOR_TABLE_NAME_LEN: usize = 192;
+
+/// Maximum DynamoDB vector index name length accepted by ScyllaDB Alternator.
+///
+/// Alternator validates index names with the same function and limit as table
+/// names. Documented in ScyllaDB `docs/alternator/vector-search.md`:
+/// "`IndexName`: 3–192 characters, matching the regex `[a-zA-Z0-9._-]+`".
+const MAX_ALTERNATOR_INDEX_NAME_LEN: usize = MAX_ALTERNATOR_TABLE_NAME_LEN;
+
+/// Maximum DynamoDB attribute name length in bytes.
+///
+/// Per AWS DynamoDB naming rules: attribute names must be between 1 and 255
+/// bytes long (UTF-8 encoded).
+/// See <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html>.
+const MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN: usize = 255;
+
+#[framed]
+pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
+    vec![
+        ("alternator_create_table".into(), create_table::new().await),
+        ("alternator_update_table".into(), update_table::new().await),
+    ]
+}
+
+const ALTERNATOR_PORT: u16 = 8000;
+
+/// In ScyllaDB Alternator, a DynamoDB table named `T` is stored under the CQL
+/// keyspace `alternator_T`. Vector Store discovers indexes by scanning
+/// `system_schema.indexes`, so the keyspace name is what VS uses to identify
+/// an Alternator-backed index.
+fn alternator_keyspace(table_name: &str) -> KeyspaceName {
+    format!("alternator_{table_name}").into()
+}
+
+/// A DynamoDB SDK interceptor that injects arbitrary key/value pairs into the
+/// JSON request body before SigV4 signing.
+///
+/// The standard `aws-sdk-dynamodb` crate serialises requests without knowledge
+/// of ScyllaDB Alternator extension fields such as `VectorIndexes`.  This
+/// interceptor fires in [`modify_before_signing`], reads the already-serialised
+/// JSON body, merges the provided fields, re-serialises, replaces the body, and
+/// updates the `Content-Length` header so the SigV4 signature and HTTP transport
+/// both operate on the correct byte count.
+///
+/// # Example
+/// ```ignore
+/// client
+///     .create_table()
+///     // ...
+///     .customize()
+///     .interceptor(JsonBodyInjectInterceptor::new([
+///         ("VectorIndexes", vector_indexes_json),
+///     ]))
+///     .send()
+///     .await?;
+/// ```
+///
+/// [`modify_before_signing`]: Intercept::modify_before_signing
+#[derive(Debug, Clone)]
+struct JsonBodyInjectInterceptor {
+    fields: Map<String, Value>,
+}
+
+impl JsonBodyInjectInterceptor {
+    /// Creates a new interceptor that will inject the given `fields` into every
+    /// outgoing request body.
+    fn new(fields: impl IntoIterator<Item = (impl Into<String>, Value)>) -> Self {
+        Self {
+            fields: fields.into_iter().map(|(k, v)| (k.into(), v)).collect(),
+        }
+    }
+}
+
+impl Intercept for JsonBodyInjectInterceptor {
+    fn name(&self) -> &'static str {
+        "JsonBodyInjectInterceptor"
+    }
+
+    fn modify_before_signing(
+        &self,
+        context: &mut BeforeTransmitInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let new_bytes = {
+            let original = context
+                .request()
+                .body()
+                .bytes()
+                .ok_or("expected in-memory body for Alternator request")?
+                .to_vec();
+
+            let mut json: Value = serde_json::from_slice(&original)?;
+            let obj = json
+                .as_object_mut()
+                .ok_or("expected JSON object body for Alternator request")?;
+            for (key, value) in &self.fields {
+                obj.insert(key.clone(), value.clone());
+            }
+            serde_json::to_vec(&json)?
+        };
+
+        let new_len = new_bytes.len();
+
+        let request = context.request_mut();
+        *request.body_mut() = SdkBody::from(new_bytes);
+        request.headers_mut().insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&new_len.to_string()).expect("content-length value is valid"),
+        );
+
+        Ok(())
+    }
+}
+
+/// Builds a DynamoDB client pointing at the ScyllaDB Alternator endpoint on
+/// `db_ip`.
+///
+/// Dummy AWS credentials are used because authorization is disabled in tests
+/// via `--alternator-enforce-authorization=false`.
+async fn make_dynamodb_client(db_ip: Ipv4Addr) -> Client {
+    let creds = Credentials::new("any", "any", None, None, "test");
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .credentials_provider(creds)
+        .endpoint_url(format!("http://{db_ip}:{ALTERNATOR_PORT}"))
+        .region(Region::new("us-east-1"))
+        .load()
+        .await;
+    Client::new(&config)
+}
+
+/// Polls the Alternator HTTP endpoint on `db_ip` until it responds successfully.
+///
+/// The Alternator port may become available slightly after the CQL port (which
+/// is what `db.wait_for_ready()` checks), so `init` should call this once after
+/// the cluster has started before any tests run.
+async fn wait_for_alternator(db_ip: Ipv4Addr) {
+    let client = make_dynamodb_client(db_ip).await;
+    common::wait_for(
+        || {
+            let c = client.clone();
+            async move { c.list_tables().limit(1).send().await.is_ok() }
+        },
+        format!("Alternator endpoint at http://{db_ip}:{ALTERNATOR_PORT} to be ready"),
+        common::DEFAULT_TEST_TIMEOUT,
+    )
+    .await;
+}
+
+async fn make_clients(actors: &TestActors) -> (Client, Vec<HttpClient>) {
+    let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
+    let dynamodb_client = make_dynamodb_client(db_ip).await;
+    let vs_clients = common::get_default_vs_ips(actors)
+        .into_iter()
+        .map(|ip| HttpClient::new((ip, common::VS_PORT).into()))
+        .collect();
+    (dynamodb_client, vs_clients)
+}
+
+fn dynamo_float_list(values: impl IntoIterator<Item = f32>) -> AttributeValue {
+    AttributeValue::L(
+        values
+            .into_iter()
+            .map(|value| AttributeValue::N(value.to_string()))
+            .collect(),
+    )
+}
+
+/// A single DynamoDB item for test operations - a flat map of attribute
+/// name -> `AttributeValue`. Constructed via builder chain:
+///
+/// ```ignore
+/// Item::new("pk", AttributeValue::S("pk-a".into()))
+///     .vec("vec", [1.0, 2.0, 3.0])
+///     .attr("ttl", AttributeValue::N("1234".into()))
+/// ```
+#[derive(Debug, Clone)]
+struct Item(pub HashMap<String, AttributeValue>);
+
+impl Item {
+    fn new(pk_attr: &str, pk_val: AttributeValue) -> Self {
+        let mut map = HashMap::new();
+        map.insert(pk_attr.to_string(), pk_val);
+        Self(map)
+    }
+
+    /// HASH-only -> `pk="{prefix}-{suffix}"`,
+    /// HASH+RANGE -> `pk=prefix, sk=suffix`.
+    fn key(pk_attr: &str, sk_attr: Option<&str>, pk_prefix: &str, suffix: &str) -> Self {
+        if let Some(sk) = sk_attr {
+            Self::new(pk_attr, AttributeValue::S(pk_prefix.to_string()))
+                .sk(sk, AttributeValue::S(suffix.to_string()))
+        } else {
+            Self::new(pk_attr, AttributeValue::S(format!("{pk_prefix}-{suffix}")))
+        }
+    }
+
+    fn sk(mut self, sk_attr: &str, sk_val: AttributeValue) -> Self {
+        self.0.insert(sk_attr.to_string(), sk_val);
+        self
+    }
+
+    fn vec(mut self, vec_attr: &str, v: [f32; 3]) -> Self {
+        self.0.insert(vec_attr.to_string(), dynamo_float_list(v));
+        self
+    }
+
+    fn attr(mut self, name: &str, val: AttributeValue) -> Self {
+        self.0.insert(name.to_string(), val);
+        self
+    }
+}
+
+async fn wait_for_index_count(client: &HttpClient, index: &IndexInfo, expected_count: usize) {
+    common::wait_for(
+        || async {
+            client
+                .index_status(&index.keyspace, &index.index)
+                .await
+                .is_ok_and(|resp| {
+                    resp.status == httpapi::IndexStatus::Serving && resp.count == expected_count
+                })
+        },
+        format!(
+            "index '{}/{}' to report count {} at {}",
+            index.keyspace,
+            index.index,
+            expected_count,
+            client.url()
+        ),
+        Duration::from_secs(60),
+    )
+    .await;
+}
+
+/// Polls ANN until the returned keys match `expected` position-by-position.
+async fn wait_for_ann(
+    client: &HttpClient,
+    index: &IndexInfo,
+    pk_name: &str,
+    sk_name: Option<&str>,
+    query_vector: [f32; 3],
+    expected: &[Item],
+) {
+    let pk_column: ColumnName = pk_name.into();
+    let sk_column: Option<ColumnName> = sk_name.map(|s| s.into());
+    let expect_count = expected.len();
+
+    let expected_keys: Vec<(String, Option<String>)> = expected
+        .iter()
+        .map(|item| {
+            let pk = av_to_key_string(item.0.get(pk_name).expect("expected Item has no pk attr"));
+            let sk = sk_name
+                .map(|sk| av_to_key_string(item.0.get(sk).expect("expected Item has no sk attr")));
+            (pk, sk)
+        })
+        .collect();
+
+    common::wait_for(
+        || async {
+            let (primary_keys, _distances, _scores) = client
+                .ann(
+                    &index.keyspace,
+                    &index.index,
+                    Vector::from(query_vector.to_vec()),
+                    None,
+                    Limit::from(
+                        NonZeroUsize::new(expect_count)
+                            .expect("expected ANN result set is non-empty"),
+                    ),
+                )
+                .await;
+
+            let Some(pk_values) = primary_keys.get(&pk_column) else {
+                return false;
+            };
+            if pk_values.len() != expect_count {
+                return false;
+            }
+
+            let sk_values: Option<&Vec<Value>> = match sk_column.as_ref() {
+                None => None,
+                Some(col) => primary_keys.get(col),
+            };
+            if sk_column.is_some() && sk_values.is_none() {
+                return false;
+            }
+
+            for (i, (exp_pk, exp_sk)) in expected_keys.iter().enumerate() {
+                let got_pk = json_value_to_key_string(&pk_values[i]);
+                if got_pk != *exp_pk {
+                    return false;
+                }
+                if let (Some(sk_vals), Some(exp_sk_str)) = (sk_values, exp_sk) {
+                    let got_sk = json_value_to_key_string(&sk_vals[i]);
+                    if got_sk != *exp_sk_str {
+                        return false;
+                    }
+                }
+            }
+
+            true
+        },
+        format!(
+            "index '{}/{}' to return expected ANN keys at {}",
+            index.keyspace,
+            index.index,
+            client.url()
+        ),
+        Duration::from_secs(60),
+    )
+    .await
+}
+
+/// Converts an `AttributeValue` to a string for key comparison.
+fn av_to_key_string(av: &AttributeValue) -> String {
+    match av {
+        AttributeValue::S(s) => s.clone(),
+        AttributeValue::N(n) => n.clone(),
+        AttributeValue::B(b) => b.as_ref().iter().fold(String::new(), |mut s, byte| {
+            let _ = write!(s, "{byte:02x}");
+            s
+        }),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Converts a `serde_json::Value` (from VS ANN response) to a string for
+/// key comparison. Strips `0x` prefix from blob hex strings.
+fn json_value_to_key_string(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.strip_prefix("0x").unwrap_or(s).to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => panic!("unexpected ANN key JSON value: {other:?}"),
+    }
+}
+
+/// Creates an Alternator table with the given key schema and optional vector
+/// indexes. Pass `&[]` for `vector_indexes` to create a plain table.
+async fn create_alternator_table(
+    client: &Client,
+    table_name: &str,
+    partition_key_name: &str,
+    pk_type: ScalarAttributeType,
+    sort_key_name: Option<&str>,
+    vector_indexes: &[(&str, &str, usize)],
+) -> Result<CreateTableOutput, SdkError<CreateTableError>> {
+    let mut builder = client
+        .create_table()
+        .table_name(table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name(partition_key_name)
+                .attribute_type(pk_type)
+                .build()
+                .expect("failed to build AttributeDefinition"),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name(partition_key_name)
+                .key_type(KeyType::Hash)
+                .build()
+                .expect("failed to build KeySchemaElement"),
+        )
+        .billing_mode(BillingMode::PayPerRequest);
+
+    if let Some(sk) = sort_key_name {
+        builder = builder
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name(sk)
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .expect("failed to build AttributeDefinition"),
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name(sk)
+                    .key_type(KeyType::Range)
+                    .build()
+                    .expect("failed to build KeySchemaElement"),
+            );
+    }
+
+    if vector_indexes.is_empty() {
+        builder.send().await
+    } else {
+        let indexes_json = serde_json::json!(
+            vector_indexes
+                .iter()
+                .map(|(index_name, vec_attr, dims)| {
+                    serde_json::json!({
+                        "IndexName": index_name,
+                        "VectorAttribute": {
+                            "AttributeName": vec_attr,
+                            "Dimensions": dims
+                        }
+                    })
+                })
+                .collect::<Vec<_>>()
+        );
+        builder
+            .customize()
+            .interceptor(JsonBodyInjectInterceptor::new([(
+                "VectorIndexes",
+                indexes_json,
+            )]))
+            .send()
+            .await
+    }
+}
+
+/// Issues an `UpdateTable` request with the given `VectorIndexUpdates` JSON.
+async fn update_table_vector_indexes(
+    client: &Client,
+    table_name: &str,
+    vector_index_updates: Value,
+) {
+    client
+        .update_table()
+        .table_name(table_name)
+        .customize()
+        .interceptor(JsonBodyInjectInterceptor::new([(
+            "VectorIndexUpdates",
+            vector_index_updates,
+        )]))
+        .send()
+        .await
+        .expect("UpdateTable with VectorIndexUpdates should succeed");
+}
+
+async fn delete_alternator_table(client: &Client, table_name: &str) {
+    client
+        .delete_table()
+        .table_name(table_name)
+        .send()
+        .await
+        .expect("DeleteTable should succeed");
+}
+
+/// Standard test init: starts ScyllaDB with the Alternator endpoint enabled on
+/// each node's own IP, alongside the Vector Store.
+#[framed]
+pub async fn init(actors: TestActors) {
+    info!("started");
+
+    let mut scylla_configs = common::get_default_scylla_node_configs(&actors).await;
+
+    for config in &mut scylla_configs {
+        let node_ip = config.db_ip;
+        config.args.extend([
+            format!("--alternator-port={ALTERNATOR_PORT}"),
+            format!("--alternator-address={node_ip}"),
+            "--alternator-write-isolation=only_rmw_uses_lwt".to_string(),
+            "--alternator-enforce-authorization=false".to_string(),
+            // NOTE: --alternator-ttl-period-in-seconds is already set in
+            // DEFAULT_SCYLLA_ARGS (0.5s). ScyllaDB rejects duplicate flags.
+        ]);
+    }
+
+    // Capture db_ip before actors is moved into init_with_config.
+    let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
+    let vs_configs = common::get_default_vs_node_configs(&actors).await;
+    common::init_with_config(actors, scylla_configs, vs_configs).await;
+
+    wait_for_alternator(db_ip).await;
+    info!("finished");
+}
+
+/// Describes the key schema, attribute names, and name prefixes for a test
+/// table. Controls what [`TableContext::create`] builds. See
+/// [`name_patterns`] for the standard 2x2 test matrix.
+#[derive(Debug, Clone)]
+struct TableShape {
+    /// When `Some`, the table name base is padded and composed with a unique
+    /// suffix so that the total equals [`MAX_ALTERNATOR_TABLE_NAME_LEN`].
+    /// When `None`, a plain unique name is used.
+    pub table_prefix: Option<&'static str>,
+    /// Same as `table_prefix`, but for the index name.
+    pub index_prefix: Option<&'static str>,
+    pub pk_name: String,
+    pub sk_name: Option<String>,
+    pub vec_name: Option<String>,
+    /// Scalar type of the partition key attribute.  Use `ScalarAttributeType::S`
+    /// for the default string key; `N` or `B` for numeric / binary key tests.
+    pub pk_type: ScalarAttributeType,
+}
+
+impl TableShape {
+    pub fn pk(&self) -> &str {
+        &self.pk_name
+    }
+    pub fn sk(&self) -> Option<&str> {
+        self.sk_name.as_deref()
+    }
+    pub fn vec(&self) -> Option<&str> {
+        self.vec_name.as_deref()
+    }
+}
+
+//
+// Base strings contain the "interesting" characters we want to test:
+// ASCII special chars, mixed case, hyphens, dots, and multi-byte UTF-8
+// (Cyrillic 2-byte, CJK 3-byte, emoji 4-byte).  The `pad_to_len` helper
+// extends them to the exact maximum length with ASCII 'X' padding.
+
+/// Pads `base` with `pad` bytes to exactly `len` bytes.
+///
+/// # Panics
+/// Panics if `base` is already longer than `len`.
+fn pad_to_len(base: &str, len: usize, pad: char) -> String {
+    assert!(
+        base.len() <= len,
+        "base ({} bytes) exceeds target length ({len})",
+        base.len()
+    );
+    let mut s = String::with_capacity(len);
+    s.push_str(base);
+    for _ in 0..(len - base.len()) {
+        s.push(pad);
+    }
+    debug_assert_eq!(s.len(), len);
+    s
+}
+
+/// Base for special table-name prefixes - tests hyphens, dots, mixed case.
+const SPECIAL_TABLE_BASE: &str = "123-With.Hyphens_UPPER.MixedCase-";
+
+/// Base for special index-name prefixes - tests hyphens, dots, mixed case.
+const SPECIAL_INDEX_BASE: &str = "123-idx.With.Hyphens_UPPER-MixedCase-";
+
+/// Base for special attribute names - tests ASCII punctuation, Cyrillic
+/// (2-byte UTF-8), CJK (3-byte UTF-8), and emoji (4-byte UTF-8).
+const SPECIAL_ATTR_BASE_PK: &str = "1:pk'.\".\\@#$ кириллица 中文 αβ 🦀 ";
+const SPECIAL_ATTR_BASE_SK: &str = "1:sk'.\".\\@#$ кириллица 中文 αβ 🦀 ";
+const SPECIAL_ATTR_BASE_VEC: &str = "1:vec'.\".\\@#$ кириллица 中文 αβ 🦀 ";
+
+/// The 2x2 matrix of table shapes exercised by every `_with_names` test.
+///
+/// Each basic-operation test (`put_item`, `delete_item`, `update_item`,
+/// `batch_write_item`, etc.) loops over this slice so that every operation
+/// is verified against all four combinations:
+///
+/// | Entry | Names | Key schema |
+/// |-------|-------|------------|
+/// | 0 | plain | HASH-only |
+/// | 1 | plain | HASH+RANGE |
+/// | 2 | special (max-length + special chars) | HASH-only |
+/// | 3 | special (max-length + special chars) | HASH+RANGE |
+fn name_patterns() -> Vec<TableShape> {
+    vec![
+        // 0: plain, HASH-only
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "pk".into(),
+            sk_name: None,
+            vec_name: Some("vec".into()),
+            pk_type: ScalarAttributeType::S,
+        },
+        // 1: plain, HASH+RANGE
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "pk".into(),
+            sk_name: Some("sk".into()),
+            vec_name: Some("vec".into()),
+            pk_type: ScalarAttributeType::S,
+        },
+        // 2: special, HASH-only
+        TableShape {
+            table_prefix: Some(SPECIAL_TABLE_BASE),
+            index_prefix: Some(SPECIAL_INDEX_BASE),
+            pk_name: pad_to_len(SPECIAL_ATTR_BASE_PK, MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN, 'X'),
+            sk_name: None,
+            vec_name: Some(pad_to_len(
+                SPECIAL_ATTR_BASE_VEC,
+                MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN,
+                'X',
+            )),
+            pk_type: ScalarAttributeType::S,
+        },
+        // 3: special, HASH+RANGE
+        TableShape {
+            table_prefix: Some(SPECIAL_TABLE_BASE),
+            index_prefix: Some(SPECIAL_INDEX_BASE),
+            pk_name: pad_to_len(SPECIAL_ATTR_BASE_PK, MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN, 'X'),
+            sk_name: Some(pad_to_len(
+                SPECIAL_ATTR_BASE_SK,
+                MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN,
+                'X',
+            )),
+            vec_name: Some(pad_to_len(
+                SPECIAL_ATTR_BASE_VEC,
+                MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN,
+                'X',
+            )),
+            pk_type: ScalarAttributeType::S,
+        },
+    ]
+}
+
+/// Resolves the final table name, index name, and [`IndexInfo`] from a
+/// [`TableShape`].  When a prefix is `Some`, the unique name is appended
+/// with a `"_"` separator and the prefix is padded so the total hits the
+/// maximum length. When `None`, a plain unique name is used.
+///
+/// This is the single source of truth for name construction - used by both
+/// [`TableContext::create`] and tests that manage the table lifecycle directly.
+fn resolve_table_names(shape: &TableShape) -> (String, String, IndexInfo) {
+    let table_name = match shape.table_prefix {
+        None => unique_alternator_table_name(),
+        Some(base) => {
+            let raw = format!("{base}_{}", unique_alternator_table_name());
+            pad_to_len(&raw, MAX_ALTERNATOR_TABLE_NAME_LEN, 'X')
+        }
+    };
+    let index_name = match shape.index_prefix {
+        None => unique_alternator_index_name().to_string(),
+        Some(base) => {
+            let raw = format!("{base}_{}", unique_alternator_index_name());
+            pad_to_len(&raw, MAX_ALTERNATOR_INDEX_NAME_LEN, 'X')
+        }
+    };
+    let index = IndexInfo::new(alternator_keyspace(&table_name).as_ref(), &index_name);
+    (table_name, index_name, index)
+}
+
+// ---------------------------------------------------------------------------
+
+/// Test fixture that encapsulates the create-table -> wait -> operate -> cleanup
+/// cycle. `done()` is idempotent (swallows `ResourceNotFoundException`).
+struct TableContext {
+    pub client: Client,
+    pub vs_client: HttpClient,
+    pub table_name: String,
+    pub index: IndexInfo,
+    pub shape: TableShape,
+}
+
+impl TableContext {
+    /// Creates a new Alternator table and (optionally) a vector index.
+    async fn create(actors: &TestActors, shape: &TableShape) -> Self {
+        let (client, vs_clients) = make_clients(actors).await;
+        let vs_client = vs_clients
+            .into_iter()
+            .next()
+            .expect("need at least one VS client");
+
+        let (table_name, _, index) = resolve_table_names(shape);
+
+        let indexes: Vec<(&str, &str, usize)> = match shape.vec() {
+            Some(va) => vec![(index.index.as_ref(), va, 3)],
+            None => vec![],
+        };
+        create_alternator_table(
+            &client,
+            &table_name,
+            shape.pk(),
+            shape.pk_type.clone(),
+            shape.sk(),
+            &indexes,
+        )
+        .await
+        .expect("CreateTable should succeed");
+        if shape.vec().is_some() {
+            common::wait_for_index(&vs_client, &index).await;
+        }
+
+        Self {
+            client,
+            vs_client,
+            table_name,
+            index,
+            shape: shape.clone(),
+        }
+    }
+
+
+    /// Inserts an item into the table.
+    async fn put(&self, item: &Item) {
+        let mut req = self.client.put_item().table_name(&self.table_name);
+        for (attr_name, attr_val) in &item.0 {
+            req = req.item(attr_name, attr_val.clone());
+        }
+        req.send().await.expect("PutItem should succeed");
+    }
+
+    /// Creates a table, inserts items, and adds a vector index via
+    /// `UpdateTable`. Waits for VS to serve the index with the correct count.
+    /// All `items` must carry a valid vector. Use
+    /// [`Self::create_with_invalid_data`] when the dataset includes items VS
+    /// should skip.
+    async fn create_with_data(actors: &TestActors, shape: &TableShape, items: &[Item]) -> Self {
+        let no_vec_shape = TableShape {
+            vec_name: None,
+            pk_type: shape.pk_type.clone(),
+            ..shape.clone()
+        };
+        let ctx = Self::create(actors, &no_vec_shape).await;
+
+        for item in items {
+            ctx.put(item).await;
+        }
+
+        let vec_attr = match &shape.vec_name {
+            None => return ctx,
+            Some(va) => va,
+        };
+
+        // Add the vector index via UpdateTable (initial-scan path).
+        update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            serde_json::json!([{
+                "Create": {
+                    "IndexName": ctx.index.index.as_ref(),
+                    "VectorAttribute": {
+                        "AttributeName": vec_attr,
+                        "Dimensions": 3
+                    }
+                }
+            }]),
+        )
+        .await;
+
+        ctx.wait_for_count(items.len()).await;
+
+        Self {
+            shape: TableShape {
+                vec_name: Some(vec_attr.clone()),
+                ..ctx.shape
+            },
+            ..ctx
+        }
+    }
+
+
+    async fn wait_for_count(&self, n: usize) {
+        wait_for_index_count(&self.vs_client, &self.index, n).await;
+    }
+
+    /// Waits until ANN returns exactly the expected items in the expected order.
+    async fn wait_for_ann(&self, qvec: [f32; 3], expected: &[Item]) {
+        wait_for_ann(
+            &self.vs_client,
+            &self.index,
+            self.shape.pk(),
+            self.shape.sk(),
+            qvec,
+            expected,
+        )
+        .await
+    }
+
+
+    /// Deletes the Alternator table. Idempotent.
+    async fn done(&self) {
+        match self
+            .client
+            .delete_table()
+            .table_name(&self.table_name)
+            .send()
+            .await
+        {
+            Ok(_) => {}
+            Err(err) => {
+                if err
+                    .as_service_error()
+                    .is_some_and(|e| matches!(e, DeleteTableError::ResourceNotFoundException(_)))
+                {
+                    // Already deleted - nothing to do.
+                } else {
+                    warn!(
+                        "DeleteTable for '{}' failed unexpectedly: {err}",
+                        self.table_name
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod auth;
 mod batch_write_item;
 mod create_table;
 mod delete_item;
@@ -108,6 +109,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
         ("alternator_query".into(), query::new().await),
         ("alternator_types".into(), types::new().await),
         ("alternator_lwt".into(), lwt::new().await),
+        ("alternator_auth".into(), auth::new().await),
     ]
 }
 

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod batch_write_item;
 mod create_table;
+mod delete_item;
+mod put_item;
+mod ttl;
+mod update_item;
 mod update_table;
 
 use crate::TestActors;
@@ -89,6 +94,14 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
     vec![
         ("alternator_create_table".into(), create_table::new().await),
         ("alternator_update_table".into(), update_table::new().await),
+        ("alternator_put_item".into(), put_item::new().await),
+        ("alternator_delete_item".into(), delete_item::new().await),
+        ("alternator_update_item".into(), update_item::new().await),
+        (
+            "alternator_batch_write_item".into(),
+            batch_write_item::new().await,
+        ),
+        ("alternator_ttl".into(), ttl::new().await),
     ]
 }
 
@@ -508,6 +521,22 @@ async fn delete_alternator_table(client: &Client, table_name: &str) {
         .expect("DeleteTable should succeed");
 }
 
+/// Asserts that an SDK result is a service error containing `expected_err`.
+fn assert_service_error<O, E>(result: Result<O, SdkError<E>>, expected_err: &str)
+where
+    O: std::fmt::Debug,
+    E: aws_smithy_types::error::metadata::ProvideErrorMetadata,
+{
+    use aws_sdk_dynamodb::error::ProvideErrorMetadata as _;
+    let err = result.expect_err("operation should have been rejected");
+    let code = err.code().unwrap_or("");
+    let message = err.message().unwrap_or("");
+    assert!(
+        code.contains(expected_err) || message.contains(expected_err),
+        "expected error containing {expected_err:?}, got code={code:?} message={message:?}"
+    );
+}
+
 /// Standard test init: starts ScyllaDB with the Alternator endpoint enabled on
 /// each node's own IP, alongside the Vector Store.
 #[framed]
@@ -746,7 +775,6 @@ impl TableContext {
         }
     }
 
-
     /// Inserts an item into the table.
     async fn put(&self, item: &Item) {
         let mut req = self.client.put_item().table_name(&self.table_name);
@@ -756,12 +784,33 @@ impl TableContext {
         req.send().await.expect("PutItem should succeed");
     }
 
+    /// Inserts an item, asserting that Scylla rejects it with `expected_err`.
+    async fn put_expecting_error(&self, item: &Item, expected_err: &str) {
+        let mut req = self.client.put_item().table_name(&self.table_name);
+        for (attr_name, attr_val) in &item.0 {
+            req = req.item(attr_name, attr_val.clone());
+        }
+        assert_service_error(req.send().await, expected_err);
+    }
+
     /// Creates a table, inserts items, and adds a vector index via
     /// `UpdateTable`. Waits for VS to serve the index with the correct count.
     /// All `items` must carry a valid vector. Use
     /// [`Self::create_with_invalid_data`] when the dataset includes items VS
     /// should skip.
     async fn create_with_data(actors: &TestActors, shape: &TableShape, items: &[Item]) -> Self {
+        Self::create_with_invalid_data(actors, shape, items, &[]).await
+    }
+
+    /// Like [`Self::create_with_data`] but also pre-inserts `invalid_items`
+    /// (wrong type, missing vector, wrong dimensions) that VS should skip.
+    /// Only `items` count toward the expected index count.
+    async fn create_with_invalid_data(
+        actors: &TestActors,
+        shape: &TableShape,
+        items: &[Item],
+        invalid_items: &[Item],
+    ) -> Self {
         let no_vec_shape = TableShape {
             vec_name: None,
             pk_type: shape.pk_type.clone(),
@@ -769,7 +818,7 @@ impl TableContext {
         };
         let ctx = Self::create(actors, &no_vec_shape).await;
 
-        for item in items {
+        for item in items.iter().chain(invalid_items.iter()) {
             ctx.put(item).await;
         }
 
@@ -805,7 +854,6 @@ impl TableContext {
         }
     }
 
-
     async fn wait_for_count(&self, n: usize) {
         wait_for_index_count(&self.vs_client, &self.index, n).await;
     }
@@ -822,7 +870,6 @@ impl TableContext {
         )
         .await
     }
-
 
     /// Deletes the Alternator table. Idempotent.
     async fn done(&self) {

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -9,6 +9,7 @@ mod delete_item;
 mod put_item;
 mod query;
 mod ttl;
+mod types;
 mod update_item;
 mod update_table;
 
@@ -104,6 +105,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
         ),
         ("alternator_ttl".into(), ttl::new().await),
         ("alternator_query".into(), query::new().await),
+        ("alternator_types".into(), types::new().await),
     ]
 }
 

--- a/crates/validator/src/alternator/put_item.rs
+++ b/crates/validator/src/alternator/put_item.rs
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+use super::dynamo_float_list;
+
+/// Inserts items via `PutItem` and verifies the VS index is updated.
+///
+/// Loops [`NAME_PATTERNS`](super::NAME_PATTERNS) so that every combination
+/// of key schema (HASH-only / HASH+RANGE) and naming style (plain /
+/// special) is covered.
+#[framed]
+async fn put_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &super::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let ctx = TableContext::create(&actors, shape).await;
+
+        let vec_attr = ctx.shape.vec().expect("TableContext has no vec_attr");
+
+        let a = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]);
+        let b = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let c = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]);
+
+        for item in [&a, &b, &c] {
+            ctx.put(item).await;
+        }
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[a, b.clone(), c.clone()])
+            .await;
+
+        // Replace item a with a vector pointing in the opposite direction -
+        // a_replaced=[-1,-1,-1] has cosine=-1.0 (antipodal to [1,1,1]) so it falls
+        // to last position.  b=[1,2,4] and c=[1,4,8] retain their order.
+        let a_replaced =
+            Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [-1.0, -1.0, -1.0]);
+        ctx.put(&a_replaced).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b, c, a_replaced]).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Inserts items with various invalid vector attributes and verifies VS does
+/// not index them.  Only the valid item should appear in the index.
+#[framed]
+async fn put_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
+    info!("started");
+
+    let shape = &super::name_patterns()[0]; // plain names, HASH-only
+    let pk = shape.pk();
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[0] always has vec");
+
+    let ctx = TableContext::create(&actors, shape).await;
+
+    let vec_with_string_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::S("3.0".into()),
+    ]);
+    let vec_with_null_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::Null(true),
+    ]);
+
+    let no_vec = Item::key(pk, None, "pk", "no-vec");
+    ctx.put(&no_vec).await;
+
+    let wrong_type_string = Item::key(pk, None, "pk", "wrong-type-string")
+        .attr(vec_attr, AttributeValue::S("not-a-vector".into()));
+    ctx.put_expecting_error(&wrong_type_string, "ValidationException")
+        .await;
+
+    let wrong_type_mostly_float_one_s = Item::key(pk, None, "pk", "wrong-type-mostly-float-one-s")
+        .attr(vec_attr, vec_with_string_elem);
+    ctx.put_expecting_error(&wrong_type_mostly_float_one_s, "ValidationException")
+        .await;
+
+    let wrong_type_mostly_float_one_null =
+        Item::key(pk, None, "pk", "wrong-type-mostly-float-one-null")
+            .attr(vec_attr, vec_with_null_elem);
+    ctx.put_expecting_error(&wrong_type_mostly_float_one_null, "ValidationException")
+        .await;
+
+    let wrong_type_too_short = Item::key(pk, None, "pk", "wrong-type-too-short")
+        .attr(vec_attr, dynamo_float_list([1.0_f32, 1.0]));
+    ctx.put_expecting_error(&wrong_type_too_short, "ValidationException")
+        .await;
+
+    let wrong_type_too_long = Item::key(pk, None, "pk", "wrong-type-too-long")
+        .attr(vec_attr, dynamo_float_list([1.0_f32, 1.0, 1.0, 1.0]));
+    ctx.put_expecting_error(&wrong_type_too_long, "ValidationException")
+        .await;
+
+    // valid is put last so that wait_for_ann acts as a sequencing barrier:
+    // when VS has indexed valid it must have already processed the no_vec CDC
+    // event before it (CDC events are ordered), proving that the item without
+    // a vector attribute was correctly ignored.
+    let valid = Item::key(pk, None, "pk", "valid").vec(vec_attr, [1.0, 1.0, 1.0]);
+    ctx.put(&valid).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[valid]).await;
+
+    let valid_no_vec = Item::key(pk, None, "pk", "valid");
+    ctx.put(&valid_no_vec).await;
+    ctx.wait_for_count(0).await;
+
+    let wrong_type2 =
+        Item::key(pk, None, "pk", "valid").attr(vec_attr, AttributeValue::S("bad".into()));
+    ctx.put_expecting_error(&wrong_type2, "ValidationException")
+        .await;
+    ctx.wait_for_count(0).await;
+
+    ctx.done().await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "put_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            put_item_updates_index,
+        )
+        .with_test(
+            "put_item_with_invalid_vector_is_not_indexed",
+            common::DEFAULT_TEST_TIMEOUT,
+            put_item_with_invalid_vector_is_not_indexed,
+        )
+}

--- a/crates/validator/src/alternator/put_item.rs
+++ b/crates/validator/src/alternator/put_item.rs
@@ -49,6 +49,27 @@ async fn put_item_updates_index(actors: TestActors) {
         ctx.put(&a_replaced).await;
         ctx.wait_for_ann([1.0, 1.0, 1.0], &[b, c, a_replaced]).await;
 
+        // Conditional PutItem exercises the LWT/Paxos path under
+        // `only_rmw_uses_lwt` (ConditionExpression makes it RMW).
+        info!(
+            "Step 3: conditional PutItem (passing condition) in '{}'",
+            ctx.table_name
+        );
+        let d = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "d").vec(vec_attr, [1.0, 1.0, 1.0]);
+        let mut req = ctx
+            .client
+            .put_item()
+            .table_name(&ctx.table_name)
+            .condition_expression("attribute_not_exists(#pk)")
+            .expression_attribute_names("#pk", ctx.shape.pk());
+        for (attr_name, attr_val) in &d.0 {
+            req = req.item(attr_name, attr_val.clone());
+        }
+        req.send()
+            .await
+            .expect("conditional PutItem with passing condition should succeed");
+        ctx.wait_for_count(4).await;
+
         ctx.done().await;
         info!("Shape {shape:?} passed");
     }

--- a/crates/validator/src/alternator/query.rs
+++ b/crates/validator/src/alternator/query.rs
@@ -1,0 +1,858 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::client::customize::CustomizableOperation;
+use aws_sdk_dynamodb::operation::query::QueryError;
+use aws_sdk_dynamodb::operation::query::QueryOutput;
+use aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::Select;
+use e2etest::TestCase;
+use httpapi::ColumnName;
+use httpapi::IndexName;
+use httpapi::Limit;
+use httpapi::Vector;
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use tracing::info;
+
+use super::Item;
+use super::JsonBodyInjectInterceptor;
+use super::TableContext;
+use super::alternator_keyspace;
+use super::dynamo_float_list;
+use super::make_clients;
+use super::unique_alternator_index_name;
+use super::unique_alternator_table_name;
+use super::wait_for_index_count;
+
+/// Extension trait that adds Alternator `VectorSearch` to any [`QueryFluentBuilder`].
+///
+/// Call `.vector_search(vector)` as the **last** builder step before `.send()`:
+///
+/// ```ignore
+/// // Simple - just the items:
+/// let items = ctx.client.query()
+///     .table_name(&ctx.table_name)
+///     .index_name(ctx.index.index.as_ref())
+///     .limit(10)
+///     .vector_search([1.0, 1.0, 1.0])
+///     .send().await.expect("Query with VectorSearch should succeed")
+///     .items().to_vec();
+///
+/// // Full output (e.g. for Select::Count):
+/// let resp = ctx.client.query()
+///     .table_name(&ctx.table_name)
+///     .index_name(ctx.index.index.as_ref())
+///     .limit(5)
+///     .select(Select::Count)
+///     .vector_search([1.0_f32, 1.0, 1.0])
+///     .send().await.expect("Query with Select::Count should succeed");
+/// ```
+pub(super) trait QueryBuilderExt {
+    fn vector_search(
+        self,
+        vector: impl IntoIterator<Item = f32>,
+    ) -> CustomizableOperation<QueryOutput, QueryError, QueryFluentBuilder>;
+}
+
+impl QueryBuilderExt for QueryFluentBuilder {
+    fn vector_search(
+        self,
+        vector: impl IntoIterator<Item = f32>,
+    ) -> CustomizableOperation<QueryOutput, QueryError, QueryFluentBuilder> {
+        let json = serde_json::json!({
+            "QueryVector": {
+                "L": vector
+                    .into_iter()
+                    .map(|v| serde_json::json!({ "N": v.to_string() }))
+                    .collect::<Vec<_>>()
+            }
+        });
+        self.customize()
+            .interceptor(JsonBodyInjectInterceptor::new([("VectorSearch", json)]))
+    }
+}
+
+/// Creates Alternator tables with a vector index (both HASH-only and
+/// HASH+RANGE schemas), inserts items, waits for the index to be SERVING, then
+/// issues a `Query` extended with the Alternator `VectorSearch` attribute (no
+/// `KeyConditionExpression`).  Asserts that results are returned, the limit is
+/// respected, and the closest item is ranked first.
+#[framed]
+async fn query_with_vector_search(actors: TestActors) {
+    info!("started");
+
+    let shapes = [
+        super::TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-QVS".into(),
+            sk_name: None,
+            vec_name: Some("Vec-QVS".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+        super::TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-QVS".into(),
+            sk_name: Some("Sk-QVS".into()),
+            vec_name: Some("Vec-QVS".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+    ];
+
+    for shape in &shapes {
+        info!("Testing shape: {shape:?}");
+
+        let dataset = [
+            Item::new(shape.pk(), AttributeValue::S("pk-a".into()))
+                .maybe_sk(shape.sk(), AttributeValue::S("sk-1".into()))
+                .vec(shape.vec().unwrap(), [1.0, 1.0, 1.0]),
+            Item::new(shape.pk(), AttributeValue::S("pk-b".into()))
+                .maybe_sk(shape.sk(), AttributeValue::S("sk-2".into()))
+                .vec(shape.vec().unwrap(), [1.0, 2.0, 4.0]),
+            Item::new(shape.pk(), AttributeValue::S("pk-c".into()))
+                .maybe_sk(shape.sk(), AttributeValue::S("sk-3".into()))
+                .vec(shape.vec().unwrap(), [4.0, 1.0, 2.0]),
+        ];
+
+        let ctx = TableContext::create_with_data(&actors, shape, &dataset).await;
+
+        info!(
+            "Issuing Query with VectorSearch Limit=2 on '{}'",
+            ctx.table_name
+        );
+        let items = ctx
+            .client
+            .query()
+            .table_name(&ctx.table_name)
+            .index_name(ctx.index.index.as_ref())
+            .limit(2)
+            .vector_search([1.0, 1.0, 1.0])
+            .send()
+            .await
+            .expect("Query with VectorSearch should succeed")
+            .items()
+            .to_vec();
+
+        assert!(
+            !items.is_empty(),
+            "Query with VectorSearch should return at least one item"
+        );
+        assert!(
+            items.len() <= 2,
+            "Query with VectorSearch Limit=2 should return at most 2 items, got {}",
+            items.len()
+        );
+        assert_eq!(
+            items[0].get(shape.pk()),
+            Some(&AttributeValue::S("pk-a".into())),
+            "closest result should be pk-a"
+        );
+        if let Some(sk_name) = shape.sk() {
+            assert_eq!(
+                items[0].get(sk_name),
+                Some(&AttributeValue::S("sk-1".into())),
+                "closest result should have sk-1"
+            );
+        }
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+#[framed]
+async fn query_uses_selected_vector_index(actors: TestActors) {
+    info!("started");
+
+    let (client, vs_clients) = super::make_clients(&actors).await;
+
+    let table_name = super::unique_alternator_table_name();
+    let partition_key_name = "Pk-Query-Case";
+    let unique_index_name = super::unique_alternator_index_name();
+    let lower_index_name: IndexName = unique_index_name.as_ref().to_ascii_lowercase().into();
+    let upper_index_name: IndexName = unique_index_name.as_ref().to_ascii_uppercase().into();
+    let lower_vector_attribute_name = "samevector";
+    let upper_vector_attribute_name = "SAMEVECTOR";
+    let lower_index = httpapi::IndexInfo::new(
+        super::alternator_keyspace(&table_name).as_ref(),
+        lower_index_name.as_ref(),
+    );
+    let upper_index = httpapi::IndexInfo::new(
+        super::alternator_keyspace(&table_name).as_ref(),
+        upper_index_name.as_ref(),
+    );
+    let dataset = [
+        ("pk-a", [1.0, 1.0, 1.0], [4.0, 1.0, 2.0]),
+        ("pk-b", [1.0, 2.0, 4.0], [2.0, 1.0, 3.0]),
+        ("pk-c", [3.0, 1.0, 2.0], [1.0, 1.0, 1.0]),
+    ];
+
+    info!(
+        "Creating Alternator table '{table_name}' with case-distinct VectorIndexes '{}' and '{}'",
+        lower_index.index, upper_index.index
+    );
+    super::create_alternator_table(
+        &client,
+        &table_name,
+        partition_key_name,
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[
+            (lower_index.index.as_ref(), lower_vector_attribute_name, 3),
+            (upper_index.index.as_ref(), upper_vector_attribute_name, 3),
+        ],
+    )
+    .await
+    .expect("CreateTable with case-distinct VectorIndexes should succeed");
+
+    info!("Inserting items with different vectors for each indexed column into '{table_name}'");
+    for (partition_key, lower_vector, upper_vector) in dataset {
+        client
+            .put_item()
+            .table_name(&table_name)
+            .item(
+                partition_key_name,
+                AttributeValue::S(partition_key.to_string()),
+            )
+            .item(lower_vector_attribute_name, dynamo_float_list(lower_vector))
+            .item(upper_vector_attribute_name, dynamo_float_list(upper_vector))
+            .send()
+            .await
+            .expect("PutItem should succeed");
+    }
+
+    info!(
+        "Waiting for Vector Store to index all {} items for '{}/{}' and '{}/{}'",
+        dataset.len(),
+        lower_index.keyspace,
+        lower_index.index,
+        upper_index.keyspace,
+        upper_index.index
+    );
+    super::wait_for_index_count(&vs_clients[0], &lower_index, dataset.len()).await;
+    super::wait_for_index_count(&vs_clients[0], &upper_index, dataset.len()).await;
+
+    info!(
+        "Querying lower-case index '{}' on '{table_name}'",
+        lower_index.index
+    );
+    let lower_items = client
+        .query()
+        .table_name(&table_name)
+        .index_name(lower_index.index.as_ref())
+        .limit(1)
+        .vector_search([1.0, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with VectorSearch should succeed")
+        .items()
+        .to_vec();
+    assert_eq!(
+        lower_items[0].get(partition_key_name),
+        Some(&AttributeValue::S("pk-a".into())),
+        "lower-case index should return pk-a as nearest"
+    );
+
+    info!(
+        "Querying upper-case index '{}' on '{table_name}'",
+        upper_index.index
+    );
+    let upper_items = client
+        .query()
+        .table_name(&table_name)
+        .index_name(upper_index.index.as_ref())
+        .limit(1)
+        .vector_search([1.0, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with VectorSearch should succeed")
+        .items()
+        .to_vec();
+    assert_eq!(
+        upper_items[0].get(partition_key_name),
+        Some(&AttributeValue::S("pk-c".into())),
+        "upper-case index should return pk-c as nearest"
+    );
+
+    super::delete_alternator_table(&client, &table_name).await;
+
+    info!("finished");
+}
+
+/// Creates an Alternator table with 5 items at known cosine distances from a
+/// query vector, retrieves all of them via VectorSearch with Limit=5, and
+/// asserts that the returned items are ordered by ascending cosine distance
+/// (nearest first).
+///
+/// Alternator vector indexes use **cosine** similarity by default.
+/// Cosine distance = 1 - cos(theta), so vectors pointing in the same direction as
+/// the query vector are "nearest" regardless of magnitude.
+#[framed]
+async fn query_with_vector_search_multiple_results_ordering(actors: TestActors) {
+    info!("started");
+
+    let dataset = [
+        Item::new("Pk-Ord", AttributeValue::S("pk-nearest".into())).vec("Vec-Ord", [1.0, 0.0, 0.0]),
+        Item::new("Pk-Ord", AttributeValue::S("pk-near".into())).vec("Vec-Ord", [1.0, 0.1, 0.0]),
+        Item::new("Pk-Ord", AttributeValue::S("pk-mid".into())).vec("Vec-Ord", [1.0, 1.0, 0.0]),
+        Item::new("Pk-Ord", AttributeValue::S("pk-far".into())).vec("Vec-Ord", [0.0, 1.0, 0.0]),
+        Item::new("Pk-Ord", AttributeValue::S("pk-farthest".into()))
+            .vec("Vec-Ord", [-1.0, 0.0, 0.0]),
+    ];
+
+    let ctx = TableContext::create_with_data(
+        &actors,
+        &super::TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-Ord".into(),
+            sk_name: None,
+            vec_name: Some("Vec-Ord".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+        &dataset,
+    )
+    .await;
+
+    let expected_order: Vec<AttributeValue> = dataset
+        .iter()
+        .map(|i| i.0.get("Pk-Ord").expect("item has no Pk-Ord").clone())
+        .collect();
+
+    info!(
+        "Issuing Query with VectorSearch Limit=5 on '{}'",
+        ctx.table_name
+    );
+    let raw = ctx
+        .client
+        .query()
+        .table_name(&ctx.table_name)
+        .index_name(ctx.index.index.as_ref())
+        .limit(5)
+        .vector_search([1.0, 0.0, 0.0])
+        .send()
+        .await
+        .expect("Query with VectorSearch should succeed")
+        .items()
+        .to_vec();
+    let actual_order: Vec<AttributeValue> = raw
+        .iter()
+        .filter_map(|item| item.get("Pk-Ord"))
+        .cloned()
+        .collect();
+
+    assert_eq!(
+        actual_order, expected_order,
+        "Results should be ordered by ascending cosine distance from query vector"
+    );
+
+    ctx.done().await;
+
+    info!("finished");
+}
+
+/// Creates tables for every entry in [`NAME_PATTERNS`](super::NAME_PATTERNS)
+/// (covering HASH-only and HASH+RANGE schemas, as well as special characters in
+/// attribute names) and issues a VectorSearch query with a
+/// `ProjectionExpression` that requests only the key attribute(s), excluding the
+/// vector and an extra "data" attribute.
+///
+/// Verifies for every shape that:
+/// - the partition key is present in each returned item,
+/// - the sort key is present when the shape has one,
+/// - the vector attribute is absent,
+/// - the extra data attribute is absent.
+#[framed]
+async fn query_with_projection_special_names(actors: TestActors) {
+    info!("started");
+
+    for shape in &super::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let data_attribute_name = "data:extra";
+        let sk = shape.sk();
+
+        let dataset = [Item::new(shape.pk(), AttributeValue::S("pk-1".into()))
+            .maybe_sk(sk, AttributeValue::S("sk-1".into()))
+            .vec(
+                shape.vec().expect("NAME_PATTERNS entries always have vec"),
+                [1.0, 1.0, 1.0],
+            )
+            .attr(
+                data_attribute_name,
+                AttributeValue::S("extra-val".to_string()),
+            )];
+
+        let ctx = TableContext::create_with_data(&actors, shape, &dataset).await;
+        let pk_name = ctx.shape.pk();
+
+        let proj_expr: &str = if shape.sk_name.is_some() {
+            "#pk, #sk"
+        } else {
+            "#pk"
+        };
+
+        info!("Querying with ProjectionExpression = '{proj_expr}'");
+        let mut builder = ctx
+            .client
+            .query()
+            .table_name(&ctx.table_name)
+            .index_name(ctx.index.index.as_ref())
+            .limit(1)
+            .projection_expression(proj_expr)
+            .expression_attribute_names("#pk", pk_name);
+        if let Some(sk_name) = shape.sk() {
+            builder = builder.expression_attribute_names("#sk", sk_name);
+        }
+        let items = builder
+            .vector_search([1.0, 1.0, 1.0])
+            .send()
+            .await
+            .expect("Query with VectorSearch should succeed")
+            .items()
+            .to_vec();
+
+        let mut expected_item: HashMap<String, AttributeValue> = HashMap::new();
+        expected_item.insert(pk_name.to_string(), AttributeValue::S("pk-1".into()));
+        if let Some(sk_name) = shape.sk() {
+            expected_item.insert(sk_name.to_string(), AttributeValue::S("sk-1".into()));
+        }
+        assert_eq!(
+            items,
+            vec![expected_item],
+            "projected item should contain only key attributes"
+        );
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Creates a table, inserts items with a partition key, vector, and extra
+/// "data" attribute.  Queries with `Select::AllAttributes` and verifies
+/// that all three attributes are returned for each item.
+#[framed]
+async fn query_with_select_all_attributes(actors: TestActors) {
+    info!("started");
+
+    let shape = super::TableShape {
+        table_prefix: None,
+        index_prefix: None,
+        pk_name: "Pk-SelAll".into(),
+        sk_name: None,
+        vec_name: Some("Vec-SelAll".into()),
+        pk_type: super::ScalarAttributeType::S,
+    };
+    let data_attribute_name = "Data-SelAll";
+
+    let dataset = [Item::new("Pk-SelAll", AttributeValue::S("pk-a".into()))
+        .vec("Vec-SelAll", [1.0, 1.0, 1.0])
+        .attr(
+            data_attribute_name,
+            AttributeValue::S("some-data".to_string()),
+        )];
+
+    let ctx = TableContext::create_with_data(&actors, &shape, &dataset).await;
+
+    info!("Querying with Select::AllAttributes");
+    let items = ctx
+        .client
+        .query()
+        .table_name(&ctx.table_name)
+        .index_name(ctx.index.index.as_ref())
+        .limit(1)
+        .select(Select::AllAttributes)
+        .vector_search([1.0, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with VectorSearch should succeed")
+        .items()
+        .to_vec();
+
+    assert_eq!(items.len(), 1, "should return 1 item");
+    let item = &items[0];
+    assert!(
+        item.contains_key("Pk-SelAll"),
+        "AllAttributes should return partition key"
+    );
+    assert!(
+        item.contains_key("Vec-SelAll"),
+        "AllAttributes should return vector attribute"
+    );
+    assert!(
+        item.contains_key(data_attribute_name),
+        "AllAttributes should return data attribute"
+    );
+
+    ctx.done().await;
+
+    info!("finished");
+}
+
+/// Creates a table with items, then queries with `Select::Count`. Verifies
+/// that the response has a count > 0 but returns no item data (the DynamoDB
+/// API returns Count/ScannedCount in the response but Items is empty).
+#[framed]
+async fn query_with_select_count(actors: TestActors) {
+    info!("started");
+
+    let dataset = [
+        Item::new("Pk-SelCnt", AttributeValue::S("pk-a".into())).vec("Vec-SelCnt", [1.0, 1.0, 1.0]),
+        Item::new("Pk-SelCnt", AttributeValue::S("pk-b".into())).vec("Vec-SelCnt", [1.0, 2.0, 4.0]),
+    ];
+
+    let ctx = TableContext::create_with_data(
+        &actors,
+        &super::TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-SelCnt".into(),
+            sk_name: None,
+            vec_name: Some("Vec-SelCnt".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+        &dataset,
+    )
+    .await;
+
+    info!("Querying with Select::Count");
+    let resp = ctx
+        .client
+        .query()
+        .table_name(&ctx.table_name)
+        .index_name(ctx.index.index.as_ref())
+        .limit(5)
+        .select(Select::Count)
+        .vector_search([1.0_f32, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with Select::Count should succeed");
+
+    assert!(
+        resp.count() > 0,
+        "Select::Count should report count > 0, got {}",
+        resp.count()
+    );
+    assert!(
+        resp.items().is_empty(),
+        "Select::Count should return empty items list, got {} items",
+        resp.items().len()
+    );
+
+    ctx.done().await;
+
+    info!("finished");
+}
+
+/// Creates a table with 3 items, queries with `Limit=1000` (far larger than
+/// the dataset), and verifies that all 3 items are returned without error or
+/// truncation. This exercises the case where `Limit > dataset_size`, which
+/// should return all available results rather than erroring.
+#[framed]
+async fn query_with_limit_larger_than_dataset(actors: TestActors) {
+    info!("started");
+
+    let dataset = [
+        Item::new("Pk-BigLim", AttributeValue::S("pk-a".into())).vec("Vec-BigLim", [1.0, 1.0, 1.0]),
+        Item::new("Pk-BigLim", AttributeValue::S("pk-b".into())).vec("Vec-BigLim", [1.0, 2.0, 4.0]),
+        Item::new("Pk-BigLim", AttributeValue::S("pk-c".into())).vec("Vec-BigLim", [2.0, 1.0, 3.0]),
+    ];
+
+    let ctx = TableContext::create_with_data(
+        &actors,
+        &super::TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-BigLim".into(),
+            sk_name: None,
+            vec_name: Some("Vec-BigLim".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+        &dataset,
+    )
+    .await;
+
+    info!(
+        "Issuing Query with VectorSearch Limit=1000 on '{}' (dataset has {} items)",
+        ctx.table_name,
+        dataset.len()
+    );
+    let items = ctx
+        .client
+        .query()
+        .table_name(&ctx.table_name)
+        .index_name(ctx.index.index.as_ref())
+        .limit(1000)
+        .vector_search([1.0, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with VectorSearch should succeed")
+        .items()
+        .to_vec();
+
+    assert_eq!(
+        items.len(),
+        dataset.len(),
+        "Query with Limit=1000 should return all {} items, got {}",
+        dataset.len(),
+        items.len()
+    );
+    info!(
+        "Query returned {} item(s) with Limit=1000 (dataset has {})",
+        items.len(),
+        dataset.len()
+    );
+
+    ctx.done().await;
+
+    info!("finished");
+}
+
+/// Creates a table with `Dimensions=1536` (the dimensionality of OpenAI
+/// text-embedding-ada-002 vectors), inserts one item with a 1536-element
+/// vector, waits for VS to index it, then issues an ANN query and asserts
+/// the inserted item is returned.
+#[framed]
+async fn query_with_large_dimensions(actors: TestActors) {
+    info!("started");
+
+    let (client, vs_clients) = make_clients(&actors).await;
+
+    let table_name = unique_alternator_table_name();
+    let index_name = unique_alternator_index_name();
+    let partition_key_name = "pk";
+    let vector_attribute_name = "vec";
+    let dimensions: usize = 1536;
+    let index = httpapi::IndexInfo::new(
+        alternator_keyspace(&table_name).as_ref(),
+        index_name.as_ref(),
+    );
+
+    info!("Creating Alternator table '{table_name}' with Dimensions={dimensions}");
+    super::create_alternator_table(
+        &client,
+        &table_name,
+        partition_key_name,
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(index.index.as_ref(), vector_attribute_name, dimensions)],
+    )
+    .await
+    .expect("CreateTable with large Dimensions should succeed");
+
+    info!(
+        "Waiting for VS to discover index '{}/{}'",
+        index.keyspace, index.index
+    );
+    common::wait_for_index(&vs_clients[0], &index).await;
+
+    let mut vector_data: Vec<f32> = vec![0.0; dimensions];
+    vector_data[0] = 1.0;
+
+    info!("Inserting item with {dimensions}-dim vector into '{table_name}'");
+    client
+        .put_item()
+        .table_name(&table_name)
+        .item(
+            partition_key_name,
+            aws_sdk_dynamodb::types::AttributeValue::S("pk-1".to_string()),
+        )
+        .item(
+            vector_attribute_name,
+            dynamo_float_list(vector_data.iter().copied()),
+        )
+        .send()
+        .await
+        .expect("PutItem with large-dimension vector should succeed");
+
+    info!("Waiting for VS to index the item");
+    wait_for_index_count(&vs_clients[0], &index, 1).await;
+
+    info!("Querying VS with a {dimensions}-dim ANN query");
+    let (pks, _, _) = vs_clients[0]
+        .ann(
+            &index.keyspace,
+            &index.index,
+            Vector::from(vector_data),
+            None,
+            Limit::from(NonZeroUsize::new(1).unwrap()),
+        )
+        .await;
+    let pk_column = ColumnName::from(partition_key_name);
+    let pk_values: Vec<&str> = pks
+        .get(&pk_column)
+        .expect("ANN result should contain the pk column")
+        .iter()
+        .map(|v| v.as_str().expect("pk value should be a string"))
+        .collect();
+    assert_eq!(
+        pk_values,
+        vec!["pk-1"],
+        "ANN should return the inserted item"
+    );
+
+    super::delete_alternator_table(&client, &table_name).await;
+
+    info!("finished");
+}
+
+/// Creates a HASH-only Alternator table with items that carry a
+/// `Category` attribute, then issues a VectorSearch `Query` with a
+/// `FilterExpression` that keeps only items whose `Category` equals `"keep"`.
+///
+/// DynamoDB/Alternator applies `FilterExpression` **after** the Vector Store
+/// returns the ANN result set (no pre-filtering optimisation), so all items
+/// are fetched from the index first and then narrowed client-side by
+/// Alternator.  The test uses `Limit` larger than the dataset to ensure all
+/// items are considered before the filter is applied.
+///
+/// Verifies that:
+/// - only items with `Category = "keep"` appear in the response,
+/// - the item with `Category = "drop"` is absent,
+/// - the remaining items are still returned in cosine-distance order.
+#[framed]
+async fn query_with_filter_expression(actors: TestActors) {
+    info!("started");
+
+    let pk_name = "Pk-Flt";
+    let vec_name = "Vec-Flt";
+    let cat_name = "Category";
+
+    // Three items close to query vector [1, 1, 1].  "pk-drop" sits between
+    // the two "keep" items in cosine distance but must be absent from results.
+    let dataset = [
+        Item::new(pk_name, AttributeValue::S("pk-keep-1".into()))
+            .vec(vec_name, [1.0, 1.0, 1.0])
+            .attr(cat_name, AttributeValue::S("keep".into())),
+        Item::new(pk_name, AttributeValue::S("pk-drop".into()))
+            .vec(vec_name, [1.0, 1.05, 1.0])
+            .attr(cat_name, AttributeValue::S("drop".into())),
+        Item::new(pk_name, AttributeValue::S("pk-keep-2".into()))
+            .vec(vec_name, [1.0, 1.1, 1.0])
+            .attr(cat_name, AttributeValue::S("keep".into())),
+    ];
+
+    let ctx = TableContext::create_with_data(
+        &actors,
+        &super::TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: pk_name.into(),
+            sk_name: None,
+            vec_name: Some(vec_name.into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+        &dataset,
+    )
+    .await;
+
+    // Use Limit larger than the dataset so all items are read from the index
+    // before FilterExpression is applied (DynamoDB applies Limit first, then
+    // FilterExpression - a Limit smaller than the dataset could exclude items
+    // before the filter ever sees them).
+    info!(
+        "Issuing Query with FilterExpression '#cat = :cat' on '{}'",
+        ctx.table_name
+    );
+    let resp = ctx
+        .client
+        .query()
+        .table_name(&ctx.table_name)
+        .index_name(ctx.index.index.as_ref())
+        .limit(100)
+        .filter_expression("#cat = :cat")
+        .projection_expression("#pk, #cat")
+        .expression_attribute_names("#pk", pk_name)
+        .expression_attribute_names("#cat", cat_name)
+        .expression_attribute_values(":cat", AttributeValue::S("keep".into()))
+        .vector_search([1.0_f32, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with FilterExpression should succeed");
+
+    // ANN ordering is preserved after filtering: pk-keep-1 is nearest to
+    // [1,1,1] (exact match), pk-keep-2 is slightly farther.  "pk-drop" must
+    // be excluded by the FilterExpression.
+    let expected: Vec<HashMap<String, AttributeValue>> = vec![
+        HashMap::from([
+            (pk_name.to_string(), AttributeValue::S("pk-keep-1".into())),
+            (cat_name.to_string(), AttributeValue::S("keep".into())),
+        ]),
+        HashMap::from([
+            (pk_name.to_string(), AttributeValue::S("pk-keep-2".into())),
+            (cat_name.to_string(), AttributeValue::S("keep".into())),
+        ]),
+    ];
+    assert_eq!(
+        resp.items(),
+        expected,
+        "unexpected FilterExpression results"
+    );
+
+    ctx.done().await;
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "query_with_vector_search",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_vector_search,
+        )
+        .with_test(
+            "query_uses_selected_vector_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_uses_selected_vector_index,
+        )
+        .with_test(
+            "query_with_vector_search_multiple_results_ordering",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_vector_search_multiple_results_ordering,
+        )
+        .with_test(
+            "query_with_projection_special_names",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_projection_special_names,
+        )
+        .with_test(
+            "query_with_select_all_attributes",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_select_all_attributes,
+        )
+        .with_test(
+            "query_with_select_count",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_select_count,
+        )
+        .with_test(
+            "query_with_limit_larger_than_dataset",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_limit_larger_than_dataset,
+        )
+        .with_test(
+            "query_with_large_dimensions",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_large_dimensions,
+        )
+        .with_test(
+            "query_with_filter_expression",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_filter_expression,
+        )
+}

--- a/crates/validator/src/alternator/ttl.rs
+++ b/crates/validator/src/alternator/ttl.rs
@@ -13,6 +13,7 @@ use crate::TestActors;
 use crate::common;
 use async_backtrace::framed;
 use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::Select;
 use aws_sdk_dynamodb::types::TimeToLiveSpecification;
 use e2etest::TestCase;
 use tracing::info;
@@ -20,6 +21,7 @@ use tracing::info;
 use super::Item;
 use super::TableContext;
 use super::TableShape;
+use super::query::QueryBuilderExt;
 
 /// Enables DynamoDB TTL on `ttl_attribute` for the given table.
 async fn enable_ttl(client: &aws_sdk_dynamodb::Client, table_name: &str, ttl_attribute: &str) {
@@ -115,6 +117,78 @@ async fn ttl_expiration_removes_vector(actors: TestActors) {
     info!("finished");
 }
 
+/// Like [`ttl_expiration_removes_vector`] but uses `Select::AllProjectedAttributes`
+/// - an index-only read that skips the base table.
+#[framed]
+async fn ttl_expiration_verified_via_query_with_all_projected(actors: TestActors) {
+    info!("started");
+
+    let shape = TableShape {
+        table_prefix: None,
+        index_prefix: None,
+        pk_name: "Pk-TTLProj".into(),
+        sk_name: None,
+        vec_name: Some("Vec-TTLProj".into()),
+        pk_type: super::ScalarAttributeType::S,
+    };
+    let ttl_attribute = "ttl_expiry";
+
+    let vec_attr = shape.vec().unwrap();
+
+    let perm1 = Item::key(shape.pk(), shape.sk(), "pk", "1").vec(vec_attr, [1.0, 1.0, 1.0]);
+    let perm2 = Item::key(shape.pk(), shape.sk(), "pk", "2").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let expiring = Item::key(shape.pk(), shape.sk(), "pk", "expiring")
+        .vec(vec_attr, [1.0, 4.0, 8.0])
+        .attr(ttl_attribute, AttributeValue::N(ttl_epoch(2).to_string()));
+
+    let ctx =
+        TableContext::create_with_data(&actors, &shape, &[perm1.clone(), perm2.clone(), expiring])
+            .await;
+
+    info!(
+        "Enabling TTL on attribute '{ttl_attribute}' for '{}'",
+        ctx.table_name
+    );
+    enable_ttl(&ctx.client, &ctx.table_name, ttl_attribute).await;
+
+    info!("Waiting for TTL to expire the item and for VS to remove it");
+    ctx.wait_for_count(2).await;
+
+    info!("Querying via Alternator with Select::AllProjectedAttributes after TTL expiration");
+    common::wait_for(
+        || {
+            let ctx = &ctx;
+            async move {
+                let items = ctx
+                    .client
+                    .query()
+                    .table_name(&ctx.table_name)
+                    .index_name(ctx.index.index.as_ref())
+                    .limit(5)
+                    .select(Select::AllProjectedAttributes)
+                    .vector_search([1.0, 1.0, 1.0])
+                    .send()
+                    .await
+                    .expect("Query with VectorSearch should succeed")
+                    .items()
+                    .to_vec();
+
+                items.len() == 2
+                    && items.iter().all(|item| {
+                        !matches!(item.get(ctx.shape.pk()), Some(AttributeValue::S(s)) if s == "pk-expiring")
+                    })
+            }
+        },
+        "AllProjectedAttributes query to return only 2 permanent items after TTL expiration",
+        common::DEFAULT_TEST_TIMEOUT,
+    )
+    .await;
+
+    ctx.done().await;
+
+    info!("finished");
+}
+
 pub(super) async fn new() -> TestCase<TestActors> {
     TestCase::empty()
         .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
@@ -123,5 +197,10 @@ pub(super) async fn new() -> TestCase<TestActors> {
             "ttl_expiration_removes_vector",
             common::DEFAULT_TEST_TIMEOUT,
             ttl_expiration_removes_vector,
+        )
+        .with_test(
+            "ttl_expiration_verified_via_query_with_all_projected",
+            common::DEFAULT_TEST_TIMEOUT,
+            ttl_expiration_verified_via_query_with_all_projected,
         )
 }

--- a/crates/validator/src/alternator/ttl.rs
+++ b/crates/validator/src/alternator/ttl.rs
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+//! Alternator TTL integration tests.
+//!
+//! These tests verify that when DynamoDB TTL expires a row, the resulting CDC
+//! tombstone is consumed by Vector Store and the expired vector is removed
+//! from the index.
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::TimeToLiveSpecification;
+use e2etest::TestCase;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+use super::TableShape;
+
+/// Enables DynamoDB TTL on `ttl_attribute` for the given table.
+async fn enable_ttl(client: &aws_sdk_dynamodb::Client, table_name: &str, ttl_attribute: &str) {
+    client
+        .update_time_to_live()
+        .table_name(table_name)
+        .time_to_live_specification(
+            TimeToLiveSpecification::builder()
+                .enabled(true)
+                .attribute_name(ttl_attribute)
+                .build()
+                .expect("failed to build TimeToLiveSpecification"),
+        )
+        .send()
+        .await
+        .expect("UpdateTimeToLive should succeed");
+}
+
+/// Returns a Unix epoch timestamp `seconds_from_now` seconds in the future.
+fn ttl_epoch(seconds_from_now: i64) -> i64 {
+    use std::time::SystemTime;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    now + seconds_from_now
+}
+
+/// Inserts 3 items (2 permanent + 1 expiring) via the initial-scan path,
+/// then enables TTL.  Waits for the TTL-expired row to be reaped and the
+/// index count to drop to 2.
+///
+/// Covers both HASH-only and HASH+RANGE key schemas.
+#[framed]
+async fn ttl_expiration_removes_vector(actors: TestActors) {
+    info!("started");
+
+    let shapes: &[TableShape] = &[
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-TTL".into(),
+            sk_name: None,
+            vec_name: Some("Vec-TTL".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-TTLHR".into(),
+            sk_name: Some("Sk-TTLHR".into()),
+            vec_name: Some("Vec-TTLHR".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+    ];
+
+    let ttl_attribute = "ttl_expiry";
+
+    for shape in shapes {
+        info!(?shape, "testing shape");
+
+        let perm1 =
+            Item::key(shape.pk(), shape.sk(), "pk", "1").vec(shape.vec().unwrap(), [1.0, 1.0, 1.0]);
+        let perm2 =
+            Item::key(shape.pk(), shape.sk(), "pk", "2").vec(shape.vec().unwrap(), [1.0, 2.0, 4.0]);
+        let expiring = Item::key(shape.pk(), shape.sk(), "pk", "expiring")
+            .vec(shape.vec().unwrap(), [1.0, 4.0, 8.0])
+            .attr(ttl_attribute, AttributeValue::N(ttl_epoch(2).to_string()));
+
+        let ctx = TableContext::create_with_data(
+            &actors,
+            shape,
+            &[perm1.clone(), perm2.clone(), expiring],
+        )
+        .await;
+
+        info!(
+            "Enabling TTL on attribute '{ttl_attribute}' for '{}'",
+            ctx.table_name
+        );
+        enable_ttl(&ctx.client, &ctx.table_name, ttl_attribute).await;
+
+        info!("Waiting for TTL expiration to propagate to VS index");
+        ctx.wait_for_count(2).await;
+
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[perm1.clone(), perm2.clone()])
+            .await;
+
+        info!("TTL expiration correctly removed expired item from index");
+        ctx.done().await;
+    }
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "ttl_expiration_removes_vector",
+            common::DEFAULT_TEST_TIMEOUT,
+            ttl_expiration_removes_vector,
+        )
+}

--- a/crates/validator/src/alternator/types.rs
+++ b/crates/validator/src/alternator/types.rs
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::primitives::Blob;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::ScalarAttributeType;
+use e2etest::TestCase;
+use std::collections::HashSet;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+use super::TableShape;
+use super::query::QueryBuilderExt;
+
+/// Shared logic for all key-type tests: creates a table with 2 initial items,
+/// adds a 3rd via PutItem, then queries with a keys-only projection and asserts
+/// that only the pk attribute is returned.
+async fn query_with_key_type(
+    actors: &TestActors,
+    shape: &TableShape,
+    initial: &[Item],
+    extra: Item,
+) {
+    let vec_attr = shape.vec().unwrap();
+    let ctx = TableContext::create_with_data(actors, shape, initial).await;
+
+    ctx.put(&extra).await;
+    ctx.wait_for_count(3).await;
+
+    let items = ctx
+        .client
+        .query()
+        .table_name(&ctx.table_name)
+        .index_name(ctx.index.index.as_ref())
+        .limit(3)
+        .projection_expression("#pk")
+        .expression_attribute_names("#pk", shape.pk())
+        .vector_search([1.0, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with VectorSearch should succeed")
+        .items()
+        .to_vec();
+
+    assert!(
+        !items.is_empty(),
+        "keys-only query should return at least one item"
+    );
+    let expected_keys: HashSet<&str> = [shape.pk()].into();
+    for item in &items {
+        let got_keys: HashSet<&str> = item.keys().map(String::as_str).collect();
+        assert_eq!(
+            got_keys,
+            expected_keys,
+            "projected item should contain only pk '{}'",
+            shape.pk()
+        );
+        assert!(
+            !item.contains_key(vec_attr),
+            "projected item should NOT contain vector '{vec_attr}'"
+        );
+    }
+
+    ctx.done().await;
+}
+
+#[framed]
+async fn query_with_string_key(actors: TestActors) {
+    info!("started");
+    let shape = TableShape {
+        table_prefix: None,
+        index_prefix: None,
+        pk_name: "Pk-StrKey".into(),
+        sk_name: None,
+        vec_name: Some("Vec-StrKey".into()),
+        pk_type: ScalarAttributeType::S,
+    };
+    let v = shape.vec().unwrap();
+    let initial = [
+        Item::new(shape.pk(), AttributeValue::S("str-a".into())).vec(v, [1.0, 1.0, 1.0]),
+        Item::new(shape.pk(), AttributeValue::S("str-b".into())).vec(v, [1.0, 2.0, 4.0]),
+    ];
+    let extra = Item::new(shape.pk(), AttributeValue::S("str-c".into())).vec(v, [1.0, 4.0, 8.0]);
+    query_with_key_type(&actors, &shape, &initial, extra).await;
+    info!("finished");
+}
+
+#[framed]
+async fn query_with_number_key(actors: TestActors) {
+    info!("started");
+    let shape = TableShape {
+        table_prefix: None,
+        index_prefix: None,
+        pk_name: "Pk-NumKey".into(),
+        sk_name: None,
+        vec_name: Some("Vec-NumKey".into()),
+        pk_type: ScalarAttributeType::N,
+    };
+    let v = shape.vec().unwrap();
+    let initial = [
+        Item::new(shape.pk(), AttributeValue::N("1".into())).vec(v, [1.0, 1.0, 1.0]),
+        Item::new(shape.pk(), AttributeValue::N("2".into())).vec(v, [1.0, 2.0, 4.0]),
+    ];
+    let extra = Item::new(shape.pk(), AttributeValue::N("3".into())).vec(v, [1.0, 4.0, 8.0]);
+    query_with_key_type(&actors, &shape, &initial, extra).await;
+    info!("finished");
+}
+
+#[framed]
+async fn query_with_binary_key(actors: TestActors) {
+    info!("started");
+    let shape = TableShape {
+        table_prefix: None,
+        index_prefix: None,
+        pk_name: "Pk-BinKey".into(),
+        sk_name: None,
+        vec_name: Some("Vec-BinKey".into()),
+        pk_type: ScalarAttributeType::B,
+    };
+    let v = shape.vec().unwrap();
+    let initial = [
+        Item::new(shape.pk(), AttributeValue::B(Blob::new(vec![0x01u8]))).vec(v, [1.0, 1.0, 1.0]),
+        Item::new(shape.pk(), AttributeValue::B(Blob::new(vec![0x02u8]))).vec(v, [1.0, 2.0, 4.0]),
+    ];
+    let extra =
+        Item::new(shape.pk(), AttributeValue::B(Blob::new(vec![0x03u8]))).vec(v, [1.0, 4.0, 8.0]);
+    query_with_key_type(&actors, &shape, &initial, extra).await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "query_with_string_key",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_string_key,
+        )
+        .with_test(
+            "query_with_number_key",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_number_key,
+        )
+        .with_test(
+            "query_with_binary_key",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_binary_key,
+        )
+}

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -22,11 +22,18 @@ use super::dynamo_float_list;
 /// The expression is supplied by the caller and may reference:
 /// - `#vec` - the vector attribute name (always bound to `ctx.shape.vec_name`)
 /// - `:val` - the new value (bound when `value` is `Some`)
+/// - `#pk`  - the partition-key attribute name (bound to `ctx.pk` only when
+///   `condition_expr` is `Some`; Alternator rejects spurious bindings)
+///
+/// An optional `condition_expr` may be supplied; when `Some` it is set as the
+/// `ConditionExpression` on the request, allowing the caller to exercise the
+/// LWT/Paxos code path under `only_rmw_uses_lwt` write isolation.
 async fn update_item_expr(
     ctx: &TableContext,
     item: &Item,
     update_expr: &str,
     value: Option<AttributeValue>,
+    condition_expr: Option<&str>,
 ) -> Result<UpdateItemOutput, SdkError<UpdateItemError>> {
     let va = ctx.shape.vec().expect("TableContext has no vec_attr");
     let mut req = ctx
@@ -35,6 +42,11 @@ async fn update_item_expr(
         .table_name(&ctx.table_name)
         .update_expression(update_expr)
         .expression_attribute_names("#vec", va);
+    // Only bind #pk when a condition expression actually references it,
+    // otherwise Alternator rejects the request as having a spurious binding.
+    if condition_expr.is_some() {
+        req = req.expression_attribute_names("#pk", ctx.shape.pk());
+    }
     for attr_name in std::iter::once(ctx.shape.pk()).chain(ctx.shape.sk()) {
         if let Some(attr_val) = item.0.get(attr_name) {
             req = req.key(attr_name, attr_val.clone());
@@ -42,6 +54,9 @@ async fn update_item_expr(
     }
     if let Some(val) = value {
         req = req.expression_attribute_values(":val", val);
+    }
+    if let Some(cond) = condition_expr {
+        req = req.condition_expression(cond);
     }
     req.send().await
 }
@@ -80,6 +95,7 @@ async fn update_item_updates_index(actors: TestActors) {
             &b_updated,
             "SET #vec = :val",
             Some(dynamo_float_list(b_vec)),
+            None,
         )
         .await
         .expect("UpdateItem should succeed");
@@ -95,6 +111,7 @@ async fn update_item_updates_index(actors: TestActors) {
             &c_with_vec,
             "SET #vec = :val",
             Some(dynamo_float_list(c_vec)),
+            None,
         )
         .await
         .expect("UpdateItem should succeed");
@@ -103,7 +120,33 @@ async fn update_item_updates_index(actors: TestActors) {
         // a=[1,2,4] has cosine similarity ≈ -0.882 (second).
         // b_updated=[1,1,1] is antipodal to [-1,-1,-1] (similarity=-1, last).
         ctx.wait_for_count(3).await;
-        ctx.wait_for_ann([-1.0, -1.0, -1.0], &[c_with_vec, a, b_updated])
+        ctx.wait_for_ann(
+            [-1.0, -1.0, -1.0],
+            &[c_with_vec.clone(), a.clone(), b_updated.clone()],
+        )
+        .await;
+
+        // Conditional UpdateItem exercises the LWT/Paxos path under
+        // `only_rmw_uses_lwt` (ConditionExpression makes it RMW).
+        info!(
+            "Step 3: conditional UpdateItem (passing condition) in '{}'",
+            ctx.table_name
+        );
+        let a_new_vec = [4.0_f32, 2.0, 1.0];
+        let a_updated = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, a_new_vec);
+        update_item_expr(
+            &ctx,
+            &a_updated,
+            "SET #vec = :val",
+            Some(dynamo_float_list(a_new_vec)),
+            Some("attribute_exists(#pk)"),
+        )
+        .await
+        .expect("conditional UpdateItem with passing condition should succeed");
+        // a_updated=[4,2,1]: ANN([4,2,1]) ->
+        //   a_updated first (sim=1.0), b_updated=[1,1,1] second (sim≈0.882),
+        //   c=[-1,-1,-1] last (sim≈-0.882).
+        ctx.wait_for_ann([4.0, 2.0, 1.0], &[a_updated, b_updated, c_with_vec])
             .await;
 
         ctx.done().await;
@@ -142,7 +185,7 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
         AttributeValue::Null(true),
     ]);
 
-    update_item_expr(&ctx, &b, "REMOVE #vec", None)
+    update_item_expr(&ctx, &b, "REMOVE #vec", None, None)
         .await
         .expect("UpdateItem should succeed");
     ctx.wait_for_count(1).await;
@@ -155,18 +198,26 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
             &a,
             "SET #vec = :val",
             Some(AttributeValue::S("not-a-vector".into())),
+            None,
         )
         .await,
         "ValidationException",
     );
 
     super::assert_service_error(
-        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_string_elem)).await,
+        update_item_expr(
+            &ctx,
+            &a,
+            "SET #vec = :val",
+            Some(vec_with_string_elem),
+            None,
+        )
+        .await,
         "ValidationException",
     );
 
     super::assert_service_error(
-        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_null_elem)).await,
+        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_null_elem), None).await,
         "ValidationException",
     );
 
@@ -176,6 +227,7 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
             &a,
             "SET #vec = :val",
             Some(dynamo_float_list([1.0_f32, 1.0])),
+            None,
         )
         .await,
         "ValidationException",
@@ -187,10 +239,154 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
             &a,
             "SET #vec = :val",
             Some(dynamo_float_list([1.0_f32, 1.0, 1.0, 1.0])),
+            None,
         )
         .await,
         "ValidationException",
     );
+
+    ctx.done().await;
+    info!("finished");
+}
+
+/// Tests element-level `UpdateItem` operations on the vector column
+/// (`SET #vec[i]`, `REMOVE #vec[i]`, `list_append`, `ADD #vec[i]`) and
+/// verifies that VS reindexes or de-indexes items correctly.
+///
+/// Starts with 2 valid items and 3 invalid-vector items (mixed types, wrong
+/// dimensions). Steps 1-5 exercise mutations on a valid item (accepted and
+/// rejected). Steps 6-8 fix the invalid items. Step 9 tests ADD (LWT path).
+#[framed]
+async fn update_item_vector_element_operations(actors: TestActors) {
+    info!("started");
+
+    let patterns = super::name_patterns();
+    let shape = &patterns[0]; // plain names, HASH-only
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[0] always has vec");
+    let pk = shape.pk();
+
+    // Two valid items so ANN order is meaningful and vector changes are
+    // detectable.  Invalid items are pre-inserted before the index exists.
+    let valid_a = Item::key(pk, None, "pk", "valid-a").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let valid_b = Item::key(pk, None, "pk", "valid-b").vec(vec_attr, [4.0, 2.0, 1.0]);
+    let mixed = Item::key(pk, None, "pk", "mixed").attr(
+        vec_attr,
+        AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::S("3.0".into()),
+        ]),
+    );
+    let too_short =
+        Item::key(pk, None, "pk", "too-short").attr(vec_attr, dynamo_float_list([1.0_f32, 2.0]));
+    let too_long = Item::key(pk, None, "pk", "too-long")
+        .attr(vec_attr, dynamo_float_list([1.0_f32, 2.0, 4.0, 8.0]));
+
+    let ctx = TableContext::create_with_invalid_data(
+        &actors,
+        shape,
+        &[valid_a.clone(), valid_b.clone()],
+        &[mixed.clone(), too_short.clone(), too_long.clone()],
+    )
+    .await;
+    info!("Step 1: SET #vec[0] on 'valid_a'");
+    update_item_expr(
+        &ctx,
+        &valid_a,
+        "SET #vec[0] = :val",
+        Some(AttributeValue::N("5.0".into())),
+        None,
+    )
+    .await
+    .expect("UpdateItem should succeed");
+    let valid_a_step1 = Item::key(pk, None, "pk", "valid-a").vec(vec_attr, [5.0, 2.0, 4.0]);
+    ctx.wait_for_ann([5.0, 2.0, 4.0], &[valid_a_step1.clone(), valid_b.clone()])
+        .await;
+
+    info!("Step 2: SET #vec[0] = S on 'valid_a' (rejected)");
+    super::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &valid_a,
+            "SET #vec[0] = :val",
+            Some(AttributeValue::S("bad".into())),
+            None,
+        )
+        .await,
+        "ValidationException",
+    );
+
+    info!("Step 3: SET #vec[2] = NULL on 'valid_a' (rejected)");
+    super::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &valid_a,
+            "SET #vec[2] = :val",
+            Some(AttributeValue::Null(true)),
+            None,
+        )
+        .await,
+        "ValidationException",
+    );
+
+    info!("Step 4: REMOVE #vec[0] on 'valid_a' (rejected - wrong dimension)");
+    super::assert_service_error(
+        update_item_expr(&ctx, &valid_a, "REMOVE #vec[0]", None, None).await,
+        "ValidationException",
+    );
+
+    info!("Step 5: list_append on 'valid_a' (rejected - wrong dimension)");
+    super::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &valid_a,
+            "SET #vec = list_append(#vec, :val)",
+            Some(AttributeValue::L(vec![AttributeValue::N("1.0".into())])),
+            None,
+        )
+        .await,
+        "ValidationException",
+    );
+    info!("Step 6: SET #vec[2] on 'mixed'");
+    update_item_expr(
+        &ctx,
+        &mixed,
+        "SET #vec[2] = :val",
+        Some(AttributeValue::N("3.0".into())),
+        None,
+    )
+    .await
+    .expect("UpdateItem should succeed");
+    ctx.wait_for_count(3).await;
+    info!("Step 7: SET #vec[2] on 'too_short' (out-of-range index appends)");
+    update_item_expr(
+        &ctx,
+        &too_short,
+        "SET #vec[2] = :val",
+        Some(AttributeValue::N("4.0".into())),
+        None,
+    )
+    .await
+    .expect("UpdateItem should succeed");
+    ctx.wait_for_count(4).await;
+    info!("Step 8: REMOVE #vec[3] on 'too_long'");
+    update_item_expr(&ctx, &too_long, "REMOVE #vec[3]", None, None)
+        .await
+        .expect("UpdateItem should succeed");
+    ctx.wait_for_count(5).await;
+    info!("Step 9: ADD #vec[0] on 'valid_b' (ADD is always RMW -> LWT path)");
+    update_item_expr(
+        &ctx,
+        &valid_b,
+        "ADD #vec[0] :val",
+        Some(AttributeValue::N("1.0".into())),
+        None,
+    )
+    .await
+    .expect("UpdateItem ADD #vec[0] should succeed");
+    let valid_b_step9 = Item::key(pk, None, "pk", "valid-b").vec(vec_attr, [5.0, 2.0, 1.0]);
+    ctx.wait_for_count(5).await;
+    ctx.wait_for_ann([5.0, 2.0, 1.0], &[valid_b_step9]).await;
 
     ctx.done().await;
     info!("finished");
@@ -209,5 +405,10 @@ pub(super) async fn new() -> TestCase<TestActors> {
             "update_item_with_invalid_vector_is_not_indexed",
             common::DEFAULT_TEST_TIMEOUT,
             update_item_with_invalid_vector_is_not_indexed,
+        )
+        .with_test(
+            "update_item_vector_element_operations",
+            common::DEFAULT_TEST_TIMEOUT,
+            update_item_vector_element_operations,
         )
 }

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
+use aws_sdk_dynamodb::operation::update_item::UpdateItemOutput;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+use super::dynamo_float_list;
+
+/// Issues an `UpdateItem` on the vector column of `item`.
+///
+/// The expression is supplied by the caller and may reference:
+/// - `#vec` - the vector attribute name (always bound to `ctx.shape.vec_name`)
+/// - `:val` - the new value (bound when `value` is `Some`)
+async fn update_item_expr(
+    ctx: &TableContext,
+    item: &Item,
+    update_expr: &str,
+    value: Option<AttributeValue>,
+) -> Result<UpdateItemOutput, SdkError<UpdateItemError>> {
+    let va = ctx.shape.vec().expect("TableContext has no vec_attr");
+    let mut req = ctx
+        .client
+        .update_item()
+        .table_name(&ctx.table_name)
+        .update_expression(update_expr)
+        .expression_attribute_names("#vec", va);
+    for attr_name in std::iter::once(ctx.shape.pk()).chain(ctx.shape.sk()) {
+        if let Some(attr_val) = item.0.get(attr_name) {
+            req = req.key(attr_name, attr_val.clone());
+        }
+    }
+    if let Some(val) = value {
+        req = req.expression_attribute_values(":val", val);
+    }
+    req.send().await
+}
+
+/// Updates a vector via `UpdateItem` and verifies the VS index reflects the
+/// change. Covers replacing an existing vector, adding a vector to a
+/// previously unindexed item, and conditional UpdateItem (LWT path).
+///
+/// Starting state: `a` and `b` indexed, `c` has no vector (count=2).
+#[framed]
+async fn update_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &super::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let vec_attr = shape.vec().expect("NAME_PATTERNS entries always have vec");
+
+        let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 4.0, 8.0]);
+        let c_no_vec = Item::key(shape.pk(), shape.sk(), "pk", "c");
+
+        let ctx = TableContext::create_with_invalid_data(
+            &actors,
+            shape,
+            &[a.clone(), b.clone()],
+            std::slice::from_ref(&c_no_vec),
+        )
+        .await;
+
+        info!("Step 1: updating 'b' vector in '{}'", ctx.table_name);
+        let b_vec = [1.0, 1.0, 1.0];
+        let b_updated = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, b_vec);
+        update_item_expr(
+            &ctx,
+            &b_updated,
+            "SET #vec = :val",
+            Some(dynamo_float_list(b_vec)),
+        )
+        .await
+        .expect("UpdateItem should succeed");
+
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b_updated.clone(), a.clone()])
+            .await;
+
+        info!("Step 2: adding vector to 'c' in '{}'", ctx.table_name);
+        let c_vec = [-1.0, -1.0, -1.0];
+        let c_with_vec = Item::key(shape.pk(), shape.sk(), "pk", "c").vec(vec_attr, c_vec);
+        update_item_expr(
+            &ctx,
+            &c_with_vec,
+            "SET #vec = :val",
+            Some(dynamo_float_list(c_vec)),
+        )
+        .await
+        .expect("UpdateItem should succeed");
+
+        // c=[-1,-1,-1] is identical to query [-1,-1,-1] (similarity=1, first).
+        // a=[1,2,4] has cosine similarity ≈ -0.882 (second).
+        // b_updated=[1,1,1] is antipodal to [-1,-1,-1] (similarity=-1, last).
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([-1.0, -1.0, -1.0], &[c_with_vec, a, b_updated])
+            .await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Tests that `UpdateItem` operations which result in an absent or invalid
+/// vector are handled correctly: REMOVE of the vector column de-indexes the
+/// item (the row remains in the table but without a vector - analogous to
+/// `put_item_with_invalid_vector_is_not_indexed` where a PutItem without a
+/// vector column is accepted but not indexed), and wrong-type updates are
+/// rejected by Scylla with `ValidationException`.
+#[framed]
+async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
+    info!("started");
+
+    let shape = &super::name_patterns()[0]; // plain names, HASH-only
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[0] always has vec");
+
+    let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 1.0, 1.0]);
+
+    let ctx = TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone()]).await;
+
+    let vec_with_string_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::S("3.0".into()),
+    ]);
+    let vec_with_null_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::Null(true),
+    ]);
+
+    update_item_expr(&ctx, &b, "REMOVE #vec", None)
+        .await
+        .expect("UpdateItem should succeed");
+    ctx.wait_for_count(1).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&a))
+        .await;
+
+    super::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &a,
+            "SET #vec = :val",
+            Some(AttributeValue::S("not-a-vector".into())),
+        )
+        .await,
+        "ValidationException",
+    );
+
+    super::assert_service_error(
+        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_string_elem)).await,
+        "ValidationException",
+    );
+
+    super::assert_service_error(
+        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_null_elem)).await,
+        "ValidationException",
+    );
+
+    super::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &a,
+            "SET #vec = :val",
+            Some(dynamo_float_list([1.0_f32, 1.0])),
+        )
+        .await,
+        "ValidationException",
+    );
+
+    super::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &a,
+            "SET #vec = :val",
+            Some(dynamo_float_list([1.0_f32, 1.0, 1.0, 1.0])),
+        )
+        .await,
+        "ValidationException",
+    );
+
+    ctx.done().await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "update_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            update_item_updates_index,
+        )
+        .with_test(
+            "update_item_with_invalid_vector_is_not_indexed",
+            common::DEFAULT_TEST_TIMEOUT,
+            update_item_with_invalid_vector_is_not_indexed,
+        )
+}

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use serde_json::Value;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+use super::TableShape;
+use super::dynamo_float_list;
+use super::name_patterns;
+use super::update_table_vector_indexes;
+use super::wait_for_index_count;
+use crate::common::wait_for_no_index;
+
+fn vector_index_create_update(index_name: &str, vec_attr: &str, dimensions: usize) -> Value {
+    serde_json::json!([
+        {
+            "Create": {
+                "IndexName": index_name,
+                "VectorAttribute": {
+                    "AttributeName": vec_attr,
+                    "Dimensions": dimensions
+                }
+            }
+        }
+    ])
+}
+
+fn vector_index_delete_update(index_name: &str) -> Value {
+    serde_json::json!([
+        {
+            "Delete": {
+                "IndexName": index_name
+            }
+        }
+    ])
+}
+
+/// Creates a plain Alternator table (no vector index), then issues an
+/// `UpdateTable` with `VectorIndexUpdates[{Create: ...}]` and waits for the
+/// Vector Store to start serving the newly created index.
+///
+/// Loops [`NAME_PATTERNS`](NAME_PATTERNS) using
+/// `TableShape { vec_name: None, ..*shape }` to create the table without an index,
+/// then adds the index via UpdateTable using the shape's naming conventions.
+#[framed]
+async fn create_vector_index_via_update_table(actors: TestActors) {
+    info!("started");
+
+    for shape in &name_patterns() {
+        let no_vec_shape = TableShape {
+            vec_name: None,
+            pk_type: shape.pk_type.clone(),
+            ..shape.clone()
+        };
+        let vec_attr = shape.vec().unwrap_or("vec");
+        info!("Testing shape: {shape:?}");
+
+        let ctx = TableContext::create(&actors, &no_vec_shape).await;
+
+        info!("Confirming no index exists yet for '{}'", ctx.table_name);
+        wait_for_no_index(&ctx.vs_client, &ctx.index).await;
+
+        info!(
+            "Issuing UpdateTable for '{}' to add vector index '{}'",
+            ctx.table_name, ctx.index.index
+        );
+        update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            vector_index_create_update(ctx.index.index.as_ref(), vec_attr, 3),
+        )
+        .await;
+
+        info!(
+            "Waiting for Vector Store to serve index '{}/{}'",
+            ctx.index.keyspace, ctx.index.index
+        );
+        common::wait_for_index(&ctx.vs_client, &ctx.index).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Like [`create_vector_index_via_update_table`] but inserts data (including
+/// invalid-vector rows) before adding the index.  Verifies that the
+/// full-scan path indexes only valid items and skips non-indexable rows.
+#[framed]
+async fn create_vector_index_via_update_table_with_preexisting_data(actors: TestActors) {
+    info!("started");
+
+    for shape in &name_patterns() {
+        let vec_attr = shape.vec().unwrap_or("vec");
+        info!("Testing shape: {shape:?}");
+
+        let no_vec_shape = TableShape {
+            vec_name: None,
+            pk_type: shape.pk_type.clone(),
+            ..shape.clone()
+        };
+
+        let vec_with_string_elem = AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::S("3.0".into()),
+        ]);
+        let vec_with_null_elem = AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::Null(true),
+        ]);
+        let valid_items = [
+            Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]),
+        ];
+        let mut all_items = valid_items.to_vec();
+        all_items.extend([
+            Item::key(shape.pk(), shape.sk(), "pk", "no-vec"),
+            Item::key(shape.pk(), shape.sk(), "pk", "wrong-type-string")
+                .attr(vec_attr, AttributeValue::S("not-a-vector".into())),
+            Item::key(
+                shape.pk(),
+                shape.sk(),
+                "pk",
+                "wrong-type-mostly-float-one-s",
+            )
+            .attr(vec_attr, vec_with_string_elem),
+            Item::key(
+                shape.pk(),
+                shape.sk(),
+                "pk",
+                "wrong-type-mostly-float-one-null",
+            )
+            .attr(vec_attr, vec_with_null_elem),
+            Item::key(shape.pk(), shape.sk(), "pk", "wrong-type-too-short")
+                .attr(vec_attr, dynamo_float_list([1.0_f32, 1.0])),
+            Item::key(shape.pk(), shape.sk(), "pk", "wrong-type-too-long")
+                .attr(vec_attr, dynamo_float_list([1.0_f32, 1.0, 1.0, 1.0])),
+        ]);
+
+        let ctx = TableContext::create_with_data(&actors, &no_vec_shape, &all_items).await;
+
+        info!("Confirming no index exists yet for '{}'", ctx.table_name);
+        wait_for_no_index(&ctx.vs_client, &ctx.index).await;
+
+        info!(
+            "Issuing UpdateTable for '{}' to add vector index '{}'",
+            ctx.table_name, ctx.index.index
+        );
+        update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            vector_index_create_update(ctx.index.index.as_ref(), vec_attr, 3),
+        )
+        .await;
+
+        info!(
+            "Waiting for Vector Store to serve index '{}/{}'",
+            ctx.index.keyspace, ctx.index.index
+        );
+        common::wait_for_index(&ctx.vs_client, &ctx.index).await;
+        wait_for_index_count(&ctx.vs_client, &ctx.index, valid_items.len()).await;
+
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &valid_items).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Creates an Alternator table (with a vector index) for each shape in
+/// [`NAME_PATTERNS`], inserts data and waits for VS to index it, then issues
+/// `UpdateTable` with `VectorIndexUpdates[{Delete: ...}]` and confirms the
+/// index disappears.  After deletion, verifies that Scylla accepts a `PutItem`
+/// with a non-vector value for the previously-indexed attribute (which would
+/// have been rejected as a `ValidationException` while the index was active).
+/// Loops [`NAME_PATTERNS`](NAME_PATTERNS).
+#[framed]
+async fn delete_vector_index_via_update_table(actors: TestActors) {
+    info!("started");
+
+    for shape in &name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let vec_attr = shape.vec().unwrap();
+        let items = [
+            Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]),
+        ];
+        let ctx = TableContext::create_with_data(&actors, shape, &items).await;
+
+        info!(
+            "Issuing UpdateTable for '{}' to delete vector index '{}'",
+            ctx.table_name, ctx.index.index
+        );
+        update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            vector_index_delete_update(ctx.index.index.as_ref()),
+        )
+        .await;
+
+        info!(
+            "Waiting for Vector Store to drop index '{}/{}'",
+            ctx.index.keyspace, ctx.index.index
+        );
+        wait_for_no_index(&ctx.vs_client, &ctx.index).await;
+
+        info!("Confirming arbitrary writes are accepted after index deletion");
+        ctx.put(
+            &Item::key(shape.pk(), shape.sk(), "pk", "c")
+                .attr(vec_attr, AttributeValue::S("not-a-vector".into())),
+        )
+        .await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "create_vector_index_via_update_table",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_vector_index_via_update_table,
+        )
+        .with_test(
+            "create_vector_index_via_update_table_with_preexisting_data",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_vector_index_via_update_table_with_preexisting_data,
+        )
+        .with_test(
+            "delete_vector_index_via_update_table",
+            common::DEFAULT_TEST_TIMEOUT,
+            delete_vector_index_via_update_table,
+        )
+}

--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -491,6 +491,29 @@ pub async fn wait_for_index(client: &HttpClient, index: &IndexInfo) -> IndexStat
     .await
 }
 
+/// Polls the VS HTTP endpoint until the given index is no longer visible
+/// (i.e. `index_status` returns an error).  Used to confirm that a delete
+/// action (via `UpdateTable` or `DeleteTable`) has been processed and
+/// propagated to the Vector Store.
+pub async fn wait_for_no_index(client: &HttpClient, index: &IndexInfo) {
+    wait_for(
+        || async {
+            client
+                .index_status(&index.keyspace, &index.index)
+                .await
+                .is_err()
+        },
+        format!(
+            "index '{}/{}' to be gone at {}",
+            index.keyspace,
+            index.index,
+            client.url()
+        ),
+        Duration::from_secs(60),
+    )
+    .await;
+}
+
 #[framed]
 pub async fn get_query_results(query: impl Into<String>, session: &Session) -> QueryRowsResult {
     let mut stmt = Statement::new(query);
@@ -522,7 +545,7 @@ static KEYSPACE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static TABLE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static INDEX_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-fn unique_name(prefix: &str, counter: &AtomicUsize) -> String {
+pub fn unique_name(prefix: &str, counter: &AtomicUsize) -> String {
     format!(
         "{prefix}_{counter}",
         counter = counter.fetch_add(1, Ordering::Relaxed)

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod alternator;
 mod ann;
 mod auth;
 mod cdc;
@@ -244,4 +245,5 @@ pub async fn test_cases() -> impl Iterator<Item = (String, TestCase<TestActors>)
     ]
     .into_iter()
     .map(|(name, test_case)| (name.to_string(), test_case))
+    .chain(alternator::test_cases().await)
 }


### PR DESCRIPTION
Add Alternator validator coverage for the main request paths exercised by
the Vector Store integration.

The new tests cover table creation, table updates, and table deletion, as
well as item operations including put, update, delete, and batch writes.
They also verify query behavior, including vector search requests and
result limiting.

Necessary AWS SDK dependencies are added to enable Alternator client.

Fixes: https://scylladb.atlassian.net/browse/VECTOR-581