### PR TITLE
fix(db_index): prevent orphaned CDC readers across db_index replacement

### DIFF
--- a/crates/validator/src/cdc.rs
+++ b/crates/validator/src/cdc.rs
@@ -12,6 +12,7 @@ use vector_search_validator_tests::TestCase;
 
 const FINE_GRAINED_CDC_MAX_LATENCY: Duration = Duration::from_secs(2);
 const CDC_MAX_LATENCY: Duration = Duration::from_secs(60);
+const CDC_ACTOR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[framed]
 pub(crate) async fn new() -> TestCase<TestActors> {
@@ -37,6 +38,11 @@ pub(crate) async fn new() -> TestCase<TestActors> {
         .with_test("cdc_lwt_insert_visible", timeout, cdc_lwt_insert_visible)
         .with_test("cdc_lwt_update_visible", timeout, cdc_lwt_update_visible)
         .with_test("cdc_lwt_delete_visible", timeout, cdc_lwt_delete_visible)
+        .with_test(
+            "recreating_index_terminates_old_cdc_actors",
+            timeout,
+            recreating_index_terminates_old_cdc_actors,
+        )
 }
 
 #[framed]
@@ -411,6 +417,114 @@ async fn cdc_lwt_delete_visible(actors: TestActors) {
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
         .await
         .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+/// Regression test for VECTOR-653.
+///
+/// When the engine replaces a `db_index` for a given index key (e.g. after
+/// DROP + CREATE of the same index), old CDC actors must terminate. If
+/// they are orphaned, the same index ends up with multiple CDC readers
+/// running concurrently, which is the symptom observed in the field.
+#[framed]
+async fn recreating_index_terminates_old_cdc_actors(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs(&actors).await;
+    let client = &clients[0];
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+
+    let index_name = "idx_vector_653_regression";
+    let index_ident = format!("{keyspace}.{index_name}");
+
+    let wide_started = format!("{index_ident}-wide-cdc-actor-started");
+    let wide_stopped = format!("{index_ident}-wide-cdc-actor-stopped");
+    let fine_started = format!("{index_ident}-fine-cdc-actor-started");
+    let fine_stopped = format!("{index_ident}-fine-cdc-actor-stopped");
+
+    client.internals_clear_counters().await.unwrap();
+    for name in [&wide_started, &wide_stopped, &fine_started, &fine_stopped] {
+        client.internals_start_counter(name.clone()).await.unwrap();
+    }
+
+    info!("creating generation 1 of index {index_ident}");
+    let index = create_index(
+        CreateIndexQuery::new(&session, &clients, table.as_ref(), "v").index_name(index_name),
+    )
+    .await;
+    wait_for_index(client, &index).await;
+
+    wait_for(
+        || async {
+            let counters = match client.internals_counters().await {
+                Ok(c) => c,
+                Err(_) => return false,
+            };
+            counters.get(&wide_started).copied().unwrap_or(0) >= 1
+                && counters.get(&fine_started).copied().unwrap_or(0) >= 1
+        },
+        "waiting for generation 1 CDC actors to start",
+        Duration::from_secs(30),
+    )
+    .await;
+
+    info!("dropping index {index_ident}");
+    session
+        .query_unpaged(format!("DROP INDEX {index_name}"), ())
+        .await
+        .expect("failed to drop an index");
+
+    info!("re-creating index {index_ident} as generation 2");
+    let index = create_index(
+        CreateIndexQuery::new(&session, &clients, table.as_ref(), "v").index_name(index_name),
+    )
+    .await;
+    wait_for_index(client, &index).await;
+
+    wait_for(
+        || async {
+            let counters = match client.internals_counters().await {
+                Ok(c) => c,
+                Err(_) => return false,
+            };
+            counters.get(&wide_started).copied().unwrap_or(0) >= 2
+                && counters.get(&fine_started).copied().unwrap_or(0) >= 2
+        },
+        "waiting for generation 2 CDC actors to start",
+        Duration::from_secs(30),
+    )
+    .await;
+
+    wait_for(
+        || async {
+            let counters = match client.internals_counters().await {
+                Ok(c) => c,
+                Err(_) => return false,
+            };
+            counters.get(&wide_stopped).copied().unwrap_or(0) >= 1
+                && counters.get(&fine_stopped).copied().unwrap_or(0) >= 1
+        },
+        "VECTOR-653: old CDC actors must terminate after db_index replacement",
+        CDC_ACTOR_STOP_TIMEOUT,
+    )
+    .await;
+
+    let counters = client.internals_counters().await.unwrap();
+    info!(
+        "final counters: wide started={} stopped={}, fine started={} stopped={}",
+        counters.get(&wide_started).copied().unwrap_or(0),
+        counters.get(&wide_stopped).copied().unwrap_or(0),
+        counters.get(&fine_started).copied().unwrap_or(0),
+        counters.get(&fine_stopped).copied().unwrap_or(0),
+    );
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
 
     info!("finished");
 }

--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -651,6 +651,11 @@ impl<'a> CreateIndexQuery<'a> {
         }
     }
 
+    pub fn index_name(mut self, index_name: impl Into<String>) -> Self {
+        self.index = index_name.into().into();
+        self
+    }
+
     pub fn partition_columns(
         mut self,
         partition_columns: impl IntoIterator<Item = impl AsRef<str>>,

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -134,9 +134,13 @@ pub(crate) fn new(
     let mut reader: CdcReaderState = config.into();
     let name = reader.name;
     let actor_key = metadata.key();
+    let span_key = actor_key.clone();
     tokio::spawn(
         async move {
             debug!("starting");
+            internals
+                .increment_counter(format!("{actor_key}-{name}-cdc-actor-started"))
+                .await;
 
             loop {
                 tokio::select! {
@@ -174,9 +178,12 @@ pub(crate) fn new(
             // Cleanup
             reader.stop().await;
 
+            internals
+                .increment_counter(format!("{actor_key}-{name}-cdc-actor-stopped"))
+                .await;
             debug!("finished");
         }
-        .instrument(error_span!("db_cdc", "{}-{}", actor_key, name)),
+        .instrument(error_span!("db_cdc", "{}-{}", span_key, name)),
     );
 
     tx

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -180,13 +180,23 @@ pub(crate) async fn new(
         CdcReaderConfig::Fine,
     );
 
-    // Monitor CDC actor channels for closure to notify about errors
-    tokio::spawn(async move {
-        tokio::select! {
-            _ = cdc_wide.closed() => {},
-            _ = cdc_fine.closed() => {},
+    // Signal from the main db_index task to the CDC monitor task that
+    // this db_index is shutting down. Without it, the monitor would keep
+    // the CDC senders alive across a db_index replacement, leaving
+    // orphaned CDC actors running (VECTOR-653).
+    let db_index_stopped = Arc::new(Notify::new());
+
+    // Monitor CDC actor channels for closure to notify about errors, or
+    // exit when the main db_index task signals shutdown.
+    tokio::spawn({
+        let db_index_stopped = Arc::clone(&db_index_stopped);
+        async move {
+            tokio::select! {
+                _ = cdc_wide.closed() => cdc_error_notify.notify_one(),
+                _ = cdc_fine.closed() => cdc_error_notify.notify_one(),
+                _ = db_index_stopped.notified() => {}
+            }
         }
-        cdc_error_notify.notify_one();
     });
 
     // Spawn main task for full scan and message processing
@@ -232,6 +242,7 @@ pub(crate) async fn new(
                 tokio::spawn(process(Arc::clone(&statements), msg, completed_scan_length.clone()));
             }
 
+            db_index_stopped.notify_one();
             debug!("finished");
         }
         .instrument(error_span!("db_index", "{}", key)),


### PR DESCRIPTION
## VECTOR-653: duplicated CDC readers after db_index replacement

### Problem

On a single vector-store instance, after a cluster topology change, logs showed repeated creation of the fine CDC reader for the same index. Old CDC reader generations were staying alive after `db_index` replacement.

### Root cause

`db_index::new` spawned a small monitor task that owned `cdc_wide` and `cdc_fine` and only awaited their `.closed()` signals to forward `cdc_error_notify`. When the engine replaced a `db_index` (e.g. after schema/topology change), that monitor kept the old CDC senders alive even though the corresponding main db_index task was gone. The old CDC actors then continued running concurrently with the new generation.

### Fix

Add a `Notify` (`db_index_stopped`) from the main db_index task to the CDC monitor task:

- The main task signals `db_index_stopped` when it exits (e.g. when `tx_index` is dropped by the engine).
- The CDC monitor adds a third branch to its `select!` that exits on `db_index_stopped.notified()`.
- On monitor exit, CDC senders are dropped, terminating old CDC actors.
- Behavior on CDC `.closed()` path (notifying `cdc_error_notify`) is unchanged.

The change is intentionally minimal: ~20 lines in `db_index.rs`.

### Regression test

A second commit adds a deterministic validator-level regression test (`cdc::recreating_index_terminates_old_cdc_actors`) that exercises the invariant directly. The test:

1. Creates an index with CDC enabled.
2. Waits until both CDC actors (wide + fine) report `-cdc-actor-started` via the internals counters endpoint.
3. `DROP INDEX` + `CREATE INDEX` with the same name, forcing a `db_index` replacement.
4. Asserts that both old CDC actors terminate (both `-cdc-actor-stopped` counters reach 1) within 10 seconds.

Supporting instrumentation is added in `db_cdc.rs`: two counter increments per CDC actor lifecycle. The counters are no-op unless registered via `internals_start_counter`, so there is no runtime cost in production.

Verified locally against `scylladb/scylla:2026.1` in Docker:

- With the fix reverted: **10/10 runs fail** on the `wait_for` timeout for the stopped counters.
- With the fix applied: **10/10 runs pass**.

Fixes VECTOR-653
