### PR TITLE
Refactor processing usearch operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5107,6 +5107,7 @@ name = "vector-store"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-trait",
  "axum",
  "axum-server",
@@ -5134,7 +5135,6 @@ dependencies = [
  "opensearch",
  "prometheus",
  "rand 0.10.1",
- "rayon",
  "rcgen",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ license = "LicenseRef-ScyllaDB-Source-Available-1.0"
 anyhow = "1.0.97"
 arrow-array = "56.0.0"
 async-backtrace = "0.2.7"
+async-channel = "2.5.0"
 async-trait = "0.1.88"
 axum = { version = "0.8.8", features = ["macros"] }
 axum-server = { version = "0.8.0", features = ["tls-rustls"] }
@@ -84,7 +85,6 @@ utoipa-swagger-ui = { version = "9.0.0", features = ["axum", "vendored"] }
 uuid = "1.16.0"
 vector-store = { path = "crates/vector-store" }
 secrecy = "0.10.3"
-rayon = "1.11.0"
 
 [patch.crates-io]
 # Currently, axum-server-dual-protocol doesn't have a published version that supports axum 0.8, so we need to use the git version from the PR.

--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -67,12 +67,13 @@ impl HttpClient {
         Vec<Distance>,
         Vec<SimilarityScore>,
     ) {
-        let resp = self
-            .post_ann(keyspace_name, index_name, vector, filter, limit)
-            .await
-            .json::<PostIndexAnnResponse>()
-            .await
-            .unwrap();
+        let resp = dbg!(
+            self.post_ann(keyspace_name, index_name, vector, filter, limit)
+                .await
+        )
+        .json::<PostIndexAnnResponse>()
+        .await
+        .unwrap();
         (resp.primary_keys, resp.distances, resp.similarity_scores)
     }
 

--- a/crates/validator/src/reconnect.rs
+++ b/crates/validator/src/reconnect.rs
@@ -272,11 +272,19 @@ async fn restarting_one_node_doesnt_break_fullscan(actors: TestActors) {
     .await;
 
     info!("Checking that full scan isn't completed");
-    let index_status = client
-        .index_status(&index.keyspace, &index.index)
-        .await
-        .expect("failed to get index status");
-    assert_eq!(index_status.status, IndexStatus::Bootstrapping);
+    wait_for(
+        || async {
+            client
+                .index_status(&index.keyspace, &index.index)
+                .await
+                .expect("failed to get index status")
+                .status
+                == IndexStatus::Bootstrapping
+        },
+        format!("index {index:?} must be bootstrapping"),
+        Duration::from_secs(10),
+    )
+    .await;
 
     let proxy_addr = get_default_scylla_proxy_node_configs(&actors)
         .await
@@ -391,11 +399,19 @@ async fn restarting_all_nodes_doesnt_break_fullscan(actors: TestActors) {
     ))
     .await;
 
-    let index_status = client
-        .index_status(&index.keyspace, &index.index)
-        .await
-        .expect("failed to get index status");
-    assert_eq!(index_status.status, IndexStatus::Bootstrapping);
+    wait_for(
+        || async {
+            client
+                .index_status(&index.keyspace, &index.index)
+                .await
+                .expect("failed to get index status")
+                .status
+                == IndexStatus::Bootstrapping
+        },
+        format!("index {index:?} must be bootstrapping"),
+        Duration::from_secs(10),
+    )
+    .await;
 
     info!("Restart each node one by one");
     for proxy_addr in get_default_scylla_proxy_node_configs(&actors)

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -28,6 +28,7 @@ slow-test-hooks = []
 
 [dependencies]
 anyhow.workspace = true
+async-channel.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 axum-server.workspace = true
@@ -71,7 +72,6 @@ utoipa.workspace = true
 utoipa-axum.workspace = true
 utoipa-swagger-ui.workspace = true
 uuid.workspace = true
-rayon.workspace = true
 
 [dev-dependencies]
 axum-test.workspace = true

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -89,25 +89,10 @@ fn init() {
     });
 }
 
-static INIT_RAYON: Once = Once::new();
-
 fn default_runtime() -> Runtime {
     let threads = dotenvy::var("VECTOR_STORE_THREADS")
         .ok()
         .and_then(|s| s.parse().ok());
-    INIT_RAYON.call_once(|| {
-        rayon::ThreadPoolBuilder::new()
-            .pipe(|b| {
-                if let Some(threads) = threads {
-                    b.num_threads(threads)
-                } else {
-                    b
-                }
-            })
-            .build_global()
-            .unwrap();
-    });
-
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .pipe(|mut b| {
             if let Some(threads) = threads {

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -29,6 +29,7 @@ use crate::internals::InternalsExt;
 use crate::node_state::Event;
 use crate::node_state::NodeState;
 use crate::node_state::NodeStateExt;
+use crate::perf;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -253,7 +254,7 @@ pub(crate) async fn new(
     internals: Sender<Internals>,
     mut config_rx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<mpsc::Sender<Db>> {
-    let (tx, mut rx) = mpsc::channel(10);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
     tokio::spawn(
         async move {
             let mut config = config_rx.borrow().clone();

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -11,6 +11,7 @@ use crate::IndexMetadata;
 use crate::db_index_backend::DbIndexBackend;
 use crate::internals::Internals;
 use crate::internals::InternalsExt;
+use crate::perf;
 use ::time::Date;
 use ::time::Month;
 use ::time::OffsetDateTime;
@@ -125,8 +126,7 @@ pub(crate) fn new(
     tx_embeddings: mpsc::Sender<(DbEmbedding, Option<AsyncInProgress>)>,
     config: CdcReaderConfig,
 ) -> mpsc::Sender<DbCdc> {
-    // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
-    let (tx, mut rx) = mpsc::channel::<DbCdc>(10);
+    let (tx, mut rx) = mpsc::channel::<DbCdc>(perf::channel_size().into());
 
     // Mark the receiver to ensure first session update is visible
     session_rx.mark_changed();

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -22,6 +22,7 @@ use crate::invariant_key::InvariantKey;
 use crate::node_state::Event;
 use crate::node_state::NodeState;
 use crate::node_state::NodeStateExt;
+use crate::perf;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -155,10 +156,8 @@ pub(crate) async fn new(
 )> {
     let key = metadata.key();
 
-    // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
-    const CHANNEL_SIZE: usize = 10;
-    let (tx_index, mut rx_index) = mpsc::channel(CHANNEL_SIZE);
-    let (tx_embeddings, rx_embeddings) = mpsc::channel(CHANNEL_SIZE);
+    let (tx_index, mut rx_index) = mpsc::channel(perf::channel_size().into());
+    let (tx_embeddings, rx_embeddings) = mpsc::channel(perf::channel_size().into());
 
     // Wait for initial session to create statements.
     let mut statements_session_rx = session_rx.clone();

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -314,6 +314,7 @@ async fn update_indexes(node_state: &Sender<NodeState>, indexes: &RwLock<Indexes
             )
         })
         .collect_vec();
+
     for (key, db_index, progress, status) in actual_indexes.into_iter() {
         let Some(new_status) = node_state
             .get_index_status(key.keyspace().as_ref(), key.index().as_ref())

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -24,6 +24,7 @@ use crate::monitor_indexes;
 use crate::monitor_items;
 use crate::node_state::NodeState;
 use crate::node_state::NodeStateExt;
+use crate::perf;
 use crate::table::Table;
 use itertools::Itertools;
 use std::sync::Arc;
@@ -111,7 +112,7 @@ pub(crate) async fn new(
     indexes: Arc<RwLock<Indexes>>,
     config_rx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<mpsc::Sender<Engine>> {
-    let (tx, mut rx) = mpsc::channel(10);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     let monitor_actor = monitor_indexes::new(
         db.clone(),

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::ColumnName;
 use crate::Config;
 use crate::DbIndexType;
 use crate::IndexKey;
@@ -17,7 +16,6 @@ use crate::db_index::DbIndexExt;
 use crate::factory::IndexFactory;
 use crate::index::Index;
 use crate::index::factory::IndexConfiguration;
-use crate::indexes::BestIndexState;
 use crate::indexes::IndexEntry;
 use crate::indexes::Indexes;
 use crate::memory;
@@ -45,7 +43,6 @@ use tracing::trace;
 type GetIndexKeysR = Vec<(IndexKey, Quantization)>;
 type AddIndexR = anyhow::Result<()>;
 type GetIndexR = Option<(mpsc::Sender<Index>, mpsc::Sender<DbIndex>)>;
-type GetBestIndexR = BestIndexState;
 
 pub(crate) enum Engine {
     GetIndexIds {
@@ -62,12 +59,6 @@ pub(crate) enum Engine {
         key: IndexKey,
         tx: oneshot::Sender<GetIndexR>,
     },
-    GetBestIndex {
-        key: IndexKey,
-        equality_columns: Vec<ColumnName>,
-        range_columns: Vec<ColumnName>,
-        tx: oneshot::Sender<GetBestIndexR>,
-    },
 }
 
 pub(crate) trait EngineExt {
@@ -75,12 +66,6 @@ pub(crate) trait EngineExt {
     async fn add_index(&self, metadata: IndexMetadata) -> AddIndexR;
     async fn del_index(&self, key: IndexKey);
     async fn get_index(&self, key: IndexKey) -> GetIndexR;
-    async fn get_best_index(
-        &self,
-        key: IndexKey,
-        equality_columns: Vec<ColumnName>,
-        range_columns: Vec<ColumnName>,
-    ) -> GetBestIndexR;
 }
 
 impl EngineExt for mpsc::Sender<Engine> {
@@ -115,25 +100,6 @@ impl EngineExt for mpsc::Sender<Engine> {
             .expect("EngineExt::get_index: internal actor should receive request");
         rx.await
             .expect("EngineExt::get_index: internal actor should send response")
-    }
-
-    async fn get_best_index(
-        &self,
-        key: IndexKey,
-        equality_columns: Vec<ColumnName>,
-        range_columns: Vec<ColumnName>,
-    ) -> GetBestIndexR {
-        let (tx, rx) = oneshot::channel();
-        self.send(Engine::GetBestIndex {
-            key,
-            equality_columns,
-            range_columns,
-            tx,
-        })
-        .await
-        .expect("EngineExt::get_best_index: internal actor should receive request");
-        rx.await
-            .expect("EngineExt::get_best_index: internal actor should send response")
     }
 }
 
@@ -188,20 +154,6 @@ pub(crate) async fn new(
 
                             Engine::GetIndex { key, tx } => get_index(key, tx, &indexes).await,
 
-                            Engine::GetBestIndex {
-                                key,
-                                equality_columns,
-                                range_columns,
-                                tx,
-                            } => {
-                                get_best_index(
-                                    key,
-                                    equality_columns,
-                                    range_columns,
-                                    tx,
-                                    &indexes,
-                                ).await
-                            }
                         }
                     }
 
@@ -348,21 +300,6 @@ async fn get_index(key: IndexKey, tx: oneshot::Sender<GetIndexR>, indexes: &RwLo
     );
 }
 
-async fn get_best_index(
-    key: IndexKey,
-    equality_columns: Vec<ColumnName>,
-    range_columns: Vec<ColumnName>,
-    tx: oneshot::Sender<GetBestIndexR>,
-    indexes: &RwLock<Indexes>,
-) {
-    let result = indexes
-        .read()
-        .unwrap()
-        .best_index(&key, &equality_columns, &range_columns);
-    tx.send(result)
-        .unwrap_or_else(|_| trace!("get_best_index: unable to send response"));
-}
-
 async fn update_indexes(node_state: &Sender<NodeState>, indexes: &RwLock<Indexes>) {
     let actual_indexes = indexes
         .read()
@@ -419,14 +356,6 @@ pub(crate) mod tests {
             key: IndexKey,
             tx: oneshot::Sender<GetIndexR>,
         ) -> impl Future<Output = ()> + Send + 'static;
-
-        fn get_best_index(
-            &self,
-            key: IndexKey,
-            equality_columns: Vec<ColumnName>,
-            range_columns: Vec<ColumnName>,
-            tx: oneshot::Sender<GetBestIndexR>,
-        ) -> impl Future<Output = ()> + Send + 'static;
     }
 
     pub(crate) fn new(sim: impl SimEngine + Send + 'static) -> mpsc::Sender<Engine> {
@@ -449,15 +378,6 @@ pub(crate) mod tests {
                         Engine::AddIndex { metadata, tx } => sim.add_index(metadata, tx).await,
                         Engine::DelIndex { key } => sim.del_index(key).await,
                         Engine::GetIndex { key, tx } => sim.get_index(key, tx).await,
-                        Engine::GetBestIndex {
-                            key,
-                            equality_columns,
-                            range_columns,
-                            tx,
-                        } => {
-                            sim.get_best_index(key, equality_columns, range_columns, tx)
-                                .await
-                        }
                     }
                 }
 

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -17,23 +17,25 @@ use crate::db_index::DbIndexExt;
 use crate::factory::IndexFactory;
 use crate::index::Index;
 use crate::index::factory::IndexConfiguration;
-use crate::indexes;
 use crate::indexes::BestIndexState;
 use crate::indexes::IndexEntry;
 use crate::indexes::Indexes;
-use crate::indexes::RoutingMap;
 use crate::memory;
 use crate::memory::Memory;
 use crate::monitor_indexes;
 use crate::monitor_items;
 use crate::node_state::NodeState;
+use crate::node_state::NodeStateExt;
 use crate::table::Table;
+use itertools::Itertools;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
+use tokio::time;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
@@ -140,6 +142,7 @@ pub(crate) async fn new(
     index_factory: Box<dyn IndexFactory + Send + Sync>,
     node_state: Sender<NodeState>,
     metrics: Arc<Metrics>,
+    indexes: Arc<RwLock<Indexes>>,
     config_rx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<mpsc::Sender<Engine>> {
     let (tx, mut rx) = mpsc::channel(10);
@@ -157,49 +160,52 @@ pub(crate) async fn new(
         async move {
             debug!("starting");
 
-            let mut indexes = Indexes::new();
-            let mut routing_map = RoutingMap::new();
-            while let Some(msg) = rx.recv().await {
-                match msg {
-                    Engine::GetIndexIds { tx } => get_index_keys(tx, &indexes).await,
+            const CHECK_INTERVAL: Duration = Duration::from_secs(1);
+            let mut interval = time::interval(CHECK_INTERVAL);
+            loop {
+                tokio::select! {
+                    msg = rx.recv() => {
+                        let Some(msg) = msg else {
+                            break;
+                        };
+                        match msg {
+                            Engine::GetIndexIds { tx } => get_index_keys(tx, &indexes).await,
 
-                    Engine::AddIndex { metadata, tx } => {
-                        add_index(
-                            metadata,
-                            tx,
-                            &db,
-                            index_factory.as_ref(),
-                            &mut indexes,
-                            &mut routing_map,
-                            metrics.clone(),
-                            memory_actor.clone(),
-                        )
-                        .await
+                            Engine::AddIndex { metadata, tx } => {
+                                add_index(
+                                    metadata,
+                                    tx,
+                                    &db,
+                                    index_factory.as_ref(),
+                                    &indexes,
+                                    metrics.clone(),
+                                    memory_actor.clone(),
+                                )
+                                .await
+                            }
+
+                            Engine::DelIndex { key } => del_index(key, &indexes).await,
+
+                            Engine::GetIndex { key, tx } => get_index(key, tx, &indexes).await,
+
+                            Engine::GetBestIndex {
+                                key,
+                                equality_columns,
+                                range_columns,
+                                tx,
+                            } => {
+                                get_best_index(
+                                    key,
+                                    equality_columns,
+                                    range_columns,
+                                    tx,
+                                    &indexes,
+                                ).await
+                            }
+                        }
                     }
 
-                    Engine::DelIndex { key } => {
-                        del_index(key, &mut indexes, &mut routing_map).await
-                    }
-
-                    Engine::GetIndex { key, tx } => get_index(key, tx, &indexes).await,
-
-                    Engine::GetBestIndex {
-                        key,
-                        equality_columns,
-                        range_columns,
-                        tx,
-                    } => {
-                        get_best_index(
-                            key,
-                            equality_columns,
-                            range_columns,
-                            tx,
-                            &indexes,
-                            &routing_map,
-                            &node_state,
-                        )
-                        .await
-                    }
+                    _ = interval.tick() => update_indexes(&node_state, &indexes).await,
                 }
             }
             drop(monitor_actor);
@@ -212,11 +218,13 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
-async fn get_index_keys(tx: oneshot::Sender<GetIndexKeysR>, indexes: &Indexes) {
+async fn get_index_keys(tx: oneshot::Sender<GetIndexKeysR>, indexes: &RwLock<Indexes>) {
     tx.send(
         indexes
+            .read()
+            .unwrap()
             .iter()
-            .map(|(key, entry)| (key.clone(), entry.quantization))
+            .map(|(key, entry)| (key.clone(), entry.quantization()))
             .collect(),
     )
     .unwrap_or_else(|_| trace!("Engine::GetIndexIds: unable to send response"));
@@ -228,13 +236,12 @@ async fn add_index(
     tx: oneshot::Sender<AddIndexR>,
     db: &mpsc::Sender<Db>,
     index_factory: &(dyn IndexFactory + Send + Sync),
-    indexes: &mut Indexes,
-    routing_map: &mut RoutingMap,
+    indexes: &RwLock<Indexes>,
     metrics: Arc<Metrics>,
     memory: Sender<Memory>,
 ) {
     let key = metadata.key();
-    if indexes.contains_key(&key) {
+    if indexes.read().unwrap().contains_key(&key) {
         trace!("add_index: trying to replace index with key {key}");
         tx.send(Ok(()))
             .unwrap_or_else(|_| trace!("add_index: unable to send response"));
@@ -317,34 +324,28 @@ async fn add_index(
         }
     };
 
-    let index_entry = IndexEntry::new(
-        index_actor,
-        monitor_actor,
-        db_index,
-        primary_key_columns,
-        metadata,
-    );
+    let index_entry = IndexEntry::new(index_actor, monitor_actor, db_index, metadata).await;
 
-    routing_map.add(index_entry.routing_group.clone(), key.clone());
-
-    indexes.insert(key.clone(), index_entry);
-
+    indexes.write().unwrap().insert(key.clone(), index_entry);
     info!("creating the index {key}");
     tx.send(Ok(()))
         .unwrap_or_else(|_| trace!("add_index: unable to send response"));
 }
 
-async fn del_index(key: IndexKey, indexes: &mut Indexes, routing_map: &mut RoutingMap) {
-    if let Some(entry) = indexes.remove(&key) {
-        routing_map.remove(entry.routing_group, &key);
+async fn del_index(key: IndexKey, indexes: &RwLock<Indexes>) {
+    if indexes.write().unwrap().remove(&key) {
+        info!("removed the index {key}");
     }
-    info!("removed the index {key}");
 }
 
-async fn get_index(key: IndexKey, tx: oneshot::Sender<GetIndexR>, indexes: &Indexes) {
-    let result = indexes::get_index(&key, indexes);
-    tx.send(result)
-        .unwrap_or_else(|_| trace!("get_index: unable to send response"));
+async fn get_index(key: IndexKey, tx: oneshot::Sender<GetIndexR>, indexes: &RwLock<Indexes>) {
+    _ = tx.send(
+        indexes
+            .read()
+            .unwrap()
+            .get(&key)
+            .map(|entry| (entry.index(), entry.db_index())),
+    );
 }
 
 async fn get_best_index(
@@ -352,21 +353,45 @@ async fn get_best_index(
     equality_columns: Vec<ColumnName>,
     range_columns: Vec<ColumnName>,
     tx: oneshot::Sender<GetBestIndexR>,
-    indexes: &Indexes,
-    routing_map: &RoutingMap,
-    node_state: &mpsc::Sender<NodeState>,
+    indexes: &RwLock<Indexes>,
 ) {
-    let result = indexes::route_index(
-        &key,
-        &equality_columns,
-        &range_columns,
-        indexes,
-        routing_map,
-        node_state,
-    )
-    .await;
+    let result = indexes
+        .read()
+        .unwrap()
+        .best_index(&key, &equality_columns, &range_columns);
     tx.send(result)
         .unwrap_or_else(|_| trace!("get_best_index: unable to send response"));
+}
+
+async fn update_indexes(node_state: &Sender<NodeState>, indexes: &RwLock<Indexes>) {
+    let actual_indexes = indexes
+        .read()
+        .unwrap()
+        .iter()
+        .map(|(key, entry)| {
+            (
+                key.clone(),
+                entry.db_index(),
+                entry.progress(),
+                entry.status(),
+            )
+        })
+        .collect_vec();
+    for (key, db_index, progress, status) in actual_indexes.into_iter() {
+        let Some(new_status) = node_state
+            .get_index_status(key.keyspace().as_ref(), key.index().as_ref())
+            .await
+        else {
+            continue;
+        };
+        let new_progress = db_index.full_scan_progress().await;
+        if (new_progress != progress || new_status != status)
+            && let Some(entry) = indexes.write().unwrap().get_mut(&key)
+        {
+            entry.set_progress(new_progress);
+            entry.set_status(new_status);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -320,35 +320,31 @@ async fn get_index_status(
     let keyspace_name: crate::KeyspaceName = keyspace_name.into();
     let index_name: crate::IndexName = index_name.into();
     let index_key = IndexKey::new(&keyspace_name, &index_name);
-    let Some((index, _)) = state.engine.get_index(index_key.clone()).await else {
+    let Some((index, status)) = state
+        .indexes
+        .read()
+        .unwrap()
+        .get(&index_key)
+        .map(|index| (index.index(), index.status()))
+    else {
         let msg = format!("missing index: {keyspace_name}.{index_name}");
         debug!("get_index_status: {msg}");
         return (StatusCode::NOT_FOUND, msg).into_response();
     };
-    if let Some(index_status) = state
-        .node_state
-        .get_index_status(keyspace_name.as_ref(), index_name.as_ref())
-        .await
-    {
-        match index.count(index_key).await {
-            Err(err) => {
-                let msg = format!("index.count request error: {err}");
-                debug!("get_index_status: {msg}");
-                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
-            }
-            Ok(count) => (
-                StatusCode::OK,
-                response::Json(httpapi::IndexStatusResponse {
-                    status: index_status.into(),
-                    count,
-                }),
-            )
-                .into_response(),
+    match index.count(index_key).await {
+        Err(err) => {
+            let msg = format!("index.count request error: {err}");
+            debug!("get_index_status: {msg}");
+            (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
         }
-    } else {
-        let msg = format!("missing index status: {keyspace_name}.{index_name}");
-        debug!("get_index_status: {msg}");
-        (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+        Ok(count) => (
+            StatusCode::OK,
+            response::Json(httpapi::IndexStatusResponse {
+                status: status.into(),
+                count,
+            }),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -22,6 +22,7 @@ use crate::internals::InternalsExt;
 use crate::metrics::Metrics;
 use crate::node_state::NodeState;
 use crate::node_state::NodeStateExt;
+use crate::perf;
 use crate::vector;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -500,193 +501,202 @@ async fn post_index_ann(
     Path((keyspace, index_name)): Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
     extract::Json(request): extract::Json<httpapi::PostIndexAnnRequest>,
 ) -> Response {
-    let keyspace: crate::KeyspaceName = keyspace.into();
-    let index_name: crate::IndexName = index_name.into();
-    if state.use_tls
-        && extensions
-            .get::<Protocol>()
-            .is_some_and(|protocol| *protocol == Protocol::Plain)
-    {
-        let msg =
-            "TLS is required, but the request was made over an insecure connection.".to_string();
-        debug!("post_index_ann: {msg}");
-        return (StatusCode::FORBIDDEN, msg).into_response();
-    }
+    perf::hotpath_async(async move {
+        let keyspace: crate::KeyspaceName = keyspace.into();
+        let index_name: crate::IndexName = index_name.into();
+        if state.use_tls
+            && extensions
+                .get::<Protocol>()
+                .is_some_and(|protocol| *protocol == Protocol::Plain)
+        {
+            let msg = "TLS is required, but the request \
+            was made over an insecure connection."
+                .to_string();
+            debug!("post_index_ann: {msg}");
+            return (StatusCode::FORBIDDEN, msg).into_response();
+        }
 
-    // Start timing
-    let timer = state
-        .metrics
-        .latency
-        .with_label_values(&[keyspace.as_ref(), index_name.as_ref()])
-        .start_timer();
+        // Start timing
+        let timer = state
+            .metrics
+            .latency
+            .with_label_values(&[keyspace.as_ref(), index_name.as_ref()])
+            .start_timer();
 
-    let index_key = IndexKey::new(&keyspace, &index_name);
-    let (equality_cols, range_cols) = restriction_columns(&request.filter);
-    let allow_filtering = request.filter.as_ref().is_some_and(|f| f.allow_filtering);
-    let (routed_key, index, primary_key_columns, table_columns) = match state
-        .indexes
-        .read()
-        .unwrap()
-        .best_index(&index_key, &equality_cols, &range_cols)
-    {
-        indexes::BestIndexState::Serving {
-            key: routed_key,
-            index,
-            needs_filtering,
-            primary_key_columns,
-            table_columns,
-        } => {
-            if matches!(needs_filtering, indexes::NeedsFiltering::Yes(_)) && !allow_filtering {
+        let index_key = IndexKey::new(&keyspace, &index_name);
+        let (equality_cols, range_cols) = restriction_columns(&request.filter);
+        let allow_filtering = request.filter.as_ref().is_some_and(|f| f.allow_filtering);
+        let (routed_key, index, primary_key_columns, table_columns) = match state
+            .indexes
+            .read()
+            .unwrap()
+            .best_index(&index_key, &equality_cols, &range_cols)
+        {
+            indexes::BestIndexState::Serving {
+                key: routed_key,
+                index,
+                needs_filtering,
+                primary_key_columns,
+                table_columns,
+            } => {
+                if matches!(needs_filtering, indexes::NeedsFiltering::Yes(_)) && !allow_filtering {
+                    timer.observe_duration();
+
+                    let msg = format!(
+                        "Index {keyspace}.{index_name} requires ALLOW FILTERING for this query"
+                    );
+                    debug!("post_index_ann: {msg}");
+                    return (StatusCode::BAD_REQUEST, msg).into_response();
+                }
+                (routed_key, index, primary_key_columns, table_columns)
+            }
+            indexes::BestIndexState::NotServing(progress) => {
                 timer.observe_duration();
 
-                let msg = format!(
-                    "Index {keyspace}.{index_name} requires ALLOW FILTERING for this query"
-                );
+                match progress {
+                    Progress::InProgress(percentage) => {
+                        let msg = format!(
+                            "Index {keyspace}.{index_name} is not available yet \
+                            as it is still being constructed, progress: {:.3}%",
+                            percentage.get()
+                        );
+                        debug!("post_index_ann: {msg}");
+                        return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
+                    }
+                    Progress::Done => {
+                        let msg = format!(
+                            "Index {keyspace}.{index_name} is not serving, \
+                            but full scan did finish."
+                        );
+                        debug!("post_index_ann: {msg}");
+                        return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
+                    }
+                }
+            }
+            indexes::BestIndexState::NotFound => {
+                timer.observe_duration();
+
+                let msg = format!("missing index: {keyspace}.{index_name}");
                 debug!("post_index_ann: {msg}");
-                return (StatusCode::BAD_REQUEST, msg).into_response();
+                return (StatusCode::NOT_FOUND, msg).into_response();
             }
-            (routed_key, index, primary_key_columns, table_columns)
-        }
-        indexes::BestIndexState::NotServing(progress) => {
-            timer.observe_duration();
+        };
 
-            match progress {
-                Progress::InProgress(percentage) => {
-                    let msg = format!(
-                        "Index {keyspace}.{index_name} is not available yet as it is still being constructed, progress: {:.3}%",
-                        percentage.get()
-                    );
-                    debug!("post_index_ann: {msg}");
-                    return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
-                }
-                Progress::Done => {
-                    let msg = format!(
-                        "Index {keyspace}.{index_name} is not serving, but full scan did finish."
-                    );
-                    debug!("post_index_ann: {msg}");
-                    return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
-                }
-            }
-        }
-        indexes::BestIndexState::NotFound => {
-            timer.observe_duration();
+        #[cfg(feature = "slow-test-hooks")]
+        state
+            .internals
+            .increment_counter(format!(
+                "ann-served-request--{}--{}",
+                routed_key.keyspace(),
+                routed_key.index(),
+            ))
+            .await;
 
-            let msg = format!("missing index: {keyspace}.{index_name}");
-            debug!("post_index_ann: {msg}");
-            return (StatusCode::NOT_FOUND, msg).into_response();
-        }
-    };
-
-    #[cfg(feature = "slow-test-hooks")]
-    state
-        .internals
-        .increment_counter(format!(
-            "ann-served-request--{}--{}",
-            routed_key.keyspace(),
-            routed_key.index(),
-        ))
-        .await;
-
-    let search_result = if let Some(filter) = request.filter {
-        let filter =
-            match try_from_post_index_ann_filter(filter, &primary_key_columns, &table_columns) {
+        let search_result = if let Some(filter) = request.filter {
+            let filter = match try_from_post_index_ann_filter(
+                filter,
+                &primary_key_columns,
+                &table_columns,
+            ) {
                 Ok(filter) => filter,
                 Err(err) => {
                     debug!("post_index_ann: {err}");
                     return (StatusCode::BAD_REQUEST, err.to_string()).into_response();
                 }
             };
-        index
-            .filtered_ann(
-                routed_key,
-                request.vector.into(),
-                filter,
-                request.limit.into(),
-            )
-            .await
-    } else {
-        index
-            .ann(routed_key, request.vector.into(), request.limit.into())
-            .await
-    };
+            index
+                .filtered_ann(
+                    routed_key,
+                    request.vector.into(),
+                    filter,
+                    request.limit.into(),
+                )
+                .await
+        } else {
+            index
+                .ann(routed_key, request.vector.into(), request.limit.into())
+                .await
+        };
 
-    // Record duration in Prometheus
-    timer.observe_duration();
+        // Record duration in Prometheus
+        timer.observe_duration();
 
-    match search_result {
-        Err(err) => match err.downcast_ref::<validator::Error>() {
-            Some(err) => (StatusCode::BAD_REQUEST, err.to_string()).into_response(),
-            None => {
-                let msg = format!("index.ann request error: {err}");
-                debug!("post_index_ann: {msg}");
-                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
-            }
-        },
-        Ok((primary_keys, distances)) => {
-            if primary_keys.len() != distances.len() {
-                let msg = format!(
-                    "wrong size of an ann response: number of primary_keys = {}, number of distances = {}",
-                    primary_keys.len(),
-                    distances.len()
-                );
-                debug!("post_index_ann: {msg}");
-                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
-            } else {
-                let similarity_scores: Vec<httpapi::SimilarityScore> = distances
-                    .iter()
-                    .copied()
-                    .map(SimilarityScore::from)
-                    .map(httpapi::SimilarityScore::from)
-                    .collect();
+        match search_result {
+            Err(err) => match err.downcast_ref::<validator::Error>() {
+                Some(err) => (StatusCode::BAD_REQUEST, err.to_string()).into_response(),
+                None => {
+                    let msg = format!("index.ann request error: {err}");
+                    debug!("post_index_ann: {msg}");
+                    (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+                }
+            },
+            Ok((primary_keys, distances)) => {
+                if primary_keys.len() != distances.len() {
+                    let msg = format!(
+                        "wrong size of an ann response: \
+                    number of primary_keys = {}, number of distances = {}",
+                        primary_keys.len(),
+                        distances.len()
+                    );
+                    debug!("post_index_ann: {msg}");
+                    (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+                } else {
+                    let similarity_scores: Vec<httpapi::SimilarityScore> = distances
+                        .iter()
+                        .copied()
+                        .map(SimilarityScore::from)
+                        .map(httpapi::SimilarityScore::from)
+                        .collect();
 
-                let primary_keys: anyhow::Result<_> = primary_key_columns
-                    .iter()
-                    .cloned()
-                    .enumerate()
-                    .map(|(idx_column, column)| {
-                        let primary_keys: anyhow::Result<_> = primary_keys
-                            .iter()
-                            .map(|primary_key| {
-                                if primary_key.len() != primary_key_columns.len() {
-                                    bail!(
-                                        "wrong size of a primary key: {}, {}",
-                                        primary_key_columns.len(),
-                                        primary_key.len()
-                                    );
-                                }
-                                Ok(primary_key)
-                            })
-                            .map_ok(|primary_key| {
-                                primary_key
-                                    .get(idx_column)
-                                    .expect("primary key index out of bounds after length check")
-                            })
-                            .map_ok(try_to_json)
-                            .map(|primary_key| primary_key.flatten())
-                            .collect();
-                        primary_keys.map(|primary_keys| (column.into(), primary_keys))
-                    })
-                    .collect();
+                    let primary_keys: anyhow::Result<_> = primary_key_columns
+                        .iter()
+                        .cloned()
+                        .enumerate()
+                        .map(|(idx_column, column)| {
+                            let primary_keys: anyhow::Result<_> = primary_keys
+                                .iter()
+                                .map(|primary_key| {
+                                    if primary_key.len() != primary_key_columns.len() {
+                                        bail!(
+                                            "wrong size of a primary key: {}, {}",
+                                            primary_key_columns.len(),
+                                            primary_key.len()
+                                        );
+                                    }
+                                    Ok(primary_key)
+                                })
+                                .map_ok(|primary_key| {
+                                    primary_key.get(idx_column).expect(
+                                        "primary key index out of bounds after length check",
+                                    )
+                                })
+                                .map_ok(try_to_json)
+                                .map(|primary_key| primary_key.flatten())
+                                .collect();
+                            primary_keys.map(|primary_keys| (column.into(), primary_keys))
+                        })
+                        .collect();
 
-                match primary_keys {
-                    Err(err) => {
-                        debug!("post_index_ann: {err}");
-                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                    match primary_keys {
+                        Err(err) => {
+                            debug!("post_index_ann: {err}");
+                            (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                        }
+                        Ok(primary_keys) => (
+                            StatusCode::OK,
+                            response::Json(httpapi::PostIndexAnnResponse {
+                                primary_keys,
+                                distances: distances.into_iter().map(|d| d.into()).collect(),
+                                similarity_scores,
+                            }),
+                        )
+                            .into_response(),
                     }
-
-                    Ok(primary_keys) => (
-                        StatusCode::OK,
-                        response::Json(httpapi::PostIndexAnnResponse {
-                            primary_keys,
-                            distances: distances.into_iter().map(|d| d.into()).collect(),
-                            similarity_scores,
-                        }),
-                    )
-                        .into_response(),
                 }
             }
         }
-    }
+    })
+    .await
 }
 
 fn try_from_post_index_ann_filter(

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -5,6 +5,7 @@
 
 use crate::Filter;
 use crate::IndexKey;
+use crate::Indexes;
 use crate::Progress;
 use crate::Quantization;
 use crate::Restriction;
@@ -61,6 +62,7 @@ use std::num::NonZero;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::LazyLock;
+use std::sync::RwLock;
 use time::Date;
 use time::OffsetDateTime;
 use time::Time;
@@ -119,6 +121,7 @@ struct RoutesInnerState {
 }
 
 pub(crate) fn new(
+    indexes: Arc<RwLock<Indexes>>,
     engine: Sender<Engine>,
     metrics: Arc<Metrics>,
     node_state: Sender<NodeState>,

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -5,18 +5,17 @@
 
 use crate::Filter;
 use crate::IndexKey;
-use crate::Indexes;
 use crate::Progress;
 use crate::Quantization;
 use crate::Restriction;
 use crate::SimilarityScore;
-use crate::db_index::DbIndexExt;
 use crate::distance;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::index::IndexExt;
 use crate::index::validator;
 use crate::indexes;
+use crate::indexes::Indexes;
 use crate::info::Info;
 use crate::internals::Internals;
 use crate::internals::InternalsExt;
@@ -113,6 +112,7 @@ struct ApiDoc;
 #[derive(Clone)]
 struct RoutesInnerState {
     engine: Sender<Engine>,
+    indexes: Arc<RwLock<Indexes>>,
     metrics: Arc<Metrics>,
     node_state: Sender<NodeState>,
     internals: Sender<Internals>,
@@ -120,7 +120,7 @@ struct RoutesInnerState {
     use_tls: bool,
 }
 
-pub(crate) fn new(
+pub(crate) async fn new(
     indexes: Arc<RwLock<Indexes>>,
     engine: Sender<Engine>,
     metrics: Arc<Metrics>,
@@ -131,6 +131,7 @@ pub(crate) fn new(
 ) -> Router {
     let state = RoutesInnerState {
         engine,
+        indexes,
         metrics: metrics.clone(),
         node_state,
         internals,
@@ -526,16 +527,18 @@ async fn post_index_ann(
     let index_key = IndexKey::new(&keyspace, &index_name);
     let (equality_cols, range_cols) = restriction_columns(&request.filter);
     let allow_filtering = request.filter.as_ref().is_some_and(|f| f.allow_filtering);
-    let (routed_key, index, db_index) = match state
-        .engine
-        .get_best_index(index_key.clone(), equality_cols, range_cols)
-        .await
+    let (routed_key, index, primary_key_columns, table_columns) = match state
+        .indexes
+        .read()
+        .unwrap()
+        .best_index(&index_key, &equality_cols, &range_cols)
     {
         indexes::BestIndexState::Serving {
             key: routed_key,
             index,
-            db_index,
             needs_filtering,
+            primary_key_columns,
+            table_columns,
         } => {
             if matches!(needs_filtering, indexes::NeedsFiltering::Yes(_)) && !allow_filtering {
                 timer.observe_duration();
@@ -546,13 +549,12 @@ async fn post_index_ann(
                 debug!("post_index_ann: {msg}");
                 return (StatusCode::BAD_REQUEST, msg).into_response();
             }
-            (routed_key, index, db_index)
+            (routed_key, index, primary_key_columns, table_columns)
         }
-        indexes::BestIndexState::NotServing(db_index) => {
+        indexes::BestIndexState::NotServing(progress) => {
             timer.observe_duration();
 
-            let scan_progress = db_index.full_scan_progress().await;
-            match scan_progress {
+            match progress {
                 Progress::InProgress(percentage) => {
                     let msg = format!(
                         "Index {keyspace}.{index_name} is not available yet as it is still being constructed, progress: {:.3}%",
@@ -589,19 +591,15 @@ async fn post_index_ann(
         ))
         .await;
 
-    let primary_key_columns = db_index.get_primary_key_columns().await;
     let search_result = if let Some(filter) = request.filter {
-        let filter = match try_from_post_index_ann_filter(
-            filter,
-            &primary_key_columns,
-            db_index.get_table_columns().await.as_ref(),
-        ) {
-            Ok(filter) => filter,
-            Err(err) => {
-                debug!("post_index_ann: {err}");
-                return (StatusCode::BAD_REQUEST, err.to_string()).into_response();
-            }
-        };
+        let filter =
+            match try_from_post_index_ann_filter(filter, &primary_key_columns, &table_columns) {
+                Ok(filter) => filter,
+                Err(err) => {
+                    debug!("post_index_ann: {err}");
+                    return (StatusCode::BAD_REQUEST, err.to_string()).into_response();
+                }
+            };
         index
             .filtered_ann(
                 routed_key,

--- a/crates/vector-store/src/httpserver.rs
+++ b/crates/vector-store/src/httpserver.rs
@@ -6,6 +6,7 @@
 use crate::config_manager::HttpServerConfig;
 use crate::engine::Engine;
 use crate::httproutes;
+use crate::indexes::Indexes;
 use crate::internals::Internals;
 use crate::metrics::Metrics;
 use crate::node_state::NodeState;
@@ -15,6 +16,7 @@ use axum_server::accept::NoDelayAcceptor;
 use axum_server::tls_rustls::RustlsConfig;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
@@ -60,6 +62,7 @@ impl HttpServerExt for mpsc::Sender<HttpServer> {
 
 struct ServerDeps {
     state: Sender<NodeState>,
+    indexes: Arc<RwLock<Indexes>>,
     engine: Sender<Engine>,
     metrics: Arc<Metrics>,
     internals: Sender<Internals>,
@@ -207,6 +210,7 @@ async fn handle_config_change(
 
 pub(crate) async fn new(
     state: Sender<NodeState>,
+    indexes: Arc<RwLock<Indexes>>,
     engine: Sender<Engine>,
     metrics: Arc<Metrics>,
     internals: Sender<Internals>,
@@ -221,6 +225,7 @@ pub(crate) async fn new(
 
     let deps = ServerDeps {
         state,
+        indexes,
         engine,
         metrics,
         internals,
@@ -301,6 +306,7 @@ async fn spawn_server(
     let handle = Handle::new();
 
     let router = httproutes::new(
+        Arc::clone(&deps.indexes),
         deps.engine.clone(),
         deps.metrics.clone(),
         deps.state.clone(),

--- a/crates/vector-store/src/httpserver.rs
+++ b/crates/vector-store/src/httpserver.rs
@@ -313,7 +313,8 @@ async fn spawn_server(
         deps.internals.clone(),
         deps.index_engine_version.clone(),
         config.tls.is_some(),
-    );
+    )
+    .await;
     tokio::spawn({
         let handle = handle.clone();
         let router = router.clone();

--- a/crates/vector-store/src/index/actor.rs
+++ b/crates/vector-store/src/index/actor.rs
@@ -2,7 +2,6 @@
  * Copyright 2025-present ScyllaDB
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
-
 use crate::AsyncInProgress;
 use crate::Distance;
 use crate::Filter;

--- a/crates/vector-store/src/index/opensearch.rs
+++ b/crates/vector-store/src/index/opensearch.rs
@@ -18,6 +18,7 @@ use crate::index::actor::Index;
 use crate::index::factory::IndexConfiguration;
 use crate::index::validator;
 use crate::memory::Memory;
+use crate::perf;
 use crate::table::IndexIdGenerator;
 use crate::table::PrimaryId;
 use crate::table::Table;
@@ -219,9 +220,7 @@ pub fn new(
     client: Arc<OpenSearch>,
 ) -> anyhow::Result<mpsc::Sender<Index>> {
     info!("Creating new index with key: {key}");
-    // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
-    const CHANNEL_SIZE: usize = 10;
-    let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     tokio::spawn({
         let cloned_key = key.clone();

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -698,9 +698,7 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
     rayon_semaphore: Arc<Semaphore>,
     memory: mpsc::Sender<Memory>,
 ) -> anyhow::Result<mpsc::Sender<Index>> {
-    // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
-    const CHANNEL_SIZE: usize = 10;
-    let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     tokio::spawn(perf::hotpath_async(
         {

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -20,6 +20,7 @@ use crate::index::validator;
 use crate::memory::Allocate;
 use crate::memory::Memory;
 use crate::memory::MemoryExt;
+use crate::perf;
 use crate::table::IndexId;
 use crate::table::PartitionId;
 use crate::table::PrimaryId;
@@ -701,7 +702,7 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
     const CHANNEL_SIZE: usize = 10;
     let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
 
-    tokio::spawn(
+    tokio::spawn(perf::hotpath_async(
         {
             let index_key = index_key.clone();
             async move {
@@ -749,7 +750,7 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
             }
         }
         .instrument(error_span!("usearch", "{index_key}")),
-    );
+    ));
 
     Ok(tx)
 }
@@ -946,7 +947,6 @@ async fn dispatch_task<I, T>(
     if should_run_on_tokio(&msg) {
         let permit = Arc::clone(tokio_semaphore).acquire_owned().await.unwrap();
         tokio::spawn(async move {
-            crate::move_to_the_end_of_async_runtime_queue().await;
             process(partition, table, dimensions, size, msg);
             drop(permit);
             drop(operation_permit);

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -26,6 +26,9 @@ use crate::table::PartitionId;
 use crate::table::PrimaryId;
 use crate::table::Table;
 use crate::table::TableSearch;
+use crate::worker;
+use crate::worker::Worker;
+use crate::worker::WorkerExt;
 use anyhow::anyhow;
 use itertools::Itertools;
 use std::collections::BTreeMap;
@@ -36,9 +39,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
-use tokio::runtime::Handle;
 use tokio::sync::Notify;
-use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
@@ -55,8 +56,7 @@ use usearch::ScalarKind;
 use usearch::b1x8;
 
 pub struct UsearchIndexFactory {
-    tokio_semaphore: Arc<Semaphore>,
-    rayon_semaphore: Arc<Semaphore>,
+    worker: async_channel::Sender<Worker>,
     mode: Mode,
 }
 
@@ -78,15 +78,13 @@ impl IndexFactory for UsearchIndexFactory {
                     quantization: index.quantization.into(),
                     ..Default::default()
                 };
-                let threads =
-                    Handle::current().metrics().num_workers() + rayon::current_num_threads();
+                let threads = perf::num_workers().into();
                 new(
                     move || Ok(Arc::new(ThreadedUsearchIndex::new(options, threads)?)),
                     index.key,
                     index.dimensions,
                     table,
-                    Arc::clone(&self.tokio_semaphore),
-                    Arc::clone(&self.rayon_semaphore),
+                    self.worker.clone(),
                     memory,
                 )
             }
@@ -100,8 +98,7 @@ impl IndexFactory for UsearchIndexFactory {
                 index.key,
                 index.dimensions,
                 table,
-                Arc::clone(&self.tokio_semaphore),
-                Arc::clone(&self.rayon_semaphore),
+                self.worker.clone(),
                 memory,
             ),
         }
@@ -116,14 +113,11 @@ impl IndexFactory for UsearchIndexFactory {
 }
 
 pub fn new_usearch(
-    tokio_semaphore: Arc<Semaphore>,
-    rayon_semaphore: Arc<Semaphore>,
     mut config_rx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<UsearchIndexFactory> {
     let config = config_rx.borrow_and_update().clone();
     Ok(UsearchIndexFactory {
-        tokio_semaphore,
-        rayon_semaphore,
+        worker: worker::new(),
         mode: if config.usearch_simulator.is_none() {
             Mode::Usearch
         } else {
@@ -694,8 +688,7 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
     index_key: IndexKey,
     dimensions: Dimensions,
     table: Arc<RwLock<impl TableSearch + Send + Sync + 'static>>,
-    tokio_semaphore: Arc<Semaphore>,
-    rayon_semaphore: Arc<Semaphore>,
+    worker: async_channel::Sender<Worker>,
     memory: mpsc::Sender<Memory>,
 ) -> anyhow::Result<mpsc::Sender<Index>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
@@ -729,15 +722,8 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
                         continue;
                     };
 
-                    dispatch_task(
-                        state,
-                        partition,
-                        &table,
-                        &tokio_semaphore,
-                        &rayon_semaphore,
-                        msg,
-                    )
-                    .await;
+                    dispatch_task(state, partition, &table, &worker, msg).await;
+                    hotpath::val!("usearch-rx.len-end").set(&rx.len());
                 }
 
                 partitions
@@ -912,8 +898,7 @@ async fn dispatch_task<I, T>(
     state: &mut IndexState,
     partition: Arc<PartitionState<I>>,
     table: &Arc<RwLock<T>>,
-    tokio_semaphore: &Arc<Semaphore>,
-    rayon_semaphore: &Arc<Semaphore>,
+    worker: &async_channel::Sender<Worker>,
     msg: Index,
 ) where
     I: UsearchIndex + Send + Sync + 'static,
@@ -926,13 +911,13 @@ async fn dispatch_task<I, T>(
             drop(operation_permit);
             let operation_permit = state.operation.permit_for_reserve().await;
             if let Some(capacity) = needs_more_capacity(partition.idx.as_ref(), is_global) {
-                let permit = Arc::clone(rayon_semaphore).acquire_owned().await.unwrap();
                 let idx = Arc::clone(&partition.idx);
-                rayon::spawn(move || {
-                    reserve(idx.as_ref(), capacity);
-                    drop(permit);
-                    drop(operation_permit);
-                });
+                worker
+                    .spawn_blocking(move || {
+                        reserve(idx.as_ref(), capacity);
+                        drop(operation_permit);
+                    })
+                    .await;
             }
         }
     }
@@ -942,25 +927,25 @@ async fn dispatch_task<I, T>(
     let table = Arc::clone(table);
     let dimensions = state.dimensions;
     let size = Arc::clone(&state.size);
-    if should_run_on_tokio(&msg) {
-        let permit = Arc::clone(tokio_semaphore).acquire_owned().await.unwrap();
-        tokio::spawn(async move {
-            process(partition, table, dimensions, size, msg);
-            drop(permit);
-            drop(operation_permit);
-        });
+    if is_non_blocking(&msg) {
+        worker
+            .spawn_non_blocking(move || {
+                process(partition, table, dimensions, size, msg);
+                drop(operation_permit);
+            })
+            .await;
         return;
     }
-    let permit = Arc::clone(rayon_semaphore).acquire_owned().await.unwrap();
-    rayon::spawn(move || {
-        process(partition, table, dimensions, size, msg);
-        drop(permit);
-        drop(operation_permit);
-    });
+    worker
+        .spawn_blocking(move || {
+            process(partition, table, dimensions, size, msg);
+            drop(operation_permit);
+        })
+        .await;
 }
 
 #[hotpath::measure]
-fn should_run_on_tokio(msg: &Index) -> bool {
+fn is_non_blocking(msg: &Index) -> bool {
     matches!(msg, Index::Ann { .. })
 }
 
@@ -1303,7 +1288,7 @@ mod tests {
             metric: MetricKind::L2sq,
             ..Default::default()
         };
-        let threads = Handle::current().metrics().num_workers() + rayon::current_num_threads();
+        let threads = perf::num_workers().into();
         let table = Arc::new(RwLock::new(MockTableSearch::new()));
         let index_key = IndexKey::new(&"vector".into(), &"store".into());
         let actor = new(
@@ -1311,8 +1296,7 @@ mod tests {
             index_key.clone(),
             NonZeroUsize::new(3).unwrap().into(),
             Arc::clone(&table),
-            Arc::new(Semaphore::new(4)),
-            Arc::new(Semaphore::new(4)),
+            worker::new(),
             memory::new(config_rx),
         )
         .unwrap();
@@ -1451,7 +1435,7 @@ mod tests {
             metric: MetricKind::L2sq,
             ..Default::default()
         };
-        let threads = Handle::current().metrics().num_workers() + rayon::current_num_threads();
+        let threads = perf::num_workers().into();
         let table = Arc::new(RwLock::new(MockTableSearch::new()));
         let index_key = IndexKey::new(&"vector".into(), &"store".into());
         let actor = new(
@@ -1459,8 +1443,7 @@ mod tests {
             index_key.clone(),
             NonZeroUsize::new(3).unwrap().into(),
             Arc::clone(&table),
-            Arc::new(Semaphore::new(4)),
-            Arc::new(Semaphore::new(4)),
+            worker::new(),
             memory_tx,
         )
         .unwrap();
@@ -1511,7 +1494,7 @@ mod tests {
             metric: MetricKind::L2sq,
             ..Default::default()
         };
-        let threads = Handle::current().metrics().num_workers() + rayon::current_num_threads();
+        let threads = perf::num_workers().into();
         let table = Arc::new(RwLock::new(MockTableSearch::new()));
         let index_key = IndexKey::new(&"vector".into(), &"store".into());
         let index = new(
@@ -1519,8 +1502,7 @@ mod tests {
             index_key.clone(),
             dimensions.into(),
             Arc::clone(&table),
-            Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
-            Arc::new(Semaphore::new(Semaphore::MAX_PERMITS)),
+            worker::new(),
             memory::new(config_rx),
         )
         .unwrap();
@@ -1536,6 +1518,12 @@ mod tests {
                 assert_eq!(key, &index_key);
                 assert!(restrictions.is_none());
                 Some((partition_id, None))
+            }
+        });
+        table.write().unwrap().expect_primary_key().returning({
+            move |check_partition_id, _| {
+                assert_eq!(partition_id, check_partition_id);
+                None
             }
         });
         let add_handles = add_concurrently(

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -710,9 +710,11 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
                 let mut partitions = BTreeMap::new();
 
                 let mut allocate_prev = Allocate::Can;
+                let allocate_rx = memory.subscribe_allocate().await;
 
                 while let Some(msg) = rx.recv().await {
-                    if !check_memory_allocation(&msg, &memory, &mut allocate_prev, &index_key).await
+                    if !check_memory_allocation(&msg, &allocate_rx, &mut allocate_prev, &index_key)
+                        .await
                     {
                         continue;
                     }
@@ -1173,7 +1175,7 @@ fn filtered_ann<I>(
 #[hotpath::measure]
 async fn check_memory_allocation(
     msg: &Index,
-    memory: &mpsc::Sender<Memory>,
+    rx_allocate: &watch::Receiver<Allocate>,
     allocate_prev: &mut Allocate,
     key: &IndexKey,
 ) -> bool {
@@ -1181,7 +1183,7 @@ async fn check_memory_allocation(
         return true;
     }
 
-    let allocate = memory.can_allocate().await;
+    let allocate = *rx_allocate.borrow();
     if allocate == Allocate::Cannot {
         if *allocate_prev == Allocate::Can {
             error!("Unable to add vector for index {key}: not enough memory to reserve more space");
@@ -1439,6 +1441,12 @@ mod tests {
     #[tokio::test]
     async fn allocate_parameter_works() {
         let (memory_tx, mut memory_rx) = mpsc::channel(1);
+        let (allocate_tx, allocate_rx) = watch::channel(Allocate::Can);
+        let memory_respond = tokio::spawn(async move {
+            let Memory::SubscribeAllocate { tx } = memory_rx.recv().await.unwrap();
+            _ = tx.send(allocate_rx);
+            memory_rx
+        });
 
         let options = IndexOptions {
             dimensions: 3,
@@ -1458,18 +1466,14 @@ mod tests {
             memory_tx,
         )
         .unwrap();
+        memory_respond.await.unwrap();
 
-        let memory_respond = tokio::spawn(async move {
-            let Memory::CanAllocate { tx } = memory_rx.recv().await.unwrap();
-            _ = tx.send(Allocate::Cannot);
-            memory_rx
-        });
+        allocate_tx.send(Allocate::Cannot).unwrap();
         let index_id = IndexIdGenerator::new().next(true).unwrap();
         let partition_id = PartitionId::global(index_id);
         actor
             .add_vector(partition_id, 1.into(), vec![1., 1., 1.].into(), None)
             .await;
-        let mut memory_rx = memory_respond.await.unwrap();
 
         table
             .write()
@@ -1480,14 +1484,10 @@ mod tests {
 
         assert_eq!(actor.count(index_key.clone()).await.unwrap(), 0);
 
-        let memory_respond = tokio::spawn(async move {
-            let Memory::CanAllocate { tx } = memory_rx.recv().await.unwrap();
-            _ = tx.send(Allocate::Can);
-        });
+        allocate_tx.send(Allocate::Can).unwrap();
         actor
             .add_vector(partition_id, 1.into(), vec![1., 1., 1.].into(), None)
             .await;
-        memory_respond.await.unwrap();
 
         // Wait for the add operation to complete, as it runs in a separate task.
         time::timeout(Duration::from_secs(10), async {

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -136,7 +136,6 @@ enum Mode {
 
 trait UsearchIndex {
     fn reserve(&self, size: usize) -> anyhow::Result<()>;
-    fn size(&self) -> usize;
     fn capacity(&self) -> usize;
     fn add(&self, primary_id: PrimaryId, vector: &Vector) -> anyhow::Result<()>;
     fn remove(&self, primary_id: PrimaryId) -> anyhow::Result<bool>;
@@ -182,10 +181,6 @@ impl UsearchIndex for ThreadedUsearchIndex {
 
     fn capacity(&self) -> usize {
         self.inner.capacity()
-    }
-
-    fn size(&self) -> usize {
-        self.inner.size()
     }
 
     fn add(&self, primary_id: PrimaryId, vector: &Vector) -> anyhow::Result<()> {
@@ -371,11 +366,6 @@ impl UsearchIndex for RwLock<Simulator> {
     }
 
     #[hotpath::measure]
-    fn size(&self) -> usize {
-        self.read().unwrap().keys.read().unwrap().len()
-    }
-
-    #[hotpath::measure]
     fn add(&self, row_id: PrimaryId, _: &Vector) -> anyhow::Result<()> {
         let start = Instant::now();
 
@@ -446,11 +436,6 @@ impl UsearchIndex for RwLock<Simulator> {
 // The value was taken for initial benchmarks (size similar to benchmark size)
 const RESERVE_INCREMENT_GLOBAL: usize = 1000000;
 const RESERVE_INCREMENT_LOCAL: usize = 1000;
-
-// When free space for index vectors drops below this, will reserve more space
-// The ratio was taken for initial benchmarks
-const RESERVE_THRESHOLD_GLOBAL: usize = RESERVE_INCREMENT_GLOBAL / 3;
-const RESERVE_THRESHOLD_LOCAL: usize = RESERVE_INCREMENT_LOCAL / 3;
 
 struct MetricConfig {
     quantization: Quantization,
@@ -627,30 +612,15 @@ mod operation {
         pub(super) async fn permit_for_reserve(&mut self) -> Permit {
             self.permit(Mode::Reserve).await
         }
-
-        /// Capacity and size permit cannot be concurrent only with reserve mode.
-        #[hotpath::measure]
-        pub(super) async fn permit_for_capacity_and_size(&mut self) -> Permit {
-            while self.mode == Mode::Reserve {
-                if self.counter.load(Ordering::Relaxed) == 0 {
-                    // checking for capacity is during add, so insert mode is fine
-                    self.mode = Mode::Insert;
-                    break;
-                }
-                self.notify.notified().await;
-            }
-
-            self.counter.fetch_add(1, Ordering::Relaxed);
-            Permit {
-                notify: Arc::clone(&self.notify),
-                counter: Arc::clone(&self.counter),
-            }
-        }
     }
 }
 
 struct PartitionState<I: UsearchIndex + Send + Sync + 'static> {
     partition_id: PartitionId,
+    size: Arc<AtomicUsize>,
+    capacity: Arc<AtomicUsize>,
+    capacity_increment: usize,
+    free_threshold: usize,
     idx: Arc<I>,
 }
 
@@ -659,7 +629,31 @@ where
     I: UsearchIndex + Send + Sync + 'static,
 {
     fn new(partition_id: PartitionId, idx: Arc<I>) -> Self {
-        Self { partition_id, idx }
+        let capacity_increment = if partition_id.index_id().is_global() {
+            RESERVE_INCREMENT_GLOBAL
+        } else {
+            RESERVE_INCREMENT_LOCAL
+        };
+        Self {
+            partition_id,
+            size: Arc::new(AtomicUsize::new(0)),
+            capacity: Arc::new(AtomicUsize::new(0)),
+            capacity_increment,
+            free_threshold: perf::channel_size().into(),
+            idx,
+        }
+    }
+
+    fn needs_more_capacity(&self) -> Option<usize> {
+        let capacity = self.capacity.load(Ordering::Relaxed);
+        let size = self.size.load(Ordering::Relaxed);
+        let free_space = capacity - size;
+
+        if free_space < self.free_threshold {
+            Some(capacity + self.capacity_increment)
+        } else {
+            None
+        }
     }
 
     fn stop(&self) {
@@ -706,7 +700,6 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
 
                 while let Some(msg) = rx.recv().await {
                     if !check_memory_allocation(&msg, &allocate_rx, &mut allocate_prev, &index_key)
-                        .await
                     {
                         continue;
                     }
@@ -904,21 +897,18 @@ async fn dispatch_task<I, T>(
     I: UsearchIndex + Send + Sync + 'static,
     T: TableSearch + Send + Sync + 'static,
 {
-    if let Index::AddVector { .. } = &msg {
-        let operation_permit = state.operation.permit_for_capacity_and_size().await;
-        let is_global = partition.partition_id.index_id().is_global();
-        if needs_more_capacity(partition.idx.as_ref(), is_global).is_some() {
-            drop(operation_permit);
-            let operation_permit = state.operation.permit_for_reserve().await;
-            if let Some(capacity) = needs_more_capacity(partition.idx.as_ref(), is_global) {
-                let idx = Arc::clone(&partition.idx);
-                worker
-                    .spawn_blocking(move || {
-                        reserve(idx.as_ref(), capacity);
-                        drop(operation_permit);
-                    })
-                    .await;
-            }
+    if let Index::AddVector { .. } = &msg
+        && partition.needs_more_capacity().is_some()
+    {
+        let operation_permit = state.operation.permit_for_reserve().await;
+        if let Some(capacity) = partition.needs_more_capacity() {
+            let partiton = Arc::clone(&partition);
+            worker
+                .spawn_blocking(move || {
+                    reserve(&partiton, capacity);
+                    drop(operation_permit);
+                })
+                .await;
         }
     }
 
@@ -930,7 +920,7 @@ async fn dispatch_task<I, T>(
     if is_non_blocking(&msg) {
         worker
             .spawn_non_blocking(move || {
-                process(partition, table, dimensions, size, msg);
+                process(&partition, table, dimensions, size, msg);
                 drop(operation_permit);
             })
             .await;
@@ -938,7 +928,7 @@ async fn dispatch_task<I, T>(
     }
     worker
         .spawn_blocking(move || {
-            process(partition, table, dimensions, size, msg);
+            process(&partition, table, dimensions, size, msg);
             drop(operation_permit);
         })
         .await;
@@ -951,7 +941,7 @@ fn is_non_blocking(msg: &Index) -> bool {
 
 #[hotpath::measure]
 fn process<I, T>(
-    partition: Arc<PartitionState<I>>,
+    partition: &PartitionState<I>,
     table: Arc<RwLock<T>>,
     dimensions: Dimensions,
     size: Arc<AtomicUsize>,
@@ -966,7 +956,7 @@ fn process<I, T>(
             embedding,
             in_progress: _in_progress,
             ..
-        } => add(partition.idx.as_ref(), primary_id, &embedding, &size),
+        } => add(partition, primary_id, &embedding, &size),
 
         Index::Ann {
             embedding,
@@ -997,55 +987,55 @@ fn process<I, T>(
             primary_id,
             in_progress: _in_progress,
             ..
-        } => remove(partition.idx.as_ref(), primary_id, &size),
+        } => remove(partition, primary_id, &size),
 
         Index::RemovePartition { .. } => unreachable!(),
     }
 }
 
 #[hotpath::measure]
-fn reserve(idx: &impl UsearchIndex, capacity: usize) {
-    let result = idx.reserve(capacity);
+fn reserve<I>(partition: &PartitionState<I>, capacity: usize)
+where
+    I: UsearchIndex + Send + Sync + 'static,
+{
+    let result = partition.idx.reserve(capacity);
     if let Err(err) = &result {
         error!("unable to reserve index capacity for {capacity} in usearch: {err}");
     } else {
-        debug!("reserve: reserved index capacity for {capacity}");
+        let actual_capacity = partition.idx.capacity();
+        debug!("reserve: reserved index capacity for {actual_capacity}");
+        partition.capacity.store(actual_capacity, Ordering::Relaxed);
     }
 }
 
 #[hotpath::measure]
-fn needs_more_capacity(idx: &impl UsearchIndex, is_global: bool) -> Option<usize> {
-    let capacity = idx.capacity();
-    let free_space = capacity - idx.size();
-    let (increment, threshold) = if is_global {
-        (RESERVE_INCREMENT_GLOBAL, RESERVE_THRESHOLD_GLOBAL)
-    } else {
-        (RESERVE_INCREMENT_LOCAL, RESERVE_THRESHOLD_LOCAL)
-    };
-
-    if free_space < threshold {
-        Some(capacity + increment)
-    } else {
-        None
-    }
-}
-
-#[hotpath::measure]
-fn add(idx: &impl UsearchIndex, primary_id: PrimaryId, embedding: &Vector, size: &AtomicUsize) {
-    if let Err(err) = idx.add(primary_id, embedding) {
+fn add<I>(
+    partition: &PartitionState<I>,
+    primary_id: PrimaryId,
+    embedding: &Vector,
+    size: &AtomicUsize,
+) where
+    I: UsearchIndex + Send + Sync + 'static,
+{
+    if let Err(err) = partition.idx.add(primary_id, embedding) {
         warn!("add: unable to add embedding: {err}");
     } else {
+        partition.size.fetch_add(1, Ordering::Relaxed);
         size.fetch_add(1, Ordering::Relaxed);
     }
 }
 
 #[hotpath::measure]
-fn remove(idx: &impl UsearchIndex, row_id: PrimaryId, size: &AtomicUsize) {
-    match idx.remove(row_id) {
+fn remove<I>(partition: &PartitionState<I>, row_id: PrimaryId, size: &AtomicUsize)
+where
+    I: UsearchIndex + Send + Sync + 'static,
+{
+    match partition.idx.remove(row_id) {
         Err(err) => warn!("remove: unable to remove embeddings: {err}"),
         Ok(false) => {}
         Ok(true) => {
             size.fetch_sub(1, Ordering::Relaxed);
+            partition.size.fetch_sub(1, Ordering::Relaxed);
         }
     }
 }
@@ -1068,7 +1058,7 @@ fn validate_dimensions(
 
 #[hotpath::measure]
 fn ann<I>(
-    partition: Arc<PartitionState<I>>,
+    partition: &PartitionState<I>,
     tx_ann: oneshot::Sender<AnnR>,
     table: &Arc<RwLock<impl TableSearch>>,
     embedding: Vector,
@@ -1108,7 +1098,7 @@ fn ann<I>(
 
 #[hotpath::measure]
 fn filtered_ann<I>(
-    partition: Arc<PartitionState<I>>,
+    partition: &PartitionState<I>,
     tx_ann: oneshot::Sender<AnnR>,
     table: &Arc<RwLock<impl TableSearch>>,
     embedding: Vector,
@@ -1156,7 +1146,7 @@ fn filtered_ann<I>(
 }
 
 #[hotpath::measure]
-async fn check_memory_allocation(
+fn check_memory_allocation(
     msg: &Index,
     rx_allocate: &watch::Receiver<Allocate>,
     allocate_prev: &mut Allocate,

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -205,12 +205,13 @@ pub(crate) enum BestIndexState {
     /// The requested index does not exist at all.
     NotFound,
     /// The requested index exists but no serving candidate was found.
-    NotServing(mpsc::Sender<DbIndex>),
+    NotServing(Progress),
     /// A serving candidate was found.
     Serving {
         key: IndexKey,
         index: mpsc::Sender<Index>,
-        db_index: mpsc::Sender<DbIndex>,
+        primary_key_columns: Arc<Vec<ColumnName>>,
+        table_columns: Arc<HashMap<ColumnName, NativeType>>,
         needs_filtering: NeedsFiltering,
     },
 }
@@ -316,11 +317,12 @@ impl Indexes {
                 BestIndexState::Serving {
                     key: routed_key.clone(),
                     index: routed_entry.index.clone(),
-                    db_index: routed_entry.db_index.clone(),
+                    primary_key_columns: Arc::clone(&routed_entry.primary_key_columns),
+                    table_columns: Arc::clone(&routed_entry.table_columns),
                     needs_filtering: needs_filtering.clone(),
                 }
             }
-            None => BestIndexState::NotServing(requested_entry.db_index.clone()),
+            None => BestIndexState::NotServing(requested_entry.progress),
         }
     }
 }

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -9,15 +9,15 @@ use crate::IndexKey;
 use crate::IndexMetadata;
 use crate::IndexVersion;
 use crate::KeyspaceName;
+use crate::Progress;
 use crate::Quantization;
 use crate::TableName;
 use crate::db_index::DbIndex;
+use crate::db_index::DbIndexExt;
 use crate::index::Index;
 use crate::monitor_items::MonitorItems;
 use crate::node_state::IndexStatus;
-use crate::node_state::NodeState;
-use crate::node_state::NodeStateExt;
-use futures::future::join_all;
+use scylla::cluster::metadata::NativeType;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
@@ -77,25 +77,29 @@ impl From<&IndexMetadata> for RoutingGroupKey {
 
 #[derive(Debug)]
 pub(crate) struct IndexEntry {
-    pub(crate) index: mpsc::Sender<Index>,
-    pub(crate) _monitor: mpsc::Sender<MonitorItems>,
-    pub(crate) db_index: mpsc::Sender<DbIndex>,
-    pub(crate) routing_group: RoutingGroupKey,
-    pub(crate) index_type: DbIndexType,
-    pub(crate) filtering_columns: Arc<Vec<ColumnName>>,
-    pub(crate) version: IndexVersion,
-    pub(crate) quantization: Quantization,
+    index: mpsc::Sender<Index>,
+    _monitor: mpsc::Sender<MonitorItems>,
+    db_index: mpsc::Sender<DbIndex>,
+    routing_group: RoutingGroupKey,
+    index_type: DbIndexType,
+    primary_key_columns: Arc<Vec<ColumnName>>,
+    filtering_columns: Arc<Vec<ColumnName>>,
+    table_columns: Arc<HashMap<ColumnName, NativeType>>,
+    version: IndexVersion,
+    quantization: Quantization,
+    status: IndexStatus,
+    progress: Progress,
 }
 
 impl IndexEntry {
-    pub(crate) fn new(
+    pub(crate) async fn new(
         index: mpsc::Sender<Index>,
         monitor: mpsc::Sender<MonitorItems>,
         db_index: mpsc::Sender<DbIndex>,
-        primary_key_columns: Arc<Vec<ColumnName>>,
         metadata: IndexMetadata,
     ) -> Self {
         let routing_group = RoutingGroupKey::from(&metadata);
+        let primary_key_columns = db_index.get_primary_key_columns().await;
         let filtering_columns: Arc<Vec<ColumnName>> = Arc::new(
             metadata
                 .filtering_columns
@@ -104,118 +108,94 @@ impl IndexEntry {
                 .cloned()
                 .collect(),
         );
+        let table_columns = db_index.get_table_columns().await;
+        let progress = db_index.full_scan_progress().await;
         Self {
             index,
             _monitor: monitor,
             db_index,
             routing_group,
             index_type: metadata.index_type,
+            primary_key_columns,
             filtering_columns,
+            table_columns,
             version: metadata.version,
             quantization: metadata.quantization,
+            status: IndexStatus::Initializing,
+            progress,
         }
     }
-}
 
-/// Storage for all active indexes.
-#[derive(Debug)]
-pub(crate) struct Indexes(HashMap<IndexKey, IndexEntry>);
-
-impl Indexes {
-    pub(crate) fn new() -> Self {
-        Self(HashMap::new())
+    pub(crate) fn index(&self) -> mpsc::Sender<Index> {
+        self.index.clone()
     }
 
-    pub(crate) fn get(&self, key: &IndexKey) -> Option<&IndexEntry> {
-        self.0.get(key)
+    pub(crate) fn db_index(&self) -> mpsc::Sender<DbIndex> {
+        self.db_index.clone()
     }
 
-    pub(crate) fn contains_key(&self, key: &IndexKey) -> bool {
-        self.0.contains_key(key)
+    pub(crate) fn quantization(&self) -> Quantization {
+        self.quantization
     }
 
-    pub(crate) fn insert(&mut self, key: IndexKey, entry: IndexEntry) {
-        self.0.insert(key, entry);
+    pub(crate) fn progress(&self) -> Progress {
+        self.progress
     }
 
-    pub(crate) fn remove(&mut self, key: &IndexKey) -> Option<IndexEntry> {
-        self.0.remove(key)
+    pub(crate) fn set_progress(&mut self, progress: Progress) {
+        self.progress = progress;
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&IndexKey, &IndexEntry)> {
-        self.0.iter()
-    }
-}
-
-/// Maps each routing group to the set of index keys that belong to it.
-#[derive(Debug)]
-pub(crate) struct RoutingMap(HashMap<RoutingGroupKey, Vec<IndexKey>>);
-
-impl RoutingMap {
-    pub(crate) fn new() -> Self {
-        Self(HashMap::new())
+    pub(crate) fn status(&self) -> IndexStatus {
+        self.status
     }
 
-    pub(crate) fn get(&self, key: &RoutingGroupKey) -> Option<&Vec<IndexKey>> {
-        self.0.get(key)
+    pub(crate) fn set_status(&mut self, status: IndexStatus) {
+        self.status = status;
     }
 
-    pub(crate) fn add(&mut self, group: RoutingGroupKey, key: IndexKey) {
-        self.0.entry(group).or_default().push(key);
-    }
+    /// Computes a routing score for an index given the query's restriction columns.
+    ///
+    /// Returns `None` when the index cannot serve the query at all. This happens
+    /// when a local index's partition key columns are not all present in the
+    /// equality restrictions, or when any non-partition-key restriction column is
+    /// not in the index's filtering columns.
+    ///
+    /// Returns `Some(NeedsFiltering)` otherwise, indicating how many restriction
+    /// columns still require index-level filtering (via filtering columns).
+    fn score_index(
+        &self,
+        equality_columns: &[ColumnName],
+        range_columns: &[ColumnName],
+    ) -> Option<NeedsFiltering> {
+        if !equality_columns
+            .iter()
+            .chain(range_columns.iter())
+            .all(|col| self.filtering_columns.contains(col))
+        {
+            return None;
+        }
 
-    pub(crate) fn remove(&mut self, group: RoutingGroupKey, key: &IndexKey) {
-        if let Entry::Occupied(mut e) = self.0.entry(group) {
-            e.get_mut().retain(|k| k != key);
-            if e.get().is_empty() {
-                e.remove();
+        match &self.index_type {
+            DbIndexType::Global => {
+                let uncovered = equality_columns.len() + range_columns.len();
+                Some(if uncovered == 0 {
+                    NeedsFiltering::No
+                } else {
+                    NeedsFiltering::Yes(uncovered)
+                })
             }
-        }
-    }
-}
-
-/// Computes a routing score for an index given the query's restriction columns.
-///
-/// Returns `None` when the index cannot serve the query at all. This happens
-/// when a local index's partition key columns are not all present in the
-/// equality restrictions, or when any non-partition-key restriction column is
-/// not in the index's filtering columns.
-///
-/// Returns `Some(NeedsFiltering)` otherwise, indicating how many restriction
-/// columns still require index-level filtering (via filtering columns).
-pub(crate) fn score_index(
-    index_type: &DbIndexType,
-    filtering_columns: &[ColumnName],
-    equality_columns: &[ColumnName],
-    range_columns: &[ColumnName],
-) -> Option<NeedsFiltering> {
-    if !equality_columns
-        .iter()
-        .chain(range_columns.iter())
-        .all(|col| filtering_columns.contains(col))
-    {
-        return None;
-    }
-
-    match index_type {
-        DbIndexType::Global => {
-            let uncovered = equality_columns.len() + range_columns.len();
-            Some(if uncovered == 0 {
-                NeedsFiltering::No
-            } else {
-                NeedsFiltering::Yes(uncovered)
-            })
-        }
-        DbIndexType::Local(pk_columns) => {
-            if !pk_columns.iter().all(|col| equality_columns.contains(col)) {
-                return None;
+            DbIndexType::Local(pk_columns) => {
+                if !pk_columns.iter().all(|col| equality_columns.contains(col)) {
+                    return None;
+                }
+                let uncovered = equality_columns.len() - pk_columns.len() + range_columns.len();
+                Some(if uncovered == 0 {
+                    NeedsFiltering::No
+                } else {
+                    NeedsFiltering::Yes(uncovered)
+                })
             }
-            let uncovered = equality_columns.len() - pk_columns.len() + range_columns.len();
-            Some(if uncovered == 0 {
-                NeedsFiltering::No
-            } else {
-                NeedsFiltering::Yes(uncovered)
-            })
         }
     }
 }
@@ -235,84 +215,112 @@ pub(crate) enum BestIndexState {
     },
 }
 
-/// Determines the index to route a query to, given a requested `IndexKey`.
-///
-/// To ensure queries are routed to the most up-to-date and best-matching index,
-/// this function applies the following routing logic:
-///
-/// 1. Returns `NotFound` if the requested index key does not exist.
-/// 2. Identifies all candidate indexes within the same routing group
-///    (i.e., sharing the same keyspace, table, and target column).
-/// 3. Filters out candidates whose `score_index` returns `None` (invalid).
-/// 4. Narrows down the remaining candidates to those that are actively serving.
-/// 5. Picks the candidate with the highest score, breaking ties by
-///    the newest `IndexVersion`.
-/// 6. Returns `NotServing` if no candidate meets the criteria.
-pub(crate) async fn route_index(
-    key: &IndexKey,
-    equality_columns: &[ColumnName],
-    range_columns: &[ColumnName],
-    indexes: &Indexes,
-    routing_map: &RoutingMap,
-    node_state: &mpsc::Sender<NodeState>,
-) -> BestIndexState {
-    let Some(requested_entry) = indexes.get(key) else {
-        return BestIndexState::NotFound;
-    };
-    let candidates = routing_map
-        .get(&requested_entry.routing_group)
-        .expect("routing_map must contain group for every index in indexes");
-
-    let routed_key = join_all(candidates.iter().filter_map(|k| {
-        let entry = indexes.get(k)?;
-        let score = score_index(
-            &entry.index_type,
-            &entry.filtering_columns,
-            equality_columns,
-            range_columns,
-        )?;
-        Some(async move {
-            let is_serving = node_state
-                .get_index_status(k.keyspace().as_ref(), k.index().as_ref())
-                .await
-                .is_some_and(|status| status == IndexStatus::Serving);
-            is_serving.then_some((k, score, &entry.version))
-        })
-    }))
-    .await
-    .into_iter()
-    .flatten()
-    .max_by(|(_, score_a, version_a), (_, score_b, version_b)| {
-        score_a.cmp(score_b).then_with(|| version_a.cmp(version_b))
-    })
-    .map(|(k, score, _)| (k, score));
-
-    match routed_key {
-        Some((routed_key, needs_filtering)) => {
-            let routed_entry = indexes.get(routed_key).expect("routed key must exist");
-            if routed_key != key {
-                debug!("routing index request from {key} to {routed_key}");
-            }
-            BestIndexState::Serving {
-                key: routed_key.clone(),
-                index: routed_entry.index.clone(),
-                db_index: routed_entry.db_index.clone(),
-                needs_filtering: needs_filtering.clone(),
-            }
-        }
-        None => BestIndexState::NotServing(requested_entry.db_index.clone()),
-    }
+/// Storage for all active indexes and map of routing group to the set of index keys that belong to it.
+#[derive(Debug)]
+pub(crate) struct Indexes {
+    entries: HashMap<IndexKey, IndexEntry>,
+    routing: HashMap<RoutingGroupKey, Vec<IndexKey>>,
 }
 
-/// Direct index lookup without routing.
-///
-/// Returns the index and db_index actors for the exact key requested,
-/// regardless of routing groups or serving status. Used by status and
-/// metrics endpoints that need to query a specific index.
-pub(crate) fn get_index(
-    key: &IndexKey,
-    indexes: &Indexes,
-) -> Option<(mpsc::Sender<Index>, mpsc::Sender<DbIndex>)> {
-    let entry = indexes.get(key)?;
-    Some((entry.index.clone(), entry.db_index.clone()))
+impl Indexes {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            routing: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn get(&self, key: &IndexKey) -> Option<&IndexEntry> {
+        self.entries.get(key)
+    }
+
+    pub(crate) fn get_mut(&mut self, key: &IndexKey) -> Option<&mut IndexEntry> {
+        self.entries.get_mut(key)
+    }
+
+    pub(crate) fn contains_key(&self, key: &IndexKey) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    pub(crate) fn insert(&mut self, key: IndexKey, entry: IndexEntry) {
+        let routing_group = entry.routing_group.clone();
+        self.entries.insert(key.clone(), entry);
+        self.routing.entry(routing_group).or_default().push(key);
+    }
+
+    pub(crate) fn remove(&mut self, key: &IndexKey) -> bool {
+        if let Some(entry) = self.entries.remove(key) {
+            if let Entry::Occupied(mut e) = self.routing.entry(entry.routing_group) {
+                e.get_mut().retain(|k| k != key);
+                if e.get().is_empty() {
+                    e.remove();
+                }
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&IndexKey, &IndexEntry)> {
+        self.entries.iter()
+    }
+
+    /// Determines the index to route a query to, given a requested `IndexKey`.
+    ///
+    /// To ensure queries are routed to the most up-to-date and best-matching index,
+    /// this function applies the following routing logic:
+    ///
+    /// 1. Returns `NotFound` if the requested index key does not exist.
+    /// 2. Identifies all candidate indexes within the same routing group
+    ///    (i.e., sharing the same keyspace, table, and target column).
+    /// 3. Filters out candidates whose `score_index` returns `None` (invalid).
+    /// 4. Narrows down the remaining candidates to those that are actively serving.
+    /// 5. Picks the candidate with the highest score, breaking ties by
+    ///    the newest `IndexVersion`.
+    /// 6. Returns `NotServing` if no candidate meets the criteria.
+    pub(crate) fn best_index(
+        &self,
+        key: &IndexKey,
+        equality_columns: &[ColumnName],
+        range_columns: &[ColumnName],
+    ) -> BestIndexState {
+        let Some(requested_entry) = self.get(key) else {
+            return BestIndexState::NotFound;
+        };
+        let candidates = self
+            .routing
+            .get(&requested_entry.routing_group)
+            .expect("routing_map must contain group for every index in indexes");
+
+        let routed_key = candidates
+            .iter()
+            .filter_map(|key| self.get(key).map(|entry| (key, entry)))
+            .filter(|(_, entry)| entry.status == IndexStatus::Serving)
+            .filter_map(|(key, entry)| {
+                entry
+                    .score_index(equality_columns, range_columns)
+                    .map(|score| (key, score, &entry.version))
+            })
+            .max_by(|(_, score_a, version_a), (_, score_b, version_b)| {
+                score_a.cmp(score_b).then_with(|| version_a.cmp(version_b))
+            })
+            .map(|(k, score, _)| (k, score));
+
+        match routed_key {
+            Some((routed_key, needs_filtering)) => {
+                let routed_entry = self.get(routed_key).expect("routed key must exist");
+                if routed_key != key {
+                    debug!("routing index request from {key} to {routed_key}");
+                }
+                BestIndexState::Serving {
+                    key: routed_key.clone(),
+                    index: routed_entry.index.clone(),
+                    db_index: routed_entry.db_index.clone(),
+                    needs_filtering: needs_filtering.clone(),
+                }
+            }
+            None => BestIndexState::NotServing(requested_entry.db_index.clone()),
+        }
+    }
 }

--- a/crates/vector-store/src/internals.rs
+++ b/crates/vector-store/src/internals.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::perf;
 use scylla::client::session::Session;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -101,9 +102,7 @@ impl InternalsExt for mpsc::Sender<Internals> {
 type Counters = RwLock<BTreeMap<String, AtomicU64>>;
 
 pub(crate) fn new() -> mpsc::Sender<Internals> {
-    // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
-    const CHANNEL_SIZE: usize = 10;
-    let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     tokio::spawn(
         async move {

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -39,6 +39,7 @@ pub use crate::distance::Distance;
 pub use crate::httpserver::HttpServer;
 pub use crate::httpserver::HttpServerExt;
 pub use crate::index_key::IndexKey;
+use crate::indexes::Indexes;
 pub use crate::info::Info;
 use crate::internals::Internals;
 use crate::metrics::Metrics;
@@ -65,6 +66,7 @@ use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
 use tokio::runtime::Builder;
 use tokio::runtime::Handle;
@@ -647,17 +649,21 @@ pub async fn run(
 ) -> anyhow::Result<(Sender<HttpServer>, Sender<HttpServer>)> {
     let metrics: Arc<Metrics> = Arc::new(metrics::Metrics::new());
     let index_engine_version = index_factory.index_engine_version();
+    let indexes = Arc::new(RwLock::new(Indexes::new()));
+
     let engine = engine::new(
         db_actor,
         index_factory,
         node_state.clone(),
         metrics.clone(),
+        Arc::clone(&indexes),
         receivers.config,
     )
     .await?;
 
     let main = httpserver::new(
         node_state.clone(),
+        Arc::clone(&indexes),
         engine.clone(),
         metrics.clone(),
         internals.clone(),
@@ -668,6 +674,7 @@ pub async fn run(
 
     let mtls = httpserver::new(
         node_state,
+        indexes,
         engine,
         metrics,
         internals,
@@ -754,7 +761,7 @@ pub async fn wait_for_shutdown() {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Percentage {
     value: f64,
 }
@@ -779,7 +786,7 @@ impl TryFrom<f64> for Percentage {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Progress {
     Done,
     InProgress(Percentage),

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -24,6 +24,7 @@ mod monitor_indexes;
 mod monitor_items;
 pub mod node_state;
 mod partition_key;
+mod perf;
 mod primary_key;
 mod similarity;
 mod table;
@@ -75,7 +76,6 @@ use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
-use tokio::task;
 use utoipa::openapi::OpenApi;
 use uuid::Uuid;
 pub use vector::Vector;
@@ -700,12 +700,6 @@ pub async fn new_node_state() -> Sender<NodeState> {
 
 pub fn new_internals() -> Sender<Internals> {
     internals::new()
-}
-
-// yield to let other tasks run before cpu-intensive processing, as it is CPU intensive and can
-// block other tasks (increase tail latency)
-async fn move_to_the_end_of_async_runtime_queue() {
-    task::yield_now().await;
 }
 
 pub fn new_index_factory_usearch(

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -31,6 +31,7 @@ mod table;
 mod timestamp;
 pub mod tls;
 mod vector;
+mod worker;
 
 pub use crate::config_manager::ConfigManager;
 pub use crate::config_manager::ConfigReceivers;
@@ -70,9 +71,7 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
 use tokio::runtime::Builder;
-use tokio::runtime::Handle;
 use tokio::signal;
-use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
@@ -617,13 +616,6 @@ pub struct DbEmbedding {
 pub struct AsyncInProgress(mpsc::Sender<()>);
 
 pub fn block_on<Output>(threads: Option<usize>, f: impl AsyncFnOnce() -> Output) -> Output {
-    if let Some(threads @ 1..) = threads {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(threads)
-            .build_global()
-            .unwrap();
-    }
-
     let mut builder = match threads {
         Some(0) | None => Builder::new_multi_thread(),
         Some(1) => Builder::new_current_thread(),
@@ -705,23 +697,7 @@ pub fn new_internals() -> Sender<Internals> {
 pub fn new_index_factory_usearch(
     config_tx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<Box<dyn IndexFactory + Send + Sync>> {
-    // A semaphore that limits the concurrency of search operations, which are performed on Tokio threads.
-    // This is a global concurrency limit for all indexes.
-    let search_concurrency = Handle::current().metrics().num_workers();
-    let tokio_semaphore = Arc::new(Semaphore::new(search_concurrency));
-    // A semaphore that limits the concurrency of add/remove operations, which are performed on Rayon threads.
-    // This is a global concurrency limit for all indexes.
-    // The limit is set to 3 times the number of Rayon threads to ensure high throughput.
-    const RAYON_CONCURRENCY_MULTIPLIER: usize = 3;
-    let add_remove_concurrency =
-        (rayon::current_num_threads() * RAYON_CONCURRENCY_MULTIPLIER).min(Semaphore::MAX_PERMITS);
-    let rayon_semaphore = Arc::new(Semaphore::new(add_remove_concurrency));
-
-    Ok(Box::new(index::usearch::new_usearch(
-        tokio_semaphore,
-        rayon_semaphore,
-        config_tx,
-    )?))
+    Ok(Box::new(index::usearch::new_usearch(config_tx)?))
 }
 
 pub fn new_index_factory_opensearch(

--- a/crates/vector-store/src/memory.rs
+++ b/crates/vector-store/src/memory.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::Config;
+use crate::perf;
 use std::sync::Arc;
 use std::time::Duration;
 use sysinfo::System;
@@ -49,9 +50,7 @@ impl MemoryExt for mpsc::Sender<Memory> {
 }
 
 pub(crate) fn new(mut config_rx: watch::Receiver<Arc<Config>>) -> mpsc::Sender<Memory> {
-    // TODO: The value of channel size was taken from initial benchmarks. Needs more testing
-    const CHANNEL_SIZE: usize = 10;
-    let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     tokio::spawn(async move {
         debug!("starting");

--- a/crates/vector-store/src/memory.rs
+++ b/crates/vector-store/src/memory.rs
@@ -27,20 +27,20 @@ pub enum Allocate {
     Cannot,
 }
 
-pub(crate) type AllocateR = Allocate;
+pub(crate) type AllocateR = watch::Receiver<Allocate>;
 
 pub enum Memory {
-    CanAllocate { tx: oneshot::Sender<AllocateR> },
+    SubscribeAllocate { tx: oneshot::Sender<AllocateR> },
 }
 
 pub(crate) trait MemoryExt {
-    async fn can_allocate(&self) -> AllocateR;
+    async fn subscribe_allocate(&self) -> AllocateR;
 }
 
 impl MemoryExt for mpsc::Sender<Memory> {
-    async fn can_allocate(&self) -> AllocateR {
+    async fn subscribe_allocate(&self) -> AllocateR {
         let (tx, rx) = oneshot::channel();
-        self.send(Memory::CanAllocate { tx })
+        self.send(Memory::SubscribeAllocate { tx })
             .await
             .expect("MemoryExt::can_allocate: internal actor should receive request");
         rx.await
@@ -70,14 +70,16 @@ pub(crate) fn new(mut config_rx: watch::Receiver<Arc<Config>>) -> mpsc::Sender<M
         );
         info!("Memory usage check interval set to {:?}", interval.period());
 
-        let mut allocate = can_allocate(used_memory(&system_info), memory_limit, Allocate::Can);
+        let (allocate_tx, allocate_rx) = watch::channel(
+            can_allocate(used_memory(&system_info), memory_limit, Allocate::Can));
 
         loop {
             select! {
                 _ = config_rx.changed() => {
                     let config_new = config_rx.borrow_and_update().clone();
                     if config.memory_limit != config_new.memory_limit {
-                        memory_limit = calculate_memory_limit(available_memory(&system_info), &config_new);
+                        memory_limit = calculate_memory_limit(
+                            available_memory(&system_info), &config_new);
                         info!("Memory limit updated to {memory_limit} bytes");
                     }
                     if config.memory_usage_check_interval != config_new.memory_usage_check_interval {
@@ -93,7 +95,9 @@ pub(crate) fn new(mut config_rx: watch::Receiver<Arc<Config>>) -> mpsc::Sender<M
 
                 _ = interval.tick() => {
                     system_info.refresh_memory();
-                    allocate = can_allocate(used_memory(&system_info), memory_limit, allocate);
+                    let allocate = *allocate_tx.borrow();
+                    _ = allocate_tx.send(
+                        can_allocate(used_memory(&system_info), memory_limit, allocate));
                 }
 
                 msg = rx.recv() => {
@@ -101,8 +105,11 @@ pub(crate) fn new(mut config_rx: watch::Receiver<Arc<Config>>) -> mpsc::Sender<M
                         break;
                     };
                     match msg {
-                        Memory::CanAllocate { tx } => {
-                            tx.send(allocate).unwrap_or_else(|_| trace!("can_allocate: unable to send response"));
+                        Memory::SubscribeAllocate { tx } => {
+                            tx
+                                .send(allocate_rx.clone())
+                                .unwrap_or_else(|_|
+                                    trace!("can_allocate: unable to send response"));
                         }
                     }
                 }
@@ -227,9 +234,10 @@ mod tests {
             ..Config::default()
         }));
         let memory_actor = new(config_rx);
+        let allocator_rx = memory_actor.subscribe_allocate().await;
 
         // be sure the actor has started
-        assert_eq!(memory_actor.can_allocate().await, Allocate::Can);
+        assert_eq!(*allocator_rx.borrow(), Allocate::Can);
 
         let available_mem = available_memory(&System::new_all());
         let default_limit = calculate_memory_limit(available_mem, &Config::default());
@@ -250,7 +258,8 @@ mod tests {
             .unwrap();
 
         // be sure the configuration reload has taken place
-        assert_eq!(memory_actor.can_allocate().await, Allocate::Can);
+        let allocator_rx = memory_actor.subscribe_allocate().await;
+        assert_eq!(*allocator_rx.borrow(), Allocate::Can);
         assert!(logs_contain(&format!(
             "Memory limit updated to {} bytes",
             { default_limit - 1 }

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -17,6 +17,7 @@ use crate::engine::EngineExt;
 use crate::node_state::Event;
 use crate::node_state::NodeState;
 use crate::node_state::NodeStateExt;
+use crate::perf;
 use anyhow::bail;
 use futures::StreamExt;
 use futures::stream;
@@ -45,7 +46,7 @@ pub(crate) async fn new(
     node_state: Sender<NodeState>,
     mut config_rx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<Sender<MonitorIndexes>> {
-    let (tx, mut rx) = mpsc::channel(10);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
     tokio::spawn(
         async move {
             const INTERVAL: Duration = Duration::from_secs(1);

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -9,6 +9,7 @@ use crate::IndexKey;
 use crate::Metrics;
 use crate::index::Index;
 use crate::index::IndexExt;
+use crate::perf;
 use crate::table::Operation;
 use crate::table::TableAdd;
 use std::sync::Arc;
@@ -35,7 +36,7 @@ pub(crate) async fn new(
     let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
     let key_for_span = key.clone();
 
-    tokio::spawn(
+    tokio::spawn(perf::hotpath_async(
         async move {
             debug!("starting");
 
@@ -54,7 +55,7 @@ pub(crate) async fn new(
             debug!("finished");
         }
         .instrument(error_span!("monitor items", "{key_for_span}")),
-    );
+    ));
     Ok(tx)
 }
 

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -31,9 +31,7 @@ pub(crate) async fn new(
     index: Sender<Index>,
     metrics: Arc<Metrics>,
 ) -> anyhow::Result<Sender<MonitorItems>> {
-    // The value was taken from initial benchmarks
-    const CHANNEL_SIZE: usize = 10;
-    let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
     let key_for_span = key.clone();
 
     tokio::spawn(perf::hotpath_async(

--- a/crates/vector-store/src/node_state.rs
+++ b/crates/vector-store/src/node_state.rs
@@ -5,6 +5,7 @@
 
 use crate::IndexKey;
 use crate::IndexMetadata;
+use crate::perf;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::hash_map::Entry::Vacant;
@@ -96,8 +97,7 @@ fn update_indexes(idxs: &mut HashMap<IndexKey, IndexStatus>, keys: HashSet<Index
 }
 
 pub(crate) async fn new() -> mpsc::Sender<NodeState> {
-    const CHANNEL_SIZE: usize = 10;
-    let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     tokio::spawn(
         async move {

--- a/crates/vector-store/src/perf.rs
+++ b/crates/vector-store/src/perf.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use tokio::task::Unconstrained;
+use tokio::task::coop;
+
+pub(crate) fn hotpath_async<F>(inner: F) -> Unconstrained<F> {
+    coop::unconstrained(inner)
+}

--- a/crates/vector-store/src/perf.rs
+++ b/crates/vector-store/src/perf.rs
@@ -3,9 +3,23 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+use std::num::NonZeroUsize;
+use tokio::runtime::Handle;
 use tokio::task::Unconstrained;
 use tokio::task::coop;
 
 pub(crate) fn hotpath_async<F>(inner: F) -> Unconstrained<F> {
     coop::unconstrained(inner)
+}
+
+pub(crate) fn num_workers() -> NonZeroUsize {
+    NonZeroUsize::new(Handle::current().metrics().num_workers())
+        .unwrap_or_else(|| NonZeroUsize::new(1).unwrap())
+}
+
+pub(crate) fn channel_size() -> NonZeroUsize {
+    const CHANNEL_SIZE_PER_WORKER: NonZeroUsize = NonZeroUsize::new(3).unwrap();
+    num_workers()
+        .checked_mul(CHANNEL_SIZE_PER_WORKER)
+        .unwrap_or_else(|| NonZeroUsize::new(1).unwrap())
 }

--- a/crates/vector-store/src/worker.rs
+++ b/crates/vector-store/src/worker.rs
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::perf;
+use async_channel::Sender;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::thread;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tracing::Instrument;
+use tracing::debug;
+use tracing::error_span;
+
+pub(crate) enum Worker {
+    SpawnNonBlocking { f: Box<dyn FnOnce() + Send> },
+    SpawnBlocking { f: Box<dyn FnOnce() + Send> },
+}
+
+pub(crate) trait WorkerExt {
+    async fn spawn_non_blocking(&self, f: impl FnOnce() + Send + 'static);
+    async fn spawn_blocking(&self, f: impl FnOnce() + Send + 'static);
+}
+
+impl WorkerExt for Sender<Worker> {
+    #[hotpath::measure]
+    async fn spawn_non_blocking(&self, f: impl FnOnce() + Send + 'static) {
+        self.send(Worker::SpawnNonBlocking { f: Box::new(f) })
+            .await
+            .expect("WorkerExt::spawn_non_blocking: internal actor should receive request");
+    }
+
+    #[hotpath::measure]
+    async fn spawn_blocking(&self, f: impl FnOnce() + Send + 'static) {
+        self.send(Worker::SpawnBlocking { f: Box::new(f) })
+            .await
+            .expect("WorkerExt::spawn_blocking: internal actor should receive request");
+    }
+}
+
+pub(crate) fn new() -> Sender<Worker> {
+    let (tx_worker, rx_worker) = async_channel::bounded(perf::channel_size().into());
+    let (tx_thread, mut rx_thread) =
+        mpsc::channel::<(Box<dyn FnOnce() + Send>, oneshot::Sender<()>)>(1);
+
+    // Dedicated thread for long tasks to avoid starving runtime.
+    thread::spawn(move || {
+        while let Some((f, tx_call)) = rx_thread.blocking_recv() {
+            f();
+            _ = tx_call.send(());
+        }
+    });
+
+    let operations_in_flow = Arc::new(AtomicUsize::new(0));
+    let thread_operations_in_flow = Arc::new(AtomicUsize::new(0));
+    let workers = perf::num_workers().into();
+    (0..workers).for_each(|id| {
+        let rx_worker = rx_worker.clone();
+        let tx_thread = tx_thread.clone();
+        let operations_in_flow = Arc::clone(&operations_in_flow);
+        let thread_operations_in_flow = Arc::clone(&thread_operations_in_flow);
+        tokio::spawn(perf::hotpath_async(
+            async move {
+                debug!("starting");
+
+                while let Ok(msg) = rx_worker.recv().await {
+                    let in_flow = operations_in_flow.fetch_add(1, Ordering::Relaxed) + 1;
+                    hotpath::val!("worker::in_flow").set(&(id, in_flow));
+                    match msg {
+                        Worker::SpawnNonBlocking { f } => {
+                            f();
+                        }
+                        Worker::SpawnBlocking { f } => {
+                            // If all workers are busy, we need to execute the blocking task in a
+                            // separate thread to avoid starving runtime.
+                            let in_thread = if in_flow == workers {
+                                let thread_in_flow =
+                                    thread_operations_in_flow.fetch_add(1, Ordering::Relaxed) + 1;
+                                hotpath::val!("worker::thread_in_flow").set(&(
+                                    id,
+                                    in_flow,
+                                    thread_in_flow,
+                                ));
+                                if thread_in_flow == 1 {
+                                    true
+                                } else {
+                                    thread_operations_in_flow.fetch_sub(1, Ordering::Relaxed);
+                                    false
+                                }
+                            } else {
+                                false
+                            };
+                            if in_thread {
+                                let (tx_call, rx_call) = oneshot::channel();
+                                tx_thread
+                                    .send((f, tx_call))
+                                    .await
+                                    .expect("Worker: internal thread should receive task");
+                                _ = rx_call.await;
+                                thread_operations_in_flow.fetch_sub(1, Ordering::Relaxed);
+                            } else {
+                                f();
+                            }
+                        }
+                    }
+                    operations_in_flow.fetch_sub(1, Ordering::Relaxed);
+                }
+
+                debug!("finished");
+            }
+            .instrument(error_span!("worker", id)),
+        ));
+    });
+    tx_worker
+}

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -512,7 +512,7 @@ async fn spawn_process_db_index(
             DbIndex::FullScanProgress { tx } => tx
                 .send({
                     let db = db.0.read().unwrap();
-                    db.next_full_scan_progress.clone().unwrap_or_else(|| {
+                    db.next_full_scan_progress.unwrap_or_else(|| {
                         if fullscan_finished.load(Ordering::Acquire) {
                             Progress::Done
                         } else {

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -9,6 +9,7 @@ use crate::db_basic::Table;
 use crate::mock_opensearch;
 use crate::usearch::test_config;
 use crate::wait_for;
+use httpapi::IndexStatus;
 use httpclient::HttpClient;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
@@ -108,10 +109,7 @@ async fn simple_create_search_delete_index() {
             client
                 .index_status(&keyspace_name, &index_name)
                 .await
-                .ok()
-                .map(|status| status.count)
-                .unwrap_or(0)
-                == 3
+                .is_ok_and(|status| status.status == IndexStatus::Serving && status.count == 3)
         },
         "Waiting for index to be added to the store",
     )

--- a/crates/vector-store/tests/integration/quantization.rs
+++ b/crates/vector-store/tests/integration/quantization.rs
@@ -73,7 +73,7 @@ async fn quantization_is_effectively_applied() {
                 client
                     .index_status(&keyspace_name, &index_name)
                     .await
-                    .is_ok_and(|s| s.count == values_len)
+                    .is_ok_and(|s| s.status == IndexStatus::Serving && s.count == values_len)
             },
             &format!("Waiting for 1 vector to be indexed ({:?})", quantization),
         )

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -240,9 +240,7 @@ async fn simple_create_search_delete_index() {
             client
                 .index_status(&keyspace_name, &index_name)
                 .await
-                .expect("failed to get index status")
-                .count
-                == 3
+                .is_ok_and(|status| status.status == IndexStatus::Serving && status.count == 3)
         },
         "Waiting for 3 vectors to be indexed",
     )


### PR DESCRIPTION
The PR tries to solve issue discovered on customer setup, where during rebuilding two indexes over CDC we observe a surge in search latency. The root cause seems to be actual low priority of ann search while indexes are built or modified in the meantime. The PR creates a benches tests for searching while indexes are built or modified using CDC.

The set of commits provides refactoring to the pipeline driven by benchmarks. Currently the changes are in parts which retrieve index data from engine or db_index, provide helpers for tokio runtime for hotpath scopes, setup channel buffering based on worker count.

The change introduces new module worker which improves management of usearch tasks. In the future it ought to manage also other long calculations.

The last commit refactors usearch capacity calculations - we don't need to call index usearch method as it complicates workflow.

In attachments there are logs from running benches at three points - base @ `benches: add new pipeline's tests`, buffers at `vector-store: increase channel buffers`, and worker at the last commit. There are clearly visible improvements between base and buffers, improvements between buffers and worker with one exception - clear search operations seems a little slower (~2%) - but there are still huge improvements from base and worker. As providing separate worker actor seems a better approach I would accept this difference.


Fixes: VECTOR-566