### PR TITLE
e2etest: remove dependency on vector-store and httpclient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,13 +1221,14 @@ dependencies = [
 name = "e2etest-vector-store-cluster"
 version = "0.0.0-dev"
 dependencies = [
+ "anyhow",
  "async-backtrace",
  "e2etest",
- "httpclient",
+ "reqwest",
+ "serde",
  "tempfile",
  "tokio",
  "tracing",
- "vector-store",
 ]
 
 [[package]]

--- a/crates/e2etest-vector-store-cluster/Cargo.toml
+++ b/crates/e2etest-vector-store-cluster/Cargo.toml
@@ -8,10 +8,11 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 async-backtrace.workspace = true
 e2etest.workspace = true
-httpclient.workspace = true
+reqwest.workspace = true
+serde.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-vector-store.workspace = true

--- a/crates/e2etest-vector-store-cluster/src/lib.rs
+++ b/crates/e2etest-vector-store-cluster/src/lib.rs
@@ -5,7 +5,7 @@
 
 use async_backtrace::frame;
 use async_backtrace::framed;
-use httpclient::HttpClient;
+use reqwest::Client;
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::net::SocketAddr;
@@ -26,10 +26,42 @@ use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
 use tracing::info;
-use vector_store::httproutes::NodeStatus;
 
 pub const VS_PORT: u16 = 6080;
 pub const DB_PORT: u16 = 9042;
+
+#[derive(serde::Deserialize, PartialEq, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum NodeStatus {
+    Initializing,
+    ConnectingToDb,
+    Bootstrapping,
+    Serving,
+}
+
+struct HttpClient {
+    client: Client,
+    url_api: String,
+}
+
+impl HttpClient {
+    fn new(addr: SocketAddr) -> Self {
+        Self {
+            url_api: format!("http://{addr}/api/v1"),
+            client: Client::new(),
+        }
+    }
+
+    async fn status(&self) -> anyhow::Result<NodeStatus> {
+        Ok(self
+            .client
+            .get(format!("{}/status", self.url_api))
+            .send()
+            .await?
+            .json()
+            .await?)
+    }
+}
 
 /// Configuration for a single Vector Store node in the test cluster.
 #[derive(Clone)]


### PR DESCRIPTION
e2etest framework should not depend on any crate from vector-store repository, as no crate from that repo shouldn't be published in crates.io. For this reason the commit copy a part for httpclient to retrieve a node status. It is a short duplicate, but e2etest crate eventually will be in different repo and published, so this seems a reasonable move.

Fixes: VECTOR-657
