### PR TITLE
Support optimized Alternator Vector type

### DIFF
--- a/crates/vector-store/src/vector.rs
+++ b/crates/vector-store/src/vector.rs
@@ -50,7 +50,7 @@ impl TryFrom<CqlValue> for Vector {
                     Ok(f)
                 })
                 .collect(),
-            CqlValue::Blob(bytes) => parse_dynamodb_vector_json(&bytes),
+            CqlValue::Blob(bytes) => parse_alternator_vector(&bytes),
             other => Err(anyhow!(
                 "unsupported CQL type for embedding column: {other:?}"
             )),
@@ -59,23 +59,52 @@ impl TryFrom<CqlValue> for Vector {
     }
 }
 
-/// Alternator type tag for the DynamoDB List type (`L`), which is how vector embeddings are serialised.
-/// Alternator prefixes each attribute value in the `:attrs` map column with a 1-byte type discriminator.
-/// The List type uses the tag value `0x04` (named `NOT_SUPPORTED_YET`)
-const ALTERNATOR_TYPE_NOT_SUPPORTED_YET: u8 = 4;
+/// Alternator type tag for unoptimized JSON encoding.
+/// Type `0x04` (`NOT_SUPPORTED_YET`) is used for any type that does not have an optimized encoding.
+/// The payload is an unoptimized JSON value.
+const ALTERNATOR_TYPE_JSON: u8 = 4;
 
-/// Parses a DynamoDB-style JSON vector stored as raw bytes.
+/// Alternator type tag for the optimized `FLOAT32VECTOR` type.
+/// The value is serialized as this 1-byte tag followed by sequential 32-bit big-endian floats,
+/// matching the CQL `VECTOR<float, N>` on-wire encoding.
+const ALTERNATOR_TYPE_FLOAT32VECTOR: u8 = 5;
+
+/// Parses an Alternator-encoded vector stored as raw bytes.
 ///
-/// Handles two representations:
-/// - Plain JSON: `{"L": [{"N": "123.4"}, {"N": "234.5"}, ...]}`
-/// - Alternator-prefixed: a 1-byte type tag (`0x04`) followed by the JSON above.
-///   This prefix is used by Alternator for attribute values in the `:attrs` map.
-fn parse_dynamodb_vector_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
-    let bytes = match bytes.first() {
-        Some(&ALTERNATOR_TYPE_NOT_SUPPORTED_YET) => &bytes[1..],
-        _ => bytes,
-    };
+/// Alternator prefixes each attribute value in the `:attrs` map column with a 1-byte type discriminator.
+/// Handles two representations based on the discriminator:
+/// - [`ALTERNATOR_TYPE_FLOAT32VECTOR`]: optimized sequential 32-bit big-endian floats.
+/// - [`ALTERNATOR_TYPE_JSON`]: unoptimized JSON representing List values.
+fn parse_alternator_vector(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
+    match bytes.first() {
+        Some(&ALTERNATOR_TYPE_FLOAT32VECTOR) => parse_alternator_vector_binary(&bytes[1..]),
+        Some(&ALTERNATOR_TYPE_JSON) => parse_alternator_list_json(&bytes[1..]),
+        Some(tag) => bail!("unsupported Alternator type tag: {tag:#04x}"),
+        None => bail!("empty blob for Alternator attribute value"),
+    }
+}
 
+/// Parses the optimized Alternator vector encoding: sequential 32-bit big-endian floats.
+fn parse_alternator_vector_binary(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
+    let chunks = bytes.chunks_exact(4);
+
+    if !chunks.remainder().is_empty() {
+        bail!(
+            "invalid Alternator vector encoding: byte length {} is not a multiple of 4",
+            bytes.len()
+        );
+    }
+
+    Ok(chunks
+        .map(|chunk| {
+            let arr: [u8; 4] = chunk.try_into().expect("chunks_exact guarantees 4 bytes");
+            f32::from_be_bytes(arr)
+        })
+        .collect())
+}
+
+/// Parses an Alternator JSON list of numbers: `{"L": [{"N": "..."}, ...]}`.
+fn parse_alternator_list_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
     #[derive(serde::Deserialize)]
     struct DynamoDbList {
         #[serde(rename = "L")]
@@ -94,7 +123,7 @@ fn parse_dynamodb_vector_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
         .map(|item| {
             item.n
                 .parse::<f32>()
-                .map_err(|e| anyhow!("invalid value in DynamoDB vector element: {e}"))
+                .map_err(|e| anyhow!("invalid value in Alternator list element: {e}"))
         })
         .collect()
 }
@@ -141,6 +170,24 @@ impl TryFrom<AlternatorAttrs<'_>> for Option<Vector> {
 mod tests {
     use super::*;
 
+    /// Prepend the [`ALTERNATOR_TYPE_JSON`] tag to a DynamoDB JSON string,
+    /// mirroring how Alternator serialises List values.
+    fn alternator_list_blob(json: &str) -> Vec<u8> {
+        let mut v = vec![ALTERNATOR_TYPE_JSON];
+        v.extend_from_slice(json.as_bytes());
+        v
+    }
+
+    /// Prepend the [`ALTERNATOR_TYPE_FLOAT32VECTOR`] tag to a sequence of big-endian floats,
+    /// mirroring how Alternator serialises the `FLOAT32VECTOR` type.
+    fn alternator_vector_blob(floats: &[f32]) -> Vec<u8> {
+        let mut v = vec![ALTERNATOR_TYPE_FLOAT32VECTOR];
+        for &f in floats {
+            v.extend_from_slice(&f.to_be_bytes());
+        }
+        v
+    }
+
     #[test]
     fn extract_from_cql_vector() {
         let value = CqlValue::Vector(vec![
@@ -155,7 +202,7 @@ mod tests {
     #[test]
     fn extract_from_dynamodb_json_blob() {
         let json = r#"{"L": [{"N": "123.4"}, {"N": "234.5"}, {"N": "345.6"}]}"#;
-        let value = CqlValue::Blob(json.as_bytes().to_vec());
+        let value = CqlValue::Blob(alternator_list_blob(json));
         let result = Vector::try_from(value).unwrap();
         assert_eq!(result, Vector::from(vec![123.4, 234.5, 345.6]));
     }
@@ -163,7 +210,7 @@ mod tests {
     #[test]
     fn extract_from_dynamodb_json_empty_list() {
         let json = r#"{"L": []}"#;
-        let value = CqlValue::Blob(json.as_bytes().to_vec());
+        let value = CqlValue::Blob(alternator_list_blob(json));
         let result = Vector::try_from(value).unwrap();
         assert_eq!(result, Vector::from(vec![]));
     }
@@ -171,7 +218,19 @@ mod tests {
     #[test]
     fn extract_from_dynamodb_json_invalid_number() {
         let json = r#"{"L": [{"N": "not_a_number"}]}"#;
-        let value = CqlValue::Blob(json.as_bytes().to_vec());
+        let value = CqlValue::Blob(alternator_list_blob(json));
+        assert!(Vector::try_from(value).is_err());
+    }
+
+    #[test]
+    fn extract_from_blob_unknown_tag() {
+        let value = CqlValue::Blob(vec![0x99, 0x00, 0x01]);
+        assert!(Vector::try_from(value).is_err());
+    }
+
+    #[test]
+    fn extract_from_blob_empty() {
+        let value = CqlValue::Blob(vec![]);
         assert!(Vector::try_from(value).is_err());
     }
 
@@ -187,25 +246,17 @@ mod tests {
         assert!(Vector::try_from(value).is_err());
     }
 
-    /// Helper: prepend the Alternator `NOT_SUPPORTED_YET` tag (0x04) to a
-    /// DynamoDB JSON string, mirroring how Alternator serialises List values.
-    fn alternator_blob(json: &str) -> Vec<u8> {
-        let mut v = vec![ALTERNATOR_TYPE_NOT_SUPPORTED_YET];
-        v.extend_from_slice(json.as_bytes());
-        v
-    }
-
     #[test]
     fn extract_from_attrs_map_with_blob_keys() {
         let json = r#"{"L": [{"N": "1.0"}, {"N": "2.0"}]}"#;
         let attrs = CqlValue::Map(vec![
             (
                 CqlValue::Blob(b"other".to_vec()),
-                CqlValue::Blob(alternator_blob(r#"{"S": "ignored"}"#)),
+                CqlValue::Blob(alternator_list_blob(r#"{"S": "ignored"}"#)),
             ),
             (
                 CqlValue::Blob(b"v".to_vec()),
-                CqlValue::Blob(alternator_blob(json)),
+                CqlValue::Blob(alternator_list_blob(json)),
             ),
         ]);
         let result = Option::<Vector>::try_from(AlternatorAttrs {
@@ -221,7 +272,7 @@ mod tests {
         let json = r#"{"L": [{"N": "3.0"}]}"#;
         let attrs = CqlValue::Map(vec![(
             CqlValue::Text("v".to_string()),
-            CqlValue::Blob(alternator_blob(json)),
+            CqlValue::Blob(alternator_list_blob(json)),
         )]);
         let result = Option::<Vector>::try_from(AlternatorAttrs {
             attrs,
@@ -255,5 +306,48 @@ mod tests {
             })
             .is_err()
         );
+    }
+
+    #[test]
+    fn extract_from_alternator_vector_blob() {
+        let value = CqlValue::Blob(alternator_vector_blob(&[1.0, 2.5, 3.0]));
+        let result = Vector::try_from(value).unwrap();
+        assert_eq!(result, Vector::from(vec![1.0, 2.5, 3.0]));
+    }
+
+    #[test]
+    fn extract_from_alternator_vector_empty() {
+        let value = CqlValue::Blob(alternator_vector_blob(&[]));
+        let result = Vector::try_from(value).unwrap();
+        assert_eq!(result, Vector::from(vec![]));
+    }
+
+    #[test]
+    fn extract_from_alternator_vector_invalid_length() {
+        // 5 bytes after the tag — not a multiple of 4
+        let mut bytes = vec![ALTERNATOR_TYPE_FLOAT32VECTOR];
+        bytes.extend_from_slice(&[0x00, 0x01, 0x02, 0x03, 0x04]);
+        let value = CqlValue::Blob(bytes);
+        assert!(Vector::try_from(value).is_err());
+    }
+
+    #[test]
+    fn extract_from_attrs_map_alternator_vector() {
+        let attrs = CqlValue::Map(vec![
+            (
+                CqlValue::Blob(b"other".to_vec()),
+                CqlValue::Blob(alternator_list_blob(r#"{"S": "ignored"}"#)),
+            ),
+            (
+                CqlValue::Blob(b"v".to_vec()),
+                CqlValue::Blob(alternator_vector_blob(&[1.0, 2.0, 3.0])),
+            ),
+        ]);
+        let result = Option::<Vector>::try_from(AlternatorAttrs {
+            attrs,
+            target_column: "v",
+        })
+        .unwrap();
+        assert_eq!(result, Some(Vector::from(vec![1.0, 2.0, 3.0])));
     }
 }


### PR DESCRIPTION
## Motivation

Alternator can store vectors using an optimized binary encoding, but the vector extraction path only supported the JSON list form. That made `FLOAT32VECTOR`-encoded vectors unusable even though they represent the same logical data.

Supporting both encodings makes the vector handling path consistent with Alternator behavior and ensures queries work regardless of which representation was used to write the item.

## Summary

Add support for Alternator's optimized `FLOAT32VECTOR` type encoding.

Until now, vector extraction only handled the existing JSON-based DynamoDB list representation. This change adds support for the optimized binary encoding used by Alternator.

## Changes

- add parsing for Alternator `FLOAT32VECTOR` type payloads encoded as sequential big-endian `f32` values
- keep support for the existing JSON `L` representation
- validate malformed binary payloads before decoding
- add unit coverage for the new parsing path in `vector-store`

## Test Coverage

- unit tests for Alternator vector blob parsing

Fixes: VECTOR-650