### PR TITLE
vector-store: add index routing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Run cargo-clippy checks
       run: cargo clippy --all-targets --workspace -- -Dwarnings
 
+    - name: Run cargo-clippy checks for test-hooks feature flag
+      run: cargo clippy --features slow-test-hooks --all-targets --workspace -- -Dwarnings
+
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
@@ -70,7 +73,7 @@ jobs:
       run: rustc --version
 
     - name: Run cargo-test checks
-      run: cargo test --features dev-tools --verbose --all-targets --workspace
+      run: cargo test --features dev-tools,slow-test-hooks --verbose --all-targets --workspace
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -126,7 +126,7 @@ async fn ann_filter_by_partition_key_eq(actors: TestActors) {
         || async {
             let result = get_opt_query_results(
                 format!(
-                    "SELECT pk, ck FROM {table} WHERE pk = 1 ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 20"
+                    "SELECT pk, ck FROM {table} WHERE pk = 1 ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 20 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -197,7 +197,7 @@ async fn ann_filter_by_partition_key_in(actors: TestActors) {
         || async {
             let result = get_opt_query_results(
                 format!(
-                    "SELECT pk, ck FROM {table} WHERE pk IN (0, 2) ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 20"
+                    "SELECT pk, ck FROM {table} WHERE pk IN (0, 2) ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 20 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -264,7 +264,7 @@ async fn ann_filter_by_clustering_key_lt(actors: TestActors) {
         || async {
             let result = get_opt_query_results(
                 format!(
-                    "SELECT ck FROM {table} WHERE pk = 0 AND ck < 3 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10"
+                    "SELECT ck FROM {table} WHERE pk = 0 AND ck < 3 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -331,7 +331,7 @@ async fn ann_filter_by_clustering_key_gt(actors: TestActors) {
         || async {
             let result = get_opt_query_results(
                 format!(
-                    "SELECT ck FROM {table} WHERE pk = 0 AND ck > 7 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10"
+                    "SELECT ck FROM {table} WHERE pk = 0 AND ck > 7 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -398,7 +398,7 @@ async fn ann_filter_by_clustering_key_range(actors: TestActors) {
         || async {
             let result = get_opt_query_results(
                 format!(
-                    "SELECT ck FROM {table} WHERE pk = 0 AND ck >= 3 AND ck <= 5 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10"
+                    "SELECT ck FROM {table} WHERE pk = 0 AND ck >= 3 AND ck <= 5 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -471,7 +471,7 @@ async fn ann_filter_by_pk_and_ck(actors: TestActors) {
         || async {
             let result = get_opt_query_results(
                 format!(
-                    "SELECT pk, ck1, ck2 FROM {table} WHERE pk = 1 AND ck1 = 0 ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 20"
+                    "SELECT pk, ck1, ck2 FROM {table} WHERE pk = 1 AND ck1 = 0 ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 20 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -541,7 +541,7 @@ async fn ann_filter_returns_no_results_when_nothing_matches(actors: TestActors) 
         || async {
             get_opt_query_results(
                 format!(
-                    "SELECT ck FROM {table} WHERE pk = 0 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10"
+                    "SELECT ck FROM {table} WHERE pk = 0 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -555,7 +555,7 @@ async fn ann_filter_returns_no_results_when_nothing_matches(actors: TestActors) 
 
     // Query for a partition key that does not exist
     let results = get_query_results(
-        format!("SELECT ck FROM {table} WHERE pk = 999 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10"),
+        format!("SELECT ck FROM {table} WHERE pk = 999 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"),
         &session,
     )
     .await;
@@ -608,7 +608,7 @@ async fn ann_filter_by_vector_column_fails(actors: TestActors) {
     session
         .query_unpaged(
             format!(
-                "SELECT pk FROM {table} WHERE v = [1.0, 0.0, 0.0] ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 5"
+                "SELECT pk FROM {table} WHERE v = [1.0, 0.0, 0.0] ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 5 ALLOW FILTERING"
             ),
             (),
         )
@@ -659,7 +659,7 @@ async fn ann_filter_by_non_indexed_column_fails(actors: TestActors) {
 
     session
         .query_unpaged(
-            format!("SELECT pk FROM {table} WHERE f = 1 ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 5"),
+            format!("SELECT pk FROM {table} WHERE f = 1 ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 5 ALLOW FILTERING"),
             (),
         )
         .await
@@ -792,7 +792,7 @@ async fn local_index_filter_by_clustering_key_range(actors: TestActors) {
         || async {
             let result = get_opt_query_results(
                 format!(
-                    "SELECT ck FROM {table} WHERE pk = 0 AND ck >= 3 AND ck <= 5 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10"
+                    "SELECT ck FROM {table} WHERE pk = 0 AND ck >= 3 AND ck <= 5 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
                 ),
                 &session,
             )
@@ -1005,7 +1005,8 @@ async fn local_ann_with_timestamp_gte_filter(actors: TestActors) {
             "SELECT pk FROM {table} \
              WHERE pk = 'alice' AND board_id = 42 \
              AND created_at >= '2024-01-01' \
-             ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5"
+             ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5
+             ALLOW FILTERING"
         ),
         &session,
     )

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -17,6 +17,7 @@ mod index_create;
 mod index_status;
 mod quantization_and_rescoring;
 mod reconnect;
+mod routing;
 mod serde;
 mod similarity_functions;
 
@@ -233,6 +234,7 @@ pub async fn test_cases() -> impl Iterator<Item = (String, TestCase<TestActors>)
         ("index_status", index_status::new().await),
         ("index_create", index_create::new().await),
         ("reconnect", reconnect::new().await),
+        ("routing", routing::new().await),
         ("serde", serde::new().await),
         ("similarity_function", similarity_functions::new().await),
         (

--- a/crates/validator/src/routing.rs
+++ b/crates/validator/src/routing.rs
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::TestActors;
+use crate::common::*;
+use async_backtrace::framed;
+use e2etest::TestCase;
+use e2etest_scylla_proxy_cluster::ScyllaProxyClusterExt;
+use httpapi::IndexInfo;
+use httpapi::IndexStatus;
+use httpclient::HttpClient;
+use scylla_proxy::Condition;
+use scylla_proxy::Reaction;
+use scylla_proxy::RequestReaction;
+use scylla_proxy::RequestRule;
+use std::time::Duration;
+use tracing::info;
+
+const ANN_LIMIT: usize = 5;
+const FRAME_DELAY: Duration = Duration::from_millis(100);
+
+#[framed]
+pub(crate) async fn new() -> TestCase<TestActors> {
+    let timeout = DEFAULT_TEST_TIMEOUT;
+    TestCase::empty()
+        .with_init(timeout, init_with_proxy_single_vs)
+        .with_cleanup(timeout, cleanup)
+        .with_test(
+            "ann_routes_to_serving_index_while_replacement_is_bootstrapping",
+            timeout,
+            ann_routes_to_serving_index_while_replacement_is_bootstrapping,
+        )
+        .with_test(
+            "ann_does_not_route_between_columns_while_requested_index_is_bootstrapping",
+            timeout,
+            ann_does_not_route_between_columns_while_requested_index_is_bootstrapping,
+        )
+        .with_test(
+            "ann_returns_not_found_for_nonexistent_index",
+            timeout,
+            ann_returns_not_found_for_nonexistent_index,
+        )
+        .with_test(
+            "ann_returns_unavailable_when_only_index_is_bootstrapping",
+            timeout,
+            ann_returns_unavailable_when_only_index_is_bootstrapping,
+        )
+        .with_test(
+            "ann_returns_not_found_after_index_is_dropped",
+            timeout,
+            ann_returns_not_found_after_index_is_dropped,
+        )
+}
+
+async fn wait_for_bootstrapping(client: &HttpClient, index: &IndexInfo) {
+    wait_for_value(
+        || async {
+            match client.index_status(&index.keyspace, &index.index).await {
+                Ok(status) if status.status == IndexStatus::Bootstrapping => Some(status),
+                _ => None,
+            }
+        },
+        format!(
+            "index '{}' must stay bootstrapping at {}",
+            index.index,
+            client.url()
+        ),
+        Duration::from_secs(60),
+    )
+    .await;
+}
+
+#[framed]
+async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
+    let client = clients.first().expect("expected a single HTTP client");
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, embedding) VALUES (0, [1.0, 2.0, 3.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert test embedding");
+
+    let oldest = create_index(CreateIndexQuery::new(
+        &session,
+        &clients,
+        &table,
+        "embedding",
+    ))
+    .await;
+    let oldest_status = wait_for_index(client, &oldest).await;
+    assert_eq!(oldest_status.count, 1);
+
+    actors
+        .db_proxy
+        .change_request_rules(Some(vec![RequestRule(
+            Condition::True,
+            RequestReaction::delay(FRAME_DELAY),
+        )]))
+        .await;
+
+    let replacement = create_index(CreateIndexQuery::new(
+        &session,
+        &clients,
+        &table,
+        "embedding",
+    ))
+    .await;
+
+    wait_for_bootstrapping(client, &replacement).await;
+
+    get_query_results(
+        format!(
+            "SELECT * FROM {table} ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT {ANN_LIMIT}"
+        ),
+        &session,
+    )
+    .await;
+
+    actors.db_proxy.turn_off_rules().await;
+    let replacement_status = wait_for_index(client, &replacement).await;
+    assert_eq!(replacement_status.count, 1);
+
+    session
+        .query_unpaged(format!("DROP INDEX {}", oldest.index), ())
+        .await
+        .expect("failed to drop oldest index");
+
+    wait_for(
+        || async {
+            client
+                .indexes()
+                .await
+                .iter()
+                .all(|i| i.index != oldest.index)
+        },
+        "oldest index must be removed",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+
+    get_query_results(
+        format!(
+            "SELECT * FROM {table} ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT {ANN_LIMIT}"
+        ),
+        &session,
+    )
+    .await;
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+#[framed]
+async fn ann_does_not_route_between_columns_while_requested_index_is_bootstrapping(
+    actors: TestActors,
+) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
+    let client = clients.first().expect("expected a single HTTP client");
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>, embedding2 VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+    session
+        .query_unpaged(
+            format!(
+                "INSERT INTO {table} (pk, embedding, embedding2) VALUES (0, [1.0, 2.0, 3.0], [1.0, 2.0, 3.0])"
+            ),
+            (),
+        )
+        .await
+        .expect("failed to insert test embedding");
+
+    let source = create_index(CreateIndexQuery::new(
+        &session,
+        &clients,
+        &table,
+        "embedding",
+    ))
+    .await;
+    let source_status = wait_for_index(client, &source).await;
+    assert_eq!(source_status.count, 1);
+
+    actors
+        .db_proxy
+        .change_request_rules(Some(vec![RequestRule(
+            Condition::True,
+            RequestReaction::delay(FRAME_DELAY),
+        )]))
+        .await;
+
+    let requested = create_index(CreateIndexQuery::new(
+        &session,
+        &clients,
+        &table,
+        "embedding2",
+    ))
+    .await;
+
+    wait_for_bootstrapping(client, &requested).await;
+
+    session
+        .query_unpaged(
+            format!(
+                "SELECT * FROM {table} ORDER BY embedding2 ANN OF [1.0, 2.0, 3.0] LIMIT {ANN_LIMIT}"
+            ),
+            (),
+        )
+        .await
+        .expect_err("ANN query should fail when index is bootstrapping");
+
+    actors.db_proxy.turn_off_rules().await;
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+#[framed]
+async fn ann_returns_not_found_for_nonexistent_index(actors: TestActors) {
+    info!("started");
+
+    let (session, _clients) = prepare_connection_single_vs_no_tls(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!(
+                "SELECT * FROM {table} ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT {ANN_LIMIT}"
+            ),
+            (),
+        )
+        .await
+        .expect_err("ANN query should fail when no index exists");
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+#[framed]
+async fn ann_returns_unavailable_when_only_index_is_bootstrapping(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
+    let client = clients.first().expect("expected a single HTTP client");
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, embedding) VALUES (0, [1.0, 2.0, 3.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert test embedding");
+
+    actors
+        .db_proxy
+        .change_request_rules(Some(vec![RequestRule(
+            Condition::True,
+            RequestReaction::delay(FRAME_DELAY),
+        )]))
+        .await;
+
+    let index = create_index(CreateIndexQuery::new(
+        &session,
+        &clients,
+        &table,
+        "embedding",
+    ))
+    .await;
+
+    wait_for_bootstrapping(client, &index).await;
+
+    session
+        .query_unpaged(
+            format!(
+                "SELECT * FROM {table} ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT {ANN_LIMIT}"
+            ),
+            (),
+        )
+        .await
+        .expect_err("ANN query should fail when index is bootstrapping");
+
+    actors.db_proxy.turn_off_rules().await;
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+#[framed]
+async fn ann_returns_not_found_after_index_is_dropped(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
+    let client = clients.first().expect("expected a single HTTP client");
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, embedding) VALUES (0, [1.0, 2.0, 3.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert test embedding");
+
+    let index = create_index(CreateIndexQuery::new(
+        &session,
+        &clients,
+        &table,
+        "embedding",
+    ))
+    .await;
+    let index_status = wait_for_index(client, &index).await;
+    assert_eq!(index_status.count, 1);
+
+    get_query_results(
+        format!(
+            "SELECT * FROM {table} ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT {ANN_LIMIT}"
+        ),
+        &session,
+    )
+    .await;
+
+    session
+        .query_unpaged(format!("DROP INDEX {}", index.index), ())
+        .await
+        .expect("failed to drop index");
+
+    wait_for(
+        || async { client.indexes().await.is_empty() },
+        "index must be removed",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!(
+                "SELECT * FROM {table} ORDER BY embedding ANN OF [1.0, 2.0, 3.0] LIMIT {ANN_LIMIT}"
+            ),
+            (),
+        )
+        .await
+        .expect_err("ANN query should fail after index is dropped");
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -22,6 +22,7 @@ harness = false
 [features]
 default = []
 dev-tools = []
+slow-test-hooks = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::Config;
 use crate::DbIndexType;
 use crate::IndexKey;
@@ -16,14 +17,17 @@ use crate::db_index::DbIndexExt;
 use crate::factory::IndexFactory;
 use crate::index::Index;
 use crate::index::factory::IndexConfiguration;
+use crate::indexes;
+use crate::indexes::BestIndexState;
+use crate::indexes::IndexEntry;
+use crate::indexes::Indexes;
+use crate::indexes::RoutingMap;
 use crate::memory;
 use crate::memory::Memory;
 use crate::monitor_indexes;
 use crate::monitor_items;
-use crate::monitor_items::MonitorItems;
 use crate::node_state::NodeState;
 use crate::table::Table;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tokio::sync::mpsc;
@@ -39,6 +43,7 @@ use tracing::trace;
 type GetIndexKeysR = Vec<(IndexKey, Quantization)>;
 type AddIndexR = anyhow::Result<()>;
 type GetIndexR = Option<(mpsc::Sender<Index>, mpsc::Sender<DbIndex>)>;
+type GetBestIndexR = BestIndexState;
 
 pub(crate) enum Engine {
     GetIndexIds {
@@ -55,6 +60,12 @@ pub(crate) enum Engine {
         key: IndexKey,
         tx: oneshot::Sender<GetIndexR>,
     },
+    GetBestIndex {
+        key: IndexKey,
+        equality_columns: Vec<ColumnName>,
+        range_columns: Vec<ColumnName>,
+        tx: oneshot::Sender<GetBestIndexR>,
+    },
 }
 
 pub(crate) trait EngineExt {
@@ -62,6 +73,12 @@ pub(crate) trait EngineExt {
     async fn add_index(&self, metadata: IndexMetadata) -> AddIndexR;
     async fn del_index(&self, key: IndexKey);
     async fn get_index(&self, key: IndexKey) -> GetIndexR;
+    async fn get_best_index(
+        &self,
+        key: IndexKey,
+        equality_columns: Vec<ColumnName>,
+        range_columns: Vec<ColumnName>,
+    ) -> GetBestIndexR;
 }
 
 impl EngineExt for mpsc::Sender<Engine> {
@@ -97,17 +114,26 @@ impl EngineExt for mpsc::Sender<Engine> {
         rx.await
             .expect("EngineExt::get_index: internal actor should send response")
     }
-}
 
-type IndexesT = HashMap<
-    IndexKey,
-    (
-        mpsc::Sender<Index>,
-        mpsc::Sender<MonitorItems>,
-        mpsc::Sender<DbIndex>,
-        Quantization,
-    ),
->;
+    async fn get_best_index(
+        &self,
+        key: IndexKey,
+        equality_columns: Vec<ColumnName>,
+        range_columns: Vec<ColumnName>,
+    ) -> GetBestIndexR {
+        let (tx, rx) = oneshot::channel();
+        self.send(Engine::GetBestIndex {
+            key,
+            equality_columns,
+            range_columns,
+            tx,
+        })
+        .await
+        .expect("EngineExt::get_best_index: internal actor should receive request");
+        rx.await
+            .expect("EngineExt::get_best_index: internal actor should send response")
+    }
+}
 
 pub(crate) async fn new(
     db: mpsc::Sender<Db>,
@@ -118,15 +144,21 @@ pub(crate) async fn new(
 ) -> anyhow::Result<mpsc::Sender<Engine>> {
     let (tx, mut rx) = mpsc::channel(10);
 
-    let monitor_actor =
-        monitor_indexes::new(db.clone(), tx.downgrade(), node_state, config_rx.clone()).await?;
+    let monitor_actor = monitor_indexes::new(
+        db.clone(),
+        tx.downgrade(),
+        node_state.clone(),
+        config_rx.clone(),
+    )
+    .await?;
     let memory_actor = memory::new(config_rx);
 
     tokio::spawn(
         async move {
             debug!("starting");
 
-            let mut indexes: IndexesT = HashMap::new();
+            let mut indexes = Indexes::new();
+            let mut routing_map = RoutingMap::new();
             while let Some(msg) = rx.recv().await {
                 match msg {
                     Engine::GetIndexIds { tx } => get_index_keys(tx, &indexes).await,
@@ -138,15 +170,36 @@ pub(crate) async fn new(
                             &db,
                             index_factory.as_ref(),
                             &mut indexes,
+                            &mut routing_map,
                             metrics.clone(),
                             memory_actor.clone(),
                         )
                         .await
                     }
 
-                    Engine::DelIndex { key } => del_index(key, &mut indexes).await,
+                    Engine::DelIndex { key } => {
+                        del_index(key, &mut indexes, &mut routing_map).await
+                    }
 
                     Engine::GetIndex { key, tx } => get_index(key, tx, &indexes).await,
+
+                    Engine::GetBestIndex {
+                        key,
+                        equality_columns,
+                        range_columns,
+                        tx,
+                    } => {
+                        get_best_index(
+                            key,
+                            equality_columns,
+                            range_columns,
+                            tx,
+                            &indexes,
+                            &routing_map,
+                            &node_state,
+                        )
+                        .await
+                    }
                 }
             }
             drop(monitor_actor);
@@ -159,22 +212,24 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
-async fn get_index_keys(tx: oneshot::Sender<GetIndexKeysR>, indexes: &IndexesT) {
+async fn get_index_keys(tx: oneshot::Sender<GetIndexKeysR>, indexes: &Indexes) {
     tx.send(
         indexes
             .iter()
-            .map(|(key, (_, _, _, quantization))| (key.clone(), *quantization))
+            .map(|(key, entry)| (key.clone(), entry.quantization))
             .collect(),
     )
     .unwrap_or_else(|_| trace!("Engine::GetIndexIds: unable to send response"));
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn add_index(
     metadata: IndexMetadata,
     tx: oneshot::Sender<AddIndexR>,
     db: &mpsc::Sender<Db>,
     index_factory: &(dyn IndexFactory + Send + Sync),
-    indexes: &mut IndexesT,
+    indexes: &mut Indexes,
+    routing_map: &mut RoutingMap,
     metrics: Arc<Metrics>,
     memory: Sender<Memory>,
 ) {
@@ -198,13 +253,13 @@ async fn add_index(
 
     let primary_key_columns = db_index.get_primary_key_columns().await;
     let table_columns = db_index.get_table_columns().await;
-    let partition_key_columns = match metadata.index_type {
-        DbIndexType::Local(partition_key_columns) => Some(partition_key_columns),
+    let partition_key_columns = match &metadata.index_type {
+        DbIndexType::Local(partition_key_columns) => Some(Arc::clone(partition_key_columns)),
         DbIndexType::Global => None,
     };
     let table = match Table::new(
         key.clone(),
-        primary_key_columns,
+        primary_key_columns.clone(),
         partition_key_columns,
         &metadata.filtering_columns,
         table_columns,
@@ -260,27 +315,56 @@ async fn add_index(
         }
     };
 
-    indexes.insert(
-        key.clone(),
-        (index_actor, monitor_actor, db_index, metadata.quantization),
+    let index_entry = IndexEntry::new(
+        index_actor,
+        monitor_actor,
+        db_index,
+        primary_key_columns,
+        metadata,
     );
+
+    routing_map.add(index_entry.routing_group.clone(), key.clone());
+
+    indexes.insert(key.clone(), index_entry);
+
     info!("creating the index {key}");
     tx.send(Ok(()))
         .unwrap_or_else(|_| trace!("add_index: unable to send response"));
 }
 
-async fn del_index(key: IndexKey, indexes: &mut IndexesT) {
-    indexes.remove(&key);
+async fn del_index(key: IndexKey, indexes: &mut Indexes, routing_map: &mut RoutingMap) {
+    if let Some(entry) = indexes.remove(&key) {
+        routing_map.remove(entry.routing_group, &key);
+    }
     info!("removed the index {key}");
 }
 
-async fn get_index(key: IndexKey, tx: oneshot::Sender<GetIndexR>, indexes: &IndexesT) {
-    tx.send(
-        indexes
-            .get(&key)
-            .map(|(index, _, db_index, _)| (index.clone(), db_index.clone())),
+async fn get_index(key: IndexKey, tx: oneshot::Sender<GetIndexR>, indexes: &Indexes) {
+    let result = indexes::get_index(&key, indexes);
+    tx.send(result)
+        .unwrap_or_else(|_| trace!("get_index: unable to send response"));
+}
+
+async fn get_best_index(
+    key: IndexKey,
+    equality_columns: Vec<ColumnName>,
+    range_columns: Vec<ColumnName>,
+    tx: oneshot::Sender<GetBestIndexR>,
+    indexes: &Indexes,
+    routing_map: &RoutingMap,
+    node_state: &mpsc::Sender<NodeState>,
+) {
+    let result = indexes::route_index(
+        &key,
+        &equality_columns,
+        &range_columns,
+        indexes,
+        routing_map,
+        node_state,
     )
-    .unwrap_or_else(|_| trace!("get_index: unable to send response"));
+    .await;
+    tx.send(result)
+        .unwrap_or_else(|_| trace!("get_best_index: unable to send response"));
 }
 
 #[cfg(test)]
@@ -308,6 +392,14 @@ pub(crate) mod tests {
             key: IndexKey,
             tx: oneshot::Sender<GetIndexR>,
         ) -> impl Future<Output = ()> + Send + 'static;
+
+        fn get_best_index(
+            &self,
+            key: IndexKey,
+            equality_columns: Vec<ColumnName>,
+            range_columns: Vec<ColumnName>,
+            tx: oneshot::Sender<GetBestIndexR>,
+        ) -> impl Future<Output = ()> + Send + 'static;
     }
 
     pub(crate) fn new(sim: impl SimEngine + Send + 'static) -> mpsc::Sender<Engine> {
@@ -330,6 +422,15 @@ pub(crate) mod tests {
                         Engine::AddIndex { metadata, tx } => sim.add_index(metadata, tx).await,
                         Engine::DelIndex { key } => sim.del_index(key).await,
                         Engine::GetIndex { key, tx } => sim.get_index(key, tx).await,
+                        Engine::GetBestIndex {
+                            key,
+                            equality_columns,
+                            range_columns,
+                            tx,
+                        } => {
+                            sim.get_best_index(key, equality_columns, range_columns, tx)
+                                .await
+                        }
                     }
                 }
 

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -15,6 +15,7 @@ use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::index::IndexExt;
 use crate::index::validator;
+use crate::indexes;
 use crate::info::Info;
 use crate::internals::Internals;
 use crate::internals::InternalsExt;
@@ -390,6 +391,39 @@ async fn get_metrics(
     (StatusCode::OK, response_headers, buffer)
 }
 
+fn restriction_columns(
+    filter: &Option<httpapi::PostIndexAnnFilter>,
+) -> (Vec<crate::ColumnName>, Vec<crate::ColumnName>) {
+    let Some(filter) = filter else {
+        return (Vec::new(), Vec::new());
+    };
+    let mut equality = Vec::new();
+    let mut range = Vec::new();
+    for r in &filter.restrictions {
+        match r {
+            httpapi::PostIndexAnnRestriction::Eq { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::In { lhs, .. } => {
+                equality.push(lhs.as_ref().into())
+            }
+            httpapi::PostIndexAnnRestriction::Lt { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::Lte { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::Gt { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::Gte { lhs, .. } => range.push(lhs.as_ref().into()),
+            httpapi::PostIndexAnnRestriction::EqTuple { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::InTuple { lhs, .. } => {
+                equality.extend(lhs.iter().map(|name| name.as_ref().into()))
+            }
+            httpapi::PostIndexAnnRestriction::LtTuple { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::LteTuple { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::GtTuple { lhs, .. }
+            | httpapi::PostIndexAnnRestriction::GteTuple { lhs, .. } => {
+                range.extend(lhs.iter().map(|name| name.as_ref().into()))
+            }
+        }
+    }
+    (equality, range)
+}
+
 impl From<distance::DistanceValue> for httpapi::Distance {
     fn from(v: distance::DistanceValue) -> Self {
         Self::from(<distance::DistanceValue as Into<f32>>::into(v))
@@ -482,23 +516,45 @@ async fn post_index_ann(
         .start_timer();
 
     let index_key = IndexKey::new(&keyspace, &index_name);
-    let Some((index, db_index)) = state.engine.get_index(index_key.clone()).await else {
-        timer.observe_duration();
-        let msg = format!("missing index: {keyspace}.{index_name}");
-        debug!("post_index_ann: {msg}");
-        return (StatusCode::NOT_FOUND, msg).into_response();
+    let (equality_cols, range_cols) = restriction_columns(&request.filter);
+    let (routed_key, index, db_index) = match state
+        .engine
+        .get_best_index(index_key.clone(), equality_cols, range_cols)
+        .await
+    {
+        indexes::BestIndexState::Serving(routed_key, index, db_index) => {
+            (routed_key, index, db_index)
+        }
+        indexes::BestIndexState::NotServing(db_index) => {
+            timer.observe_duration();
+
+            let scan_progress = db_index.full_scan_progress().await;
+            match scan_progress {
+                Progress::InProgress(percentage) => {
+                    let msg = format!(
+                        "Index {keyspace}.{index_name} is not available yet as it is still being constructed, progress: {:.3}%",
+                        percentage.get()
+                    );
+                    debug!("post_index_ann: {msg}");
+                    return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
+                }
+                Progress::Done => {
+                    let msg = format!(
+                        "Index {keyspace}.{index_name} is not serving, but full scan did finish."
+                    );
+                    debug!("post_index_ann: {msg}");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
+                }
+            }
+        }
+        indexes::BestIndexState::NotFound => {
+            timer.observe_duration();
+
+            let msg = format!("missing index: {keyspace}.{index_name}");
+            debug!("post_index_ann: {msg}");
+            return (StatusCode::NOT_FOUND, msg).into_response();
+        }
     };
-
-    let scan_progress = db_index.full_scan_progress().await;
-
-    if let Progress::InProgress(percentage) = scan_progress {
-        let msg = format!(
-            "Index {keyspace}.{index_name} is not available yet as it is still being constructed, progress: {:.3}%",
-            percentage.get()
-        );
-        debug!("post_index_ann: {msg}");
-        return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
-    }
 
     let primary_key_columns = db_index.get_primary_key_columns().await;
     let search_result = if let Some(filter) = request.filter {
@@ -515,7 +571,7 @@ async fn post_index_ann(
         };
         index
             .filtered_ann(
-                index_key,
+                routed_key,
                 request.vector.into(),
                 filter,
                 request.limit.into(),
@@ -523,7 +579,7 @@ async fn post_index_ann(
             .await
     } else {
         index
-            .ann(index_key, request.vector.into(), request.limit.into())
+            .ann(routed_key, request.vector.into(), request.limit.into())
             .await
     };
 

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -571,6 +571,16 @@ async fn post_index_ann(
         }
     };
 
+    #[cfg(feature = "slow-test-hooks")]
+    state
+        .internals
+        .increment_counter(format!(
+            "ann-served-request--{}--{}",
+            routed_key.keyspace(),
+            routed_key.index(),
+        ))
+        .await;
+
     let primary_key_columns = db_index.get_primary_key_columns().await;
     let search_result = if let Some(filter) = request.filter {
         let filter = match try_from_post_index_ann_filter(

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -517,12 +517,27 @@ async fn post_index_ann(
 
     let index_key = IndexKey::new(&keyspace, &index_name);
     let (equality_cols, range_cols) = restriction_columns(&request.filter);
+    let allow_filtering = request.filter.as_ref().is_some_and(|f| f.allow_filtering);
     let (routed_key, index, db_index) = match state
         .engine
         .get_best_index(index_key.clone(), equality_cols, range_cols)
         .await
     {
-        indexes::BestIndexState::Serving(routed_key, index, db_index) => {
+        indexes::BestIndexState::Serving {
+            key: routed_key,
+            index,
+            db_index,
+            needs_filtering,
+        } => {
+            if matches!(needs_filtering, indexes::NeedsFiltering::Yes(_)) && !allow_filtering {
+                timer.observe_duration();
+
+                let msg = format!(
+                    "Index {keyspace}.{index_name} requires ALLOW FILTERING for this query"
+                );
+                debug!("post_index_ann: {msg}");
+                return (StatusCode::BAD_REQUEST, msg).into_response();
+            }
             (routed_key, index, db_index)
         }
         indexes::BestIndexState::NotServing(db_index) => {

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -227,7 +227,12 @@ pub(crate) enum BestIndexState {
     /// The requested index exists but no serving candidate was found.
     NotServing(mpsc::Sender<DbIndex>),
     /// A serving candidate was found.
-    Serving(IndexKey, mpsc::Sender<Index>, mpsc::Sender<DbIndex>),
+    Serving {
+        key: IndexKey,
+        index: mpsc::Sender<Index>,
+        db_index: mpsc::Sender<DbIndex>,
+        needs_filtering: NeedsFiltering,
+    },
 }
 
 /// Determines the index to route a query to, given a requested `IndexKey`.
@@ -280,19 +285,20 @@ pub(crate) async fn route_index(
     .max_by(|(_, score_a, version_a), (_, score_b, version_b)| {
         score_a.cmp(score_b).then_with(|| version_a.cmp(version_b))
     })
-    .map(|(k, _, _)| k);
+    .map(|(k, score, _)| (k, score));
 
     match routed_key {
-        Some(routed_key) => {
+        Some((routed_key, needs_filtering)) => {
             let routed_entry = indexes.get(routed_key).expect("routed key must exist");
             if routed_key != key {
                 debug!("routing index request from {key} to {routed_key}");
             }
-            BestIndexState::Serving(
-                routed_key.clone(),
-                routed_entry.index.clone(),
-                routed_entry.db_index.clone(),
-            )
+            BestIndexState::Serving {
+                key: routed_key.clone(),
+                index: routed_entry.index.clone(),
+                db_index: routed_entry.db_index.clone(),
+                needs_filtering: needs_filtering.clone(),
+            }
         }
         None => BestIndexState::NotServing(requested_entry.db_index.clone()),
     }

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::ColumnName;
+use crate::DbIndexType;
+use crate::IndexKey;
+use crate::IndexMetadata;
+use crate::IndexVersion;
+use crate::KeyspaceName;
+use crate::Quantization;
+use crate::TableName;
+use crate::db_index::DbIndex;
+use crate::index::Index;
+use crate::monitor_items::MonitorItems;
+use crate::node_state::IndexStatus;
+use crate::node_state::NodeState;
+use crate::node_state::NodeStateExt;
+use futures::future::join_all;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::debug;
+
+/// Indicates whether an index requires server-side filtering for a given query.
+///
+/// Used by routing to rank candidate indexes: an index that needs no filtering
+/// (all restriction columns are covered by the partition key or filtering columns)
+/// is preferred over one that still needs filtering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NeedsFiltering {
+    /// All restriction columns are covered by the index partition key
+    /// or filtering columns - no extra filtering needed.
+    No,
+    /// This many restriction columns are not covered by the partition key
+    /// or filtering columns and require server-side filtering.
+    Yes(usize),
+}
+
+impl PartialOrd for NeedsFiltering {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NeedsFiltering {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (NeedsFiltering::No, NeedsFiltering::No) => std::cmp::Ordering::Equal,
+            (NeedsFiltering::No, NeedsFiltering::Yes(_)) => std::cmp::Ordering::Greater,
+            (NeedsFiltering::Yes(_), NeedsFiltering::No) => std::cmp::Ordering::Less,
+            (NeedsFiltering::Yes(a), NeedsFiltering::Yes(b)) => b.cmp(a),
+        }
+    }
+}
+
+/// Key for grouping indexes that can be routed between each other
+/// (i.e., indexes over the same keyspace, table, and target column).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct RoutingGroupKey {
+    keyspace: KeyspaceName,
+    table: TableName,
+    column: ColumnName,
+}
+
+impl From<&IndexMetadata> for RoutingGroupKey {
+    fn from(metadata: &IndexMetadata) -> Self {
+        Self {
+            keyspace: metadata.keyspace_name.clone(),
+            table: metadata.table_name.clone(),
+            column: metadata.target_column.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct IndexEntry {
+    pub(crate) index: mpsc::Sender<Index>,
+    pub(crate) _monitor: mpsc::Sender<MonitorItems>,
+    pub(crate) db_index: mpsc::Sender<DbIndex>,
+    pub(crate) routing_group: RoutingGroupKey,
+    pub(crate) index_type: DbIndexType,
+    pub(crate) filtering_columns: Arc<Vec<ColumnName>>,
+    pub(crate) version: IndexVersion,
+    pub(crate) quantization: Quantization,
+}
+
+impl IndexEntry {
+    pub(crate) fn new(
+        index: mpsc::Sender<Index>,
+        monitor: mpsc::Sender<MonitorItems>,
+        db_index: mpsc::Sender<DbIndex>,
+        primary_key_columns: Arc<Vec<ColumnName>>,
+        metadata: IndexMetadata,
+    ) -> Self {
+        let routing_group = RoutingGroupKey::from(&metadata);
+        let filtering_columns: Arc<Vec<ColumnName>> = Arc::new(
+            metadata
+                .filtering_columns
+                .iter()
+                .chain(primary_key_columns.iter())
+                .cloned()
+                .collect(),
+        );
+        Self {
+            index,
+            _monitor: monitor,
+            db_index,
+            routing_group,
+            index_type: metadata.index_type,
+            filtering_columns,
+            version: metadata.version,
+            quantization: metadata.quantization,
+        }
+    }
+}
+
+/// Storage for all active indexes.
+#[derive(Debug)]
+pub(crate) struct Indexes(HashMap<IndexKey, IndexEntry>);
+
+impl Indexes {
+    pub(crate) fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub(crate) fn get(&self, key: &IndexKey) -> Option<&IndexEntry> {
+        self.0.get(key)
+    }
+
+    pub(crate) fn contains_key(&self, key: &IndexKey) -> bool {
+        self.0.contains_key(key)
+    }
+
+    pub(crate) fn insert(&mut self, key: IndexKey, entry: IndexEntry) {
+        self.0.insert(key, entry);
+    }
+
+    pub(crate) fn remove(&mut self, key: &IndexKey) -> Option<IndexEntry> {
+        self.0.remove(key)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&IndexKey, &IndexEntry)> {
+        self.0.iter()
+    }
+}
+
+/// Maps each routing group to the set of index keys that belong to it.
+#[derive(Debug)]
+pub(crate) struct RoutingMap(HashMap<RoutingGroupKey, Vec<IndexKey>>);
+
+impl RoutingMap {
+    pub(crate) fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub(crate) fn get(&self, key: &RoutingGroupKey) -> Option<&Vec<IndexKey>> {
+        self.0.get(key)
+    }
+
+    pub(crate) fn add(&mut self, group: RoutingGroupKey, key: IndexKey) {
+        self.0.entry(group).or_default().push(key);
+    }
+
+    pub(crate) fn remove(&mut self, group: RoutingGroupKey, key: &IndexKey) {
+        if let Entry::Occupied(mut e) = self.0.entry(group) {
+            e.get_mut().retain(|k| k != key);
+            if e.get().is_empty() {
+                e.remove();
+            }
+        }
+    }
+}
+
+/// Computes a routing score for an index given the query's restriction columns.
+///
+/// Returns `None` when the index cannot serve the query at all. This happens
+/// when a local index's partition key columns are not all present in the
+/// equality restrictions, or when any non-partition-key restriction column is
+/// not in the index's filtering columns.
+///
+/// Returns `Some(NeedsFiltering)` otherwise, indicating how many restriction
+/// columns still require index-level filtering (via filtering columns).
+pub(crate) fn score_index(
+    index_type: &DbIndexType,
+    filtering_columns: &[ColumnName],
+    equality_columns: &[ColumnName],
+    range_columns: &[ColumnName],
+) -> Option<NeedsFiltering> {
+    if !equality_columns
+        .iter()
+        .chain(range_columns.iter())
+        .all(|col| filtering_columns.contains(col))
+    {
+        return None;
+    }
+
+    match index_type {
+        DbIndexType::Global => {
+            let uncovered = equality_columns.len() + range_columns.len();
+            Some(if uncovered == 0 {
+                NeedsFiltering::No
+            } else {
+                NeedsFiltering::Yes(uncovered)
+            })
+        }
+        DbIndexType::Local(pk_columns) => {
+            if !pk_columns.iter().all(|col| equality_columns.contains(col)) {
+                return None;
+            }
+            let uncovered = equality_columns.len() - pk_columns.len() + range_columns.len();
+            Some(if uncovered == 0 {
+                NeedsFiltering::No
+            } else {
+                NeedsFiltering::Yes(uncovered)
+            })
+        }
+    }
+}
+
+/// Result of routing an ANN query to the best matching index.
+pub(crate) enum BestIndexState {
+    /// The requested index does not exist at all.
+    NotFound,
+    /// The requested index exists but no serving candidate was found.
+    NotServing(mpsc::Sender<DbIndex>),
+    /// A serving candidate was found.
+    Serving(IndexKey, mpsc::Sender<Index>, mpsc::Sender<DbIndex>),
+}
+
+/// Determines the index to route a query to, given a requested `IndexKey`.
+///
+/// To ensure queries are routed to the most up-to-date and best-matching index,
+/// this function applies the following routing logic:
+///
+/// 1. Returns `NotFound` if the requested index key does not exist.
+/// 2. Identifies all candidate indexes within the same routing group
+///    (i.e., sharing the same keyspace, table, and target column).
+/// 3. Filters out candidates whose `score_index` returns `None` (invalid).
+/// 4. Narrows down the remaining candidates to those that are actively serving.
+/// 5. Picks the candidate with the highest score, breaking ties by
+///    the newest `IndexVersion`.
+/// 6. Returns `NotServing` if no candidate meets the criteria.
+pub(crate) async fn route_index(
+    key: &IndexKey,
+    equality_columns: &[ColumnName],
+    range_columns: &[ColumnName],
+    indexes: &Indexes,
+    routing_map: &RoutingMap,
+    node_state: &mpsc::Sender<NodeState>,
+) -> BestIndexState {
+    let Some(requested_entry) = indexes.get(key) else {
+        return BestIndexState::NotFound;
+    };
+    let candidates = routing_map
+        .get(&requested_entry.routing_group)
+        .expect("routing_map must contain group for every index in indexes");
+
+    let routed_key = join_all(candidates.iter().filter_map(|k| {
+        let entry = indexes.get(k)?;
+        let score = score_index(
+            &entry.index_type,
+            &entry.filtering_columns,
+            equality_columns,
+            range_columns,
+        )?;
+        Some(async move {
+            let is_serving = node_state
+                .get_index_status(k.keyspace().as_ref(), k.index().as_ref())
+                .await
+                .is_some_and(|status| status == IndexStatus::Serving);
+            is_serving.then_some((k, score, &entry.version))
+        })
+    }))
+    .await
+    .into_iter()
+    .flatten()
+    .max_by(|(_, score_a, version_a), (_, score_b, version_b)| {
+        score_a.cmp(score_b).then_with(|| version_a.cmp(version_b))
+    })
+    .map(|(k, _, _)| k);
+
+    match routed_key {
+        Some(routed_key) => {
+            let routed_entry = indexes.get(routed_key).expect("routed key must exist");
+            if routed_key != key {
+                debug!("routing index request from {key} to {routed_key}");
+            }
+            BestIndexState::Serving(
+                routed_key.clone(),
+                routed_entry.index.clone(),
+                routed_entry.db_index.clone(),
+            )
+        }
+        None => BestIndexState::NotServing(requested_entry.db_index.clone()),
+    }
+}
+
+/// Direct index lookup without routing.
+///
+/// Returns the index and db_index actors for the exact key requested,
+/// regardless of routing groups or serving status. Used by status and
+/// metrics endpoints that need to query a specific index.
+pub(crate) fn get_index(
+    key: &IndexKey,
+    indexes: &Indexes,
+) -> Option<(mpsc::Sender<Index>, mpsc::Sender<DbIndex>)> {
+    let entry = indexes.get(key)?;
+    Some((entry.index.clone(), entry.db_index.clone()))
+}

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -14,6 +14,7 @@ mod httproutes;
 mod httpserver;
 mod index;
 mod index_key;
+mod indexes;
 mod info;
 mod internals;
 mod invariant_key;
@@ -518,6 +519,27 @@ pub struct Filter {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::From)]
 pub struct IndexVersion(Uuid);
+
+impl IndexVersion {
+    fn gregorian_ticks(&self) -> u64 {
+        self.0
+            .get_timestamp()
+            .map(|ts| ts.to_gregorian().0)
+            .unwrap_or(0)
+    }
+}
+
+impl PartialOrd for IndexVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for IndexVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.gregorian_ticks().cmp(&other.gregorian_ticks())
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// Information about an index

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -13,6 +13,8 @@ use scylla::value::CqlTimeuuid;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
@@ -20,11 +22,12 @@ use vector_store::AsyncInProgress;
 use vector_store::ColumnName;
 use vector_store::DbCustomIndex;
 use vector_store::DbEmbedding;
-use vector_store::DbIndexType;
 use vector_store::Dimensions;
 use vector_store::IndexMetadata;
 use vector_store::IndexName;
+use vector_store::IndexVersion;
 use vector_store::KeyspaceName;
+use vector_store::Percentage;
 use vector_store::PrimaryKey;
 use vector_store::Progress;
 use vector_store::TableName;
@@ -94,7 +97,7 @@ pub(crate) struct Table {
 
 struct Index {
     metadata: IndexMetadata,
-    version: Uuid,
+    version: IndexVersion,
     fullscan_fn: Option<ScanFn>,
     cdc_fn: Option<ScanFn>,
 }
@@ -117,7 +120,7 @@ struct DbMock {
     schema_version: CqlTimeuuid,
     keyspaces: HashMap<KeyspaceName, Keyspace>,
     next_get_db_index_failed: bool,
-    next_full_scan_progress: Progress,
+    next_full_scan_progress: Option<Progress>,
     simulate_endless_get_indexes_processing: bool,
 }
 
@@ -133,7 +136,7 @@ impl DbBasic {
             schema_version: CqlTimeuuid::from(Uuid::new_v4()),
             keyspaces: HashMap::new(),
             next_get_db_index_failed: false,
-            next_full_scan_progress: Progress::Done,
+            next_full_scan_progress: None,
             simulate_endless_get_indexes_processing: false,
         })))
     }
@@ -185,8 +188,8 @@ impl DbBasic {
         keyspace.indexes.insert(
             metadata.index_name.clone(),
             Index {
+                version: metadata.version.clone(),
                 metadata,
-                version: Uuid::new_v4(),
                 fullscan_fn,
                 cdc_fn,
             },
@@ -219,7 +222,7 @@ impl DbBasic {
     }
 
     pub(crate) fn set_next_full_scan_progress(&self, progress: Progress) {
-        self.0.write().unwrap().next_full_scan_progress = progress;
+        self.0.write().unwrap().next_full_scan_progress = Some(progress);
     }
 
     pub(crate) fn simulate_endless_get_indexes_processing(&self) {
@@ -264,8 +267,8 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
                                 index: index_name.clone(),
                                 table: index.metadata.table_name.clone(),
                                 target_column: index.metadata.target_column.clone(),
-                                index_type: DbIndexType::Global,
-                                filtering_columns: Arc::new(Vec::new()),
+                                index_type: index.metadata.index_type.clone(),
+                                filtering_columns: index.metadata.filtering_columns.clone(),
                             })
                     })
                     .collect()))
@@ -286,7 +289,7 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
                 .keyspaces
                 .get(&keyspace)
                 .and_then(|keyspace| keyspace.indexes.get(&index))
-                .map(|index| index.version.into())))
+                .map(|index| index.version.clone())))
             .map_err(|_| anyhow!("Db::GetIndexVersion: unable to send response"))
             .unwrap(),
 
@@ -353,15 +356,25 @@ pub(crate) fn new_db_index(
 
     let (tx_index, mut rx_index) = mpsc::channel(10);
     let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+    let fullscan_finished = Arc::new(AtomicBool::new(false));
     tokio::spawn({
+        let fullscan_finished = fullscan_finished.clone();
         async move {
             let fullscan_fn = fullscan(&mut db, &metadata);
+            node_state
+                .send(NodeState::SendEvent(Event::FullScanStarted(
+                    metadata.clone(),
+                )))
+                .await
+                .unwrap();
             let fullscan = {
                 let tx_embeddings = tx_embeddings.clone();
+                let fullscan_finished = fullscan_finished.clone();
                 async move {
                     if let Some(fullscan_fn) = fullscan_fn {
                         fullscan_fn(tx_embeddings).await;
                     }
+                    fullscan_finished.store(true, Ordering::Release);
                 }
                 .shared()
             };
@@ -372,7 +385,7 @@ pub(crate) fn new_db_index(
                         let Some(msg) = msg else {
                             break;
                         };
-                        process_db_index(&db, &metadata, msg).await;
+                        process_db_index(&db, &metadata, &fullscan_finished, msg).await;
                     }
                 }
             }
@@ -400,13 +413,13 @@ pub(crate) fn new_db_index(
                         let Some(msg) = msg else {
                             break;
                         };
-                        process_db_index(&db, &metadata, msg).await;
+                        process_db_index(&db, &metadata, &fullscan_finished, msg).await;
                     }
                 }
             }
 
             while let Some(msg) = rx_index.recv().await {
-                process_db_index(&db, &metadata, msg).await;
+                process_db_index(&db, &metadata, &fullscan_finished, msg).await;
             }
             drop(tx_embeddings);
         }
@@ -432,7 +445,12 @@ fn cdc(db: &mut DbBasic, metadata: &IndexMetadata) -> Option<ScanFn> {
         .and_then(|index| index.cdc_fn.take())
 }
 
-async fn process_db_index(db: &DbBasic, metadata: &IndexMetadata, msg: DbIndex) {
+async fn process_db_index(
+    db: &DbBasic,
+    metadata: &IndexMetadata,
+    fullscan_finished: &Arc<AtomicBool>,
+    msg: DbIndex,
+) {
     match msg {
         DbIndex::GetPrimaryKeyColumns { tx } => tx
             .send(
@@ -462,10 +480,14 @@ async fn process_db_index(db: &DbBasic, metadata: &IndexMetadata, msg: DbIndex) 
 
         DbIndex::FullScanProgress { tx } => tx
             .send({
-                let mut db = db.0.write().unwrap();
-                let val = db.next_full_scan_progress.clone();
-                db.next_full_scan_progress = Progress::Done;
-                val
+                let db = db.0.read().unwrap();
+                db.next_full_scan_progress.clone().unwrap_or_else(|| {
+                    if fullscan_finished.load(Ordering::Acquire) {
+                        Progress::Done
+                    } else {
+                        Progress::InProgress(Percentage::try_from(0.0).unwrap())
+                    }
+                })
             })
             .map_err(|_| anyhow!("DbIndex::GetTargetColumn: unable to send response"))
             .unwrap(),

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -11,6 +11,7 @@ mod mock_opensearch;
 mod openapi;
 mod opensearch;
 mod quantization;
+mod routing;
 mod status;
 mod usearch;
 

--- a/crates/vector-store/tests/integration/quantization.rs
+++ b/crates/vector-store/tests/integration/quantization.rs
@@ -272,7 +272,7 @@ async fn can_search_with_filter_when_quantization_is_enabled() {
                     lhs: pk_column.clone(),
                     rhs: vec![pk_value.into()],
                 }],
-                allow_filtering: false,
+                allow_filtering: true,
             }),
         )
         .await;

--- a/crates/vector-store/tests/integration/quantization.rs
+++ b/crates/vector-store/tests/integration/quantization.rs
@@ -9,6 +9,7 @@ use crate::usearch::test_config;
 use crate::wait_for;
 use crate::wait_for_value;
 use httpapi::DataType;
+use httpapi::IndexStatus;
 use httpapi::PostIndexAnnFilter;
 use httpapi::PostIndexAnnRestriction;
 use scylla::value::CqlValue;
@@ -193,6 +194,18 @@ async fn search_with_quantization(quantization: Quantization, filter: Option<Pos
 
     let keyspace_name = index.keyspace_name.clone().into();
     let index_name = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Serving)
+        },
+        &format!("Waiting for index to be serving ({:?})", quantization),
+    )
+    .await;
+
     // expect to find the inserted vector as the nearest neighbor
     // with distance 0.0 as we are searching for the same vector
     wait_for(
@@ -299,6 +312,18 @@ async fn binary_quantization_with_non_divisible_by_8_dimensions() {
 
     let keyspace_name = index.keyspace_name.clone().into();
     let index_name = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Serving)
+        },
+        "Waiting for index to be serving",
+    )
+    .await;
+
     // expect to find the inserted vector as the nearest neighbor
     // with distance 0.0 as we are searching for the same vector
     wait_for(

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -1,0 +1,716 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::db_basic;
+use crate::db_basic::DbBasic;
+use crate::db_basic::ScanFn;
+use crate::db_basic::Table;
+use crate::usearch::test_config;
+use crate::wait_for;
+use futures::FutureExt;
+use httpapi::IndexStatus;
+use httpapi::PostIndexAnnFilter;
+use httpapi::PostIndexAnnRestriction;
+use httpclient::HttpClient;
+use reqwest::StatusCode;
+use scylla::cluster::metadata::NativeType;
+use scylla::value::CqlValue;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use tokio::sync::watch;
+use uuid::Uuid;
+use vector_store::ColumnName;
+use vector_store::DbIndexType;
+use vector_store::IndexMetadata;
+use vector_store::Timestamp;
+
+const ANN_LIMIT: usize = 5;
+
+fn ordered_timeuuid(time: u32) -> Uuid {
+    let mut bytes = [0u8; 16];
+    bytes[0..4].copy_from_slice(&time.to_be_bytes());
+    bytes[6] = 0x10;
+    bytes[8] = 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+/// A scan function that never completes, keeping the index bootstrapping.
+fn blocking_scan_fn() -> ScanFn {
+    Box::new(|_tx| std::future::pending::<()>().boxed())
+}
+
+fn single_row_scan(pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'static) -> ScanFn {
+    db_basic::scan_fn([(
+        pks.into_iter().collect::<Vec<_>>().into(),
+        Some(vec![1.0, 2.0, 3.0].into()),
+        Timestamp::from_unix_timestamp(10),
+    )])
+}
+
+fn make_index(
+    name: &str,
+    column: &str,
+    index_type: DbIndexType,
+    filtering_columns: &[&str],
+    version: Uuid,
+) -> IndexMetadata {
+    IndexMetadata {
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: name.into(),
+        target_column: column.into(),
+        index_type,
+        filtering_columns: Arc::new(
+            filtering_columns
+                .iter()
+                .map(|s| ColumnName::from(*s))
+                .collect(),
+        ),
+        dimensions: NonZeroUsize::new(3).unwrap().into(),
+        connectivity: Default::default(),
+        expansion_add: Default::default(),
+        expansion_search: Default::default(),
+        space_type: Default::default(),
+        version: version.into(),
+        quantization: Default::default(),
+    }
+}
+
+async fn setup() -> (HttpClient, DbBasic, impl Sized) {
+    let node_state = vector_store::new_node_state().await;
+    let internals = vector_store::new_internals();
+    let (db_actor, db) = db_basic::new(node_state.clone());
+    let (config_tx, config_rx) = watch::channel(Arc::new(test_config()));
+    let index_factory = vector_store::new_index_factory_usearch(config_rx.clone()).unwrap();
+    let (server, addr) =
+        vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+            .await
+            .unwrap();
+    (HttpClient::new(addr), db, (server, config_tx))
+}
+
+fn add_table(
+    db: &DbBasic,
+    primary_keys: impl IntoIterator<Item = ColumnName>,
+    columns: impl IntoIterator<Item = (ColumnName, NativeType)>,
+    vector_columns: impl IntoIterator<Item = ColumnName>,
+) {
+    db.add_table(
+        "vector".into(),
+        "items".into(),
+        Table {
+            primary_keys: Arc::new(primary_keys.into_iter().collect()),
+            columns: Arc::new(columns.into_iter().collect()),
+            dimensions: vector_columns
+                .into_iter()
+                .map(|c| (c, NonZeroUsize::new(3).unwrap().into()))
+                .collect(),
+        },
+    )
+    .unwrap();
+}
+
+async fn wait_for_serving(client: &HttpClient, index: &IndexMetadata) {
+    let ks = index.keyspace_name.as_ref().into();
+    let idx = index.index_name.as_ref().into();
+    wait_for(
+        || async {
+            client
+                .index_status(&ks, &idx)
+                .await
+                .is_ok_and(|s| s.status == IndexStatus::Serving)
+        },
+        &format!("index {} to be serving", index.index_name),
+    )
+    .await;
+}
+
+async fn wait_for_bootstrapping(client: &HttpClient, index: &IndexMetadata) {
+    let ks = index.keyspace_name.as_ref().into();
+    let idx = index.index_name.as_ref().into();
+    wait_for(
+        || async {
+            client
+                .index_status(&ks, &idx)
+                .await
+                .is_ok_and(|s| s.status == IndexStatus::Bootstrapping)
+        },
+        &format!("index {} to be bootstrapping", index.index_name),
+    )
+    .await;
+}
+
+async fn post_ann(client: &HttpClient, index: &IndexMetadata) -> reqwest::Response {
+    let keyspace_name = index.keyspace_name.as_ref().into();
+    let index_name = index.index_name.as_ref().into();
+    client
+        .post_ann(
+            &keyspace_name,
+            &index_name,
+            vec![0.0_f32, 0.0, 0.0].into(),
+            None,
+            NonZeroUsize::new(ANN_LIMIT).unwrap().into(),
+        )
+        .await
+}
+
+async fn post_ann_with_filter(
+    client: &HttpClient,
+    index: &IndexMetadata,
+    filter: PostIndexAnnFilter,
+) -> reqwest::Response {
+    let keyspace_name = index.keyspace_name.as_ref().into();
+    let index_name = index.index_name.as_ref().into();
+    client
+        .post_ann(
+            &keyspace_name,
+            &index_name,
+            vec![0.0_f32, 0.0, 0.0].into(),
+            Some(filter),
+            NonZeroUsize::new(ANN_LIMIT).unwrap().into(),
+        )
+        .await
+}
+
+async fn assert_ann_served_by(
+    client: &HttpClient,
+    expected: &IndexMetadata,
+    request: impl std::future::Future<Output = reqwest::Response>,
+) -> reqwest::Response {
+    client
+        .internals_clear_counters()
+        .await
+        .expect("internals counters must be cleared");
+    let counter_name = format!(
+        "ann-served-request--{}--{}",
+        expected.keyspace_name, expected.index_name
+    );
+    client
+        .internals_start_counter(counter_name.clone())
+        .await
+        .expect("internals served counter must be registered");
+
+    let before = client
+        .internals_counters()
+        .await
+        .unwrap()
+        .get(&counter_name)
+        .copied()
+        .unwrap_or(0);
+    let response = request.await;
+    let after = client
+        .internals_counters()
+        .await
+        .unwrap()
+        .get(&counter_name)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(
+        after - before,
+        1,
+        "expected ANN request to be served by {}",
+        expected.index_name,
+    );
+    response
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    let oldest = make_index(
+        "oldest",
+        "embedding",
+        DbIndexType::Global,
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        oldest.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &oldest).await;
+
+    let replacement = make_index(
+        "replacement",
+        "embedding",
+        DbIndexType::Global,
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(replacement.clone(), Some(blocking_scan_fn()), None)
+        .unwrap();
+    wait_for_bootstrapping(&client, &replacement).await;
+
+    let response = assert_ann_served_by(&client, &oldest, post_ann(&client, &replacement)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_newest_serving_index() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    let oldest = make_index(
+        "oldest",
+        "embedding",
+        DbIndexType::Global,
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        oldest.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &oldest).await;
+
+    let replacement = make_index(
+        "replacement",
+        "embedding",
+        DbIndexType::Global,
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(
+        replacement.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &replacement).await;
+
+    let response = assert_ann_served_by(&client, &replacement, post_ann(&client, &oldest)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_newest_local_index_with_same_score() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into(), "ck".into()],
+        [
+            ("pk".into(), NativeType::Int),
+            ("ck".into(), NativeType::Int),
+        ],
+        ["embedding".into()],
+    );
+
+    let older_local = make_index(
+        "older",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk".into()])),
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        older_local.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &older_local).await;
+
+    let newer_local = make_index(
+        "newer",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk".into()])),
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(
+        newer_local.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &newer_local).await;
+
+    let filter = PostIndexAnnFilter {
+        restrictions: vec![PostIndexAnnRestriction::Eq {
+            lhs: "pk".into(),
+            rhs: 1.into(),
+        }],
+        allow_filtering: false,
+    };
+
+    let response = assert_ann_served_by(
+        &client,
+        &newer_local,
+        post_ann_with_filter(&client, &older_local, filter),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_local_index_with_more_matching_partition_key_columns() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk1".into(), "pk2".into(), "ck".into()],
+        [
+            ("pk1".into(), NativeType::Int),
+            ("pk2".into(), NativeType::Int),
+            ("ck".into(), NativeType::Int),
+        ],
+        ["embedding".into()],
+    );
+
+    let less_precise = make_index(
+        "less_precise",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk1".into()])),
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        less_precise.clone(),
+        Some(single_row_scan([
+            CqlValue::Int(1),
+            CqlValue::Int(1),
+            CqlValue::Int(1),
+        ])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &less_precise).await;
+
+    let more_precise = make_index(
+        "more_precise",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk1".into(), "pk2".into()])),
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(
+        more_precise.clone(),
+        Some(single_row_scan([
+            CqlValue::Int(1),
+            CqlValue::Int(1),
+            CqlValue::Int(1),
+        ])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &more_precise).await;
+
+    let filter = PostIndexAnnFilter {
+        restrictions: vec![
+            PostIndexAnnRestriction::Eq {
+                lhs: "pk1".into(),
+                rhs: 1.into(),
+            },
+            PostIndexAnnRestriction::Eq {
+                lhs: "pk2".into(),
+                rhs: 1.into(),
+            },
+        ],
+        allow_filtering: false,
+    };
+
+    let response = assert_ann_served_by(
+        &client,
+        &more_precise,
+        post_ann_with_filter(&client, &less_precise, filter),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_local_index_with_filter_columns_covering_restriction() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into(), "ck".into()],
+        [
+            ("pk".into(), NativeType::Int),
+            ("ck".into(), NativeType::Int),
+            ("f".into(), NativeType::Int),
+        ],
+        ["embedding".into()],
+    );
+
+    let covering = make_index(
+        "covering",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk".into()])),
+        &["f"],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        covering.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &covering).await;
+
+    let non_covering = make_index(
+        "non_covering",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk".into()])),
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(
+        non_covering.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &non_covering).await;
+
+    let filter = PostIndexAnnFilter {
+        restrictions: vec![
+            PostIndexAnnRestriction::Eq {
+                lhs: "pk".into(),
+                rhs: 1.into(),
+            },
+            PostIndexAnnRestriction::Eq {
+                lhs: "f".into(),
+                rhs: 1.into(),
+            },
+        ],
+        allow_filtering: true,
+    };
+
+    // TODO: update this assertion to expect StatusCode::OK once filtering on
+    // non-primary-key columns is supported end-to-end. Currently the request
+    // is routed correctly but fails at the filter validation layer.
+    let response = assert_ann_served_by(
+        &client,
+        &covering,
+        post_ann_with_filter(&client, &non_covering, filter),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_global_index_with_filter_columns_covering_restriction() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into(), "ck".into()],
+        [
+            ("pk".into(), NativeType::Int),
+            ("ck".into(), NativeType::Int),
+            ("f".into(), NativeType::Int),
+        ],
+        ["embedding".into()],
+    );
+
+    let covering = make_index(
+        "covering",
+        "embedding",
+        DbIndexType::Global,
+        &["f"],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        covering.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &covering).await;
+
+    let non_covering = make_index(
+        "non_covering",
+        "embedding",
+        DbIndexType::Global,
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(
+        non_covering.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &non_covering).await;
+
+    let filter = PostIndexAnnFilter {
+        restrictions: vec![
+            PostIndexAnnRestriction::Eq {
+                lhs: "pk".into(),
+                rhs: 1.into(),
+            },
+            PostIndexAnnRestriction::Eq {
+                lhs: "f".into(),
+                rhs: 1.into(),
+            },
+        ],
+        allow_filtering: true,
+    };
+
+    // TODO: update this assertion to expect StatusCode::OK once filtering on
+    // non-primary-key columns is supported end-to-end. Currently the request
+    // is routed correctly but fails at the filter validation layer.
+    let response = assert_ann_served_by(
+        &client,
+        &covering,
+        post_ann_with_filter(&client, &non_covering, filter),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_local_index_when_pk_restrictions_match() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into(), "ck".into()],
+        [
+            ("pk".into(), NativeType::Int),
+            ("ck".into(), NativeType::Int),
+        ],
+        ["embedding".into()],
+    );
+
+    let local_index = make_index(
+        "local_idx",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk".into()])),
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        local_index.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &local_index).await;
+
+    let global_index = make_index(
+        "global_idx",
+        "embedding",
+        DbIndexType::Global,
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(
+        global_index.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &global_index).await;
+
+    let filter = PostIndexAnnFilter {
+        restrictions: vec![PostIndexAnnRestriction::Eq {
+            lhs: "pk".into(),
+            rhs: 1.into(),
+        }],
+        allow_filtering: false,
+    };
+
+    let response = assert_ann_served_by(
+        &client,
+        &local_index,
+        post_ann_with_filter(&client, &global_index, filter),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_global_index_without_pk_restrictions() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into(), "ck".into()],
+        [
+            ("pk".into(), NativeType::Int),
+            ("ck".into(), NativeType::Int),
+        ],
+        ["embedding".into()],
+    );
+
+    let local_index = make_index(
+        "local_idx",
+        "embedding",
+        DbIndexType::Local(Arc::new(vec!["pk".into()])),
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        local_index.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &local_index).await;
+
+    let global_index = make_index(
+        "global_idx",
+        "embedding",
+        DbIndexType::Global,
+        &[],
+        ordered_timeuuid(2),
+    );
+    db.add_index(
+        global_index.clone(),
+        Some(single_row_scan([CqlValue::Int(1), CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &global_index).await;
+
+    let response =
+        assert_ann_served_by(&client, &global_index, post_ann(&client, &local_index)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -422,6 +422,48 @@ async fn ann_returns_bad_request_when_provided_vector_size_is_not_eq_index_dimen
 }
 
 #[tokio::test]
+#[ntest::timeout(10_000)]
+async fn ann_returns_bad_request_when_filtering_required_but_not_allowed() {
+    crate::enable_tracing();
+
+    let pk_column: ColumnName = "pk".into();
+    let ck_column: ColumnName = "ck".into();
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexType::Global,
+        [pk_column.clone(), ck_column.clone()],
+        [
+            (pk_column.clone(), NativeType::Int),
+            (ck_column.clone(), NativeType::Int),
+        ],
+        Some(db_basic::scan_fn([(
+            [CqlValue::Int(1), CqlValue::Int(1)].into(),
+            Some(vec![1., 1., 1.].into()),
+            Timestamp::from_unix_timestamp(10),
+        )])),
+        None,
+    )
+    .await;
+
+    let result = client
+        .post_ann(
+            &index.keyspace_name.into(),
+            &index.index_name.into(),
+            vec![1.0, 2.0, 3.0].into(),
+            Some(PostIndexAnnFilter {
+                restrictions: vec![PostIndexAnnRestriction::Eq {
+                    lhs: pk_column.into(),
+                    rhs: 1.into(),
+                }],
+                allow_filtering: false,
+            }),
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(result.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn ann_fail_while_building() {
     crate::enable_tracing();
     let (run, index, db, _node_state) = setup_store(
@@ -559,7 +601,7 @@ async fn ann_filter_partition_key_int_eq() {
                             lhs: pk_column_http.clone(),
                             rhs: 1.into(),
                         }],
-                        allow_filtering: false,
+                        allow_filtering: true,
                     }),
                     NonZeroUsize::new(100).unwrap().into(),
                 )
@@ -632,7 +674,7 @@ async fn ann_filter_clustering_key_int_eq() {
                             lhs: ck_column_http.clone(),
                             rhs: 1.into(),
                         }],
-                        allow_filtering: false,
+                        allow_filtering: true,
                     }),
                     NonZeroUsize::new(100).unwrap().into(),
                 )
@@ -705,7 +747,7 @@ async fn ann_filter_partition_key_int_in() {
                             lhs: pk_column_http.clone(),
                             rhs: vec![1.into(), 2.into()],
                         }],
-                        allow_filtering: false,
+                        allow_filtering: true,
                     }),
                     NonZeroUsize::new(100).unwrap().into(),
                 )
@@ -782,7 +824,7 @@ async fn ann_filter_clustering_key_int_in() {
                             lhs: ck_column_http.clone(),
                             rhs: vec![1.into(), 3.into()],
                         }],
-                        allow_filtering: false,
+                        allow_filtering: true,
                     }),
                     NonZeroUsize::new(100).unwrap().into(),
                 )
@@ -954,7 +996,7 @@ async fn run_ann_filter_int_int(
                     vec![1.0, 2.0, 3.0].into(),
                     Some(PostIndexAnnFilter {
                         restrictions: restrictions.clone(),
-                        allow_filtering: false,
+                        allow_filtering: true,
                     }),
                     NonZeroUsize::new(100).unwrap().into(),
                 )
@@ -1437,7 +1479,7 @@ async fn ann_filter_partition_key_text_gt() {
                             lhs: pk_column_http.clone(),
                             rhs: "b".into(),
                         }],
-                        allow_filtering: false,
+                        allow_filtering: true,
                     }),
                     NonZeroUsize::new(100).unwrap().into(),
                 )

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -10,6 +10,7 @@ use crate::db_basic::ScanFn;
 use crate::db_basic::Table;
 use crate::wait_for;
 use crate::wait_for_value;
+use httpapi::IndexStatus;
 use httpapi::PostIndexAnnFilter;
 use httpapi::PostIndexAnnResponse;
 use httpapi::PostIndexAnnRestriction;
@@ -167,9 +168,17 @@ pub(crate) async fn setup_store_and_wait_for_index(
     .await;
     let (client, server, _config_tx) = run.await;
 
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
     wait_for(
-        || async { !client.indexes().await.is_empty() },
-        "Waiting for index to be added to the store",
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Serving)
+        },
+        "Waiting for index to be serving",
     )
     .await;
 
@@ -423,7 +432,9 @@ async fn ann_fail_while_building() {
             ("pk".to_string().into(), NativeType::Int),
             ("ck".to_string().into(), NativeType::Text),
         ],
-        None,
+        Some(Box::new(|_tx| {
+            futures::FutureExt::boxed(std::future::pending::<()>())
+        })),
         None,
     )
     .await;
@@ -432,10 +443,24 @@ async fn ann_fail_while_building() {
     ));
     let (client, _server, _config_tx) = run.await;
 
+    let keyspace_name = index.keyspace_name.into();
+    let index_name = index.index_name.into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Bootstrapping)
+        },
+        "Waiting for index to be bootstrapping",
+    )
+    .await;
+
     let result = client
         .post_ann(
-            &index.keyspace_name.into(),
-            &index.index_name.into(),
+            &keyspace_name,
+            &index_name,
             vec![1.0, 2.0, 3.0].into(),
             None,
             NonZeroUsize::new(1).unwrap().into(),


### PR DESCRIPTION
# Motivation

This PR implements index routing in Vector Store, following the changes in ScyllaDB (https://github.com/scylladb/scylladb/pull/29407) allowing for multiple indexes on the same column.

# Solution

When a replacement index is created for the same keyspace, table, and target column, ANN requests can hit the new index while it is still bootstrapping. Before this change, those requests returned `503 Service Unavailable` even if another compatible index in the same routing group was already fully serving.

This change adds routing so ANN requests are served by the best matching index that has completed its full scan. That keeps queries available during index replacement while preserving the existing `503` behavior when no safe fallback exists.

## Index selection algorithm

When an ANN request arrives, the system finds all indexes that cover the same keyspace, table, and target column and picks the best one:

1. **Eliminate ineligible indexes.** A candidate is dropped if any of the query's restriction columns (equality or range) are not present in the index's filtering columns (which include the table's primary key columns). A local index is additionally dropped if its partition key columns are not all present in the query's equality restrictions.

2. **Score the remaining candidates.** Each index is scored by how many restriction columns still need server-side filtering. For local indexes, partition-key columns covered by equality restrictions are not counted. An index that covers every restriction column scores `NeedsFiltering::No`; otherwise, `NeedsFiltering::Yes(n)` where fewer uncovered columns is better.

3. **Require the index to be serving.** Only indexes whose `IndexStatus` is `Serving` are considered.

4. **Break ties by version.** Among candidates with the same score, the one with the newest `IndexVersion` (created most recently) wins.

If the selected index needs filtering (`NeedsFiltering::Yes`) and the query does not include `ALLOW FILTERING`, the request returns `400 Bad Request`.

If no serving candidate exists and the originally requested index is still building, the request returns `503 Service Unavailable` with a progress indicator. If the full scan already finished but the index is not serving, it returns `500 Internal Server Error`. If the requested index does not exist at all, the request returns `404 Not Found`.

## What changed
- add `indexes` module with `Indexes`, `RoutingMap`, `IndexEntry`, `score_index`, and `route_index`
- group indexes by keyspace, table, and target column via `RoutingGroupKey`
- add `Engine::GetBestIndex` message and `EngineExt::get_best_index` to route ANN queries through the engine actor
- score serving candidates using the ANN query's equality and range restriction columns
- prefer local indexes when partition key restrictions match, prefer indexes with fewer uncovered restriction columns, and break ties by newest `IndexVersion`
- use the routed index key for ANN execution (`ann` and `filtered_ann` calls)
- status and metrics endpoints continue using `get_index` (direct lookup, no routing)
- return `400 Bad Request` when a routed index needs filtering but the query omits `ALLOW FILTERING`
- make `IndexVersion` orderable so tie-breaking is deterministic
- add `slow-test-hooks` feature flag with an `ann-served-request` counter to verify which index actually served an ANN request
- tighten integration test waits to block on `Serving` status rather than simple index discovery
- update full scan progress simulation in `DbBasic` to report `InProgress(0%)` until the scan finishes
- add `ALLOW FILTERING` to all validator filtering test queries that include restriction columns

## Testing
- add integration tests for index scoring (`score_index`), local-vs-global routing, partition key precision, and filtering column match ranking
- add validator end-to-end tests that ANN requests to a bootstrapping replacement index are served by the newest best matching serving index
- add validator coverage that routing does not cross target columns and still returns `503` until the requested index is serving
- add validator coverage for not-found, unavailable-while-bootstrapping, and dropped-index edge cases

Fixes: VECTOR-640