### PR TITLE
fix index status endpoint to reflect actual scan progress

### DIFF
--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -43,6 +43,8 @@ use axum_server_dual_protocol::Protocol;
 use bigdecimal::BigDecimal;
 use httpapi::DataType;
 use httpapi::IndexInfo;
+use httpapi::IndexStatus;
+use httpapi::IndexStatusResponse;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use prometheus::Encoder;
@@ -316,7 +318,7 @@ async fn get_index_status(
     let keyspace_name: crate::KeyspaceName = keyspace_name.into();
     let index_name: crate::IndexName = index_name.into();
     let index_key = IndexKey::new(&keyspace_name, &index_name);
-    let Some((index, _)) = state.engine.get_index(index_key.clone()).await else {
+    let Some((index, db_index)) = state.engine.get_index(index_key.clone()).await else {
         let msg = format!("missing index: {keyspace_name}.{index_name}");
         debug!("get_index_status: {msg}");
         return (StatusCode::NOT_FOUND, msg).into_response();
@@ -326,6 +328,13 @@ async fn get_index_status(
         .get_index_status(keyspace_name.as_ref(), index_name.as_ref())
         .await
     {
+        // Use the same full-scan-progress check as the ANN endpoint: if the scan
+        // is still in progress, report BOOTSTRAPPING even if the state machine
+        // already transitioned to Serving.
+        let status = match db_index.full_scan_progress().await {
+            Progress::InProgress(_) => IndexStatus::Bootstrapping,
+            Progress::Done => IndexStatus::from(index_status),
+        };
         match index.count(index_key).await {
             Err(err) => {
                 let msg = format!("index.count request error: {err}");
@@ -334,10 +343,7 @@ async fn get_index_status(
             }
             Ok(count) => (
                 StatusCode::OK,
-                response::Json(httpapi::IndexStatusResponse {
-                    status: index_status.into(),
-                    count,
-                }),
+                response::Json(IndexStatusResponse { status, count }),
             )
                 .into_response(),
         }


### PR DESCRIPTION
fix index status endpoint to reflect actual scan progress
    
The GET /api/v1/indexes/{keyspace}/{index}/status endpoint was reporting
SERVING based solely on the node state machine, which transitions to
Serving when FullScanFinished is emitted. However, the ANN query endpoint
independently checks db_index.full_scan_progress() and returns 503 if the
scan is still InProgress.
    
These two checks could disagree. We noticed in Alternator Vector Search
when indexing a table with numeric keys (instead of string), that a
separate bug in the vector store caused the indexing to fail, after
which the "status" API reported the index is SERVING - while the "ann"
API refused to proceed because it knew the indexing never finished.
    
These two APIs need to be consistent: If an "ann" will never succeed
because the indexing is permenently stuck in the middle (because of
a bug...), then the "status" API should also permanently report
BOOTSTRAPPING, not SERVING.
    
Fix by making get_index_status use the same full_scan_progress() check as
the ANN endpoint: report BOOTSTRAPPING whenever the scan is still InProgress,
regardless of the state machine.
    
Fixes VECTOR-595