### PR TITLE
Improve build-release error message for dirty working tree

### DIFF
--- a/scripts/build-release
+++ b/scripts/build-release
@@ -10,7 +10,14 @@ cd $repo
 vector_store_version=$(./scripts/run-with-release-toolchain cargo info vector-store | grep ^version: | cut -d ' ' -f 2)
 
 # ensure the git repository is clean
-git status --porcelain | grep -q . && echo "git repository is not clean." && exit 1
+if git status --porcelain | grep -q . ; then
+    echo "error: git repository is not clean. Dirty files:"
+    git status --porcelain
+    echo ""
+    echo "Please commit or discard uncommitted changes before building a release."
+    echo "To discard all changes: git checkout -- ."
+    exit 1
+fi
 
 archs="amd64 arm64"
 


### PR DESCRIPTION
When `build-release` detects uncommitted changes it now lists the dirty files and tells the user how to fix the issue, instead of just printing "git repository is not clean."