### PR TITLE
vector-store: fix blob primary key round-trip in CQL path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
 
 [[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +2719,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +2857,15 @@ name = "rand_pcg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
@@ -4003,6 +4039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4253,6 +4295,7 @@ dependencies = [
  "axum-server-dual-protocol",
  "chrono",
  "clap",
+ "const-hex",
  "criterion",
  "dashmap 6.1.0",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ axum = { version = "0.8.1", features = ["macros"] }
 axum-server = { version = "0.7.2", features = ["tls-rustls"] }
 axum-server-dual-protocol = "0.7.0"
 bcrypt = "0.15"
+const-hex = "1.18.1"
 clap = { version = "4.5.40", features = ["derive"] }
 chrono = "0.4.43"
 criterion = { version = "0.8.2", features = ["async_tokio"] }

--- a/crates/validator-vector-store/src/serde.rs
+++ b/crates/validator-vector-store/src/serde.rs
@@ -29,6 +29,7 @@ async fn test_serialization_deserialization_all_types(actors: TestActors) {
     let cases = vec![
         ("ascii", "'random_text'"),
         ("bigint", "1234"),
+        ("blob", "0xdeadbeef"),
         ("boolean", "true"),
         ("date", "'2023-10-01'"),
         ("double", "3.14159"),

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -31,6 +31,7 @@ axum-server.workspace = true
 axum-server-dual-protocol.workspace = true
 clap.workspace = true
 chrono.workspace = true
+const-hex.workspace = true
 dashmap.workspace = true
 derive_more.workspace = true
 dotenvy.workspace = true

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -867,6 +867,8 @@ fn try_to_json(value: CqlValue) -> anyhow::Result<Value> {
             })?,
         )),
 
+        CqlValue::Blob(value) => Ok(Value::String(const_hex::encode_prefixed(&value))),
+
         _ => unimplemented!(),
     }
 }
@@ -919,6 +921,14 @@ fn try_from_json(value: Value, cql_type: &NativeType) -> anyhow::Result<CqlValue
                 })
                 .map_err(|err| anyhow!("Failed to parse Timestamp from string '{value}': {err}"))?;
                 Ok(CqlValue::Timestamp(datetime.into()))
+            }
+            NativeType::Blob => {
+                if !value.starts_with("0x") {
+                    bail!("Blob value must be a '0x'-prefixed hex string");
+                }
+                let bytes = const_hex::decode(&value)
+                    .map_err(|err| anyhow!("Invalid hex in blob value: {err}"))?;
+                Ok(CqlValue::Blob(bytes))
             }
             _ => bail!("Cannot convert string to CqlValue::{cql_type:?}, unsupported type"),
         },
@@ -1547,6 +1557,26 @@ mod tests {
             .unwrap(),
             CqlValue::Timestamp(OffsetDateTime::from_unix_timestamp(64).unwrap().into())
         );
+
+        assert_eq!(
+            try_from_json(Value::String("0xdeadbeef".to_string()), &NativeType::Blob).unwrap(),
+            CqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])
+        );
+        assert_eq!(
+            try_from_json(Value::String("0x".to_string()), &NativeType::Blob).unwrap(),
+            CqlValue::Blob(vec![])
+        );
+        assert_eq!(
+            try_from_json(Value::String("0x00".to_string()), &NativeType::Blob).unwrap(),
+            CqlValue::Blob(vec![0x00])
+        );
+
+        // missing 0x prefix
+        assert!(try_from_json(Value::String("deadbeef".to_string()), &NativeType::Blob).is_err());
+        // invalid hex characters
+        assert!(try_from_json(Value::String("0xgg".to_string()), &NativeType::Blob).is_err());
+        // odd-length hex digits (after stripping prefix)
+        assert!(try_from_json(Value::String("0xabc".to_string()), &NativeType::Blob).is_err());
     }
 
     #[test]
@@ -1639,6 +1669,19 @@ mod tests {
         );
         assert!(try_to_json(CqlValue::Float(f32::NAN)).is_err());
         assert!(try_to_json(CqlValue::Double(f64::NAN)).is_err());
+
+        assert_eq!(
+            try_to_json(CqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])).unwrap(),
+            Value::String("0xdeadbeef".to_string())
+        );
+        assert_eq!(
+            try_to_json(CqlValue::Blob(vec![])).unwrap(),
+            Value::String("0x".to_string())
+        );
+        assert_eq!(
+            try_to_json(CqlValue::Blob(vec![0x00])).unwrap(),
+            Value::String("0x00".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Blob is a valid CQL primary key type. Previously, try_to_json hit unimplemented!() for CqlValue::Blob (crashing the server when a blob key appeared in an ANN result), and try_from_json had no NativeType::Blob arm (failing any ANN filter restriction on a blob-keyed column).

- try_to_json: serialise CqlValue::Blob as a '0x'-prefixed lowercase hex string, consistent with how CQL JSON represents blob values.
- try_from_json: parse '0x'-prefixed hex strings back into CqlValue::Blob so blob keys round-trip through the VS HTTP layer.
- Add unit tests covering both directions including empty blobs, single bytes, multi-byte values, and error cases (missing prefix, invalid hex, odd-length hex).
- Add blob to the serde validator test matrix, exercising the full CQL blob-key lifecycle: table creation, full-scan ingestion into InvariantKey, and ANN query results serialized via try_to_json.

Fixes: VECTOR-608