### PR TITLE
vector-store: refactor server config (prerequisite for mTLS API server)

### DIFF
--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -44,11 +44,13 @@ use uuid::Uuid;
 use vector_store::AsyncInProgress;
 use vector_store::ColumnName;
 use vector_store::Config;
+use vector_store::ConfigReceivers;
 use vector_store::Connectivity;
 use vector_store::DbEmbedding;
 use vector_store::DbIndexType;
 use vector_store::ExpansionAdd;
 use vector_store::ExpansionSearch;
+use vector_store::HttpServerConfig;
 use vector_store::IndexMetadata;
 use vector_store::PrimaryKey;
 use vector_store::Quantization;
@@ -182,11 +184,18 @@ async fn run_vector_store(
     let internals = vector_store::new_internals();
     let index_factory = vector_store::new_index_factory_usearch(config.clone()).unwrap();
 
-    let (server, addr) = vector_store::run(node_state, db, internals, index_factory, config)
+    let addr = config.borrow().vector_store_addr;
+    let (http_tx, http_rx) = watch::channel(Arc::new(HttpServerConfig { addr, tls: None }));
+    let receivers = ConfigReceivers {
+        config,
+        http: http_rx,
+    };
+
+    let (server, addr) = vector_store::run(node_state, db, internals, index_factory, receivers)
         .await
         .unwrap();
 
-    (server, HttpClient::new(addr))
+    ((http_tx, server), HttpClient::new(addr))
 }
 
 async fn wait_until_index_is_created(

--- a/crates/vector-store/src/config_manager.rs
+++ b/crates/vector-store/src/config_manager.rs
@@ -5,22 +5,68 @@
 
 use crate::Config;
 use crate::Credentials;
+use crate::tls;
+use crate::tls::TlsServerConfig;
 use anyhow::anyhow;
 use anyhow::bail;
 use itertools::Itertools;
 use secrecy::ExposeSecret;
+use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::watch;
 
+#[derive(Clone, PartialEq)]
+pub struct HttpServerConfig {
+    pub addr: SocketAddr,
+    pub tls: Option<TlsServerConfig>,
+}
+
+impl HttpServerConfig {
+    pub(crate) fn protocol_label(&self) -> &'static str {
+        match &self.tls {
+            None => "HTTP",
+            Some(_) => "HTTPS",
+        }
+    }
+}
+
+pub struct ConfigReceivers {
+    pub config: watch::Receiver<Arc<Config>>,
+    pub http: watch::Receiver<Arc<HttpServerConfig>>,
+}
+
+async fn derive_http_config(config: &Config) -> anyhow::Result<HttpServerConfig> {
+    let tls = match load_server_identity(config).await? {
+        Some(identity) => Some(TlsServerConfig::new(&identity)?),
+        None => None,
+    };
+    Ok(HttpServerConfig {
+        addr: config.vector_store_addr,
+        tls,
+    })
+}
+
+async fn load_server_identity(config: &Config) -> anyhow::Result<Option<tls::ServerIdentity>> {
+    let cert = config.tls_cert_path.as_ref();
+    let key = config.tls_key_path.as_ref();
+    match (cert, key) {
+        (Some(cert), Some(key)) => Ok(Some(tls::ServerIdentity::new(cert, key).await?)),
+        (None, None) => Ok(None),
+        (Some(_), None) => bail!("TLS cert path is set but key path is missing"),
+        (None, Some(_)) => bail!("TLS key path is set but cert path is missing"),
+    }
+}
+
 pub struct ConfigManager {
     config_tx: watch::Sender<Arc<Config>>,
+    http_config_tx: watch::Sender<Arc<HttpServerConfig>>,
 }
 
 impl ConfigManager {
-    /// Create a new ConfigManager and return both the manager and a receiver for configuration
-    /// change notifications. The receiver can be cloned to share with multiple consumers.
+    /// Create a new ConfigManager and return both the manager and receivers for configuration
+    /// change notifications. The receivers can be cloned to share with multiple consumers.
     ///
     /// After creating the ConfigManager, call `start()` from within a Tokio runtime context
     /// to begin listening for SIGHUP signals.
@@ -29,10 +75,21 @@ impl ConfigManager {
     /// * `config` - Initial configuration
     ///
     /// # Returns
-    /// A tuple of (ConfigManager, receiver for configuration changes)
-    pub fn new(config: Config) -> (Self, watch::Receiver<Arc<Config>>) {
+    /// A tuple of (ConfigManager, config receivers)
+    pub async fn new(config: Config) -> anyhow::Result<(Self, ConfigReceivers)> {
+        let http = derive_http_config(&config).await?;
         let (config_tx, config_rx) = watch::channel(Arc::new(config));
-        (Self { config_tx }, config_rx)
+        let (http_config_tx, http_config_rx) = watch::channel(Arc::new(http));
+        Ok((
+            Self {
+                config_tx,
+                http_config_tx,
+            },
+            ConfigReceivers {
+                config: config_rx,
+                http: http_config_rx,
+            },
+        ))
     }
 
     /// Start listening for SIGHUP signals in a background task.
@@ -57,16 +114,30 @@ impl ConfigManager {
         let old_config = self.config_tx.borrow().clone();
 
         // Load new configuration
-        let new_config = Arc::new(load_config(env).await?);
+        let new_config = load_config(env).await?;
 
         // Check for restart-required changes
         self.check_restart_required_changes(&old_config, &new_config);
 
-        // Update the config atomically - watch will notify all receivers
-        self.config_tx.send(new_config)?;
+        self.send_config(new_config).await;
 
         tracing::info!("Configuration reloaded successfully");
         Ok(())
+    }
+
+    async fn send_config(&self, config: Config) {
+        match derive_http_config(&config).await {
+            Ok(http) => {
+                self.http_config_tx.send(Arc::new(http)).ok();
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to derive HTTP server config: {e}. \
+                     Keeping previous HTTP server config to avoid TLS downgrade"
+                );
+            }
+        }
+        self.config_tx.send(Arc::new(config)).ok();
     }
 
     /// Check for configuration changes that require a server restart and log warnings.
@@ -99,6 +170,10 @@ impl ConfigManager {
                 "These changes have been stored but will not take effect until the server is restarted."
             );
         }
+    }
+
+    fn all_receivers_dropped(&self) -> bool {
+        self.config_tx.receiver_count() == 0 && self.http_config_tx.receiver_count() == 0
     }
 
     /// Start listening for SIGHUP signals and reload configuration when received.
@@ -138,8 +213,7 @@ impl ConfigManager {
                     }
                 }
                 _ = check_interval.tick() => {
-                    // Periodically check if there are any receivers left
-                    if self.config_tx.receiver_count() == 0 {
+                    if self.all_receivers_dropped() {
                         tracing::debug!("No more configuration receivers, stopping SIGHUP handler");
                         break;
                     }
@@ -529,36 +603,15 @@ mod tests {
 
     #[tokio::test]
     async fn config_manager_reload_notifies_watchers() {
-        let initial_config = Config {
-            vector_store_addr: "127.0.0.1:6080".parse().unwrap(),
-            scylladb_uri: "127.0.0.1:9042".to_string(),
-            threads: None,
-            memory_limit: None,
-            memory_usage_check_interval: None,
-            opensearch_addr: None,
-            credentials: None,
-            usearch_simulator: None,
-            alter_index_simulator: false,
-            disable_colors: false,
-            tls_cert_path: None,
-            tls_key_path: None,
-            cql_connection_timeout: None,
-            cql_keepalive_interval: None,
-            cql_keepalive_timeout: None,
-            cql_tcp_keepalive_interval: None,
-            cql_uri_translation_map: None,
-            cdc_safety_interval: None,
-            cdc_sleep_interval: None,
-            cdc_fine_safety_interval: None,
-            cdc_fine_sleep_interval: None,
-        };
+        let (config_manager, receivers) = ConfigManager::new(Config::default()).await.unwrap();
 
-        let (config_manager, mut config_rx) = ConfigManager::new(initial_config);
-
+        let mut config_rx = receivers.config;
+        let mut http_rx = receivers.http;
         // Get initial config
         let initial = config_rx.borrow().clone();
         assert_eq!(initial.vector_store_addr.to_string(), "127.0.0.1:6080");
         assert_eq!(initial.scylladb_uri, "127.0.0.1:9042");
+        assert_eq!(http_rx.borrow().addr.to_string(), "127.0.0.1:6080");
 
         // Reload config with different environment values
         let env = mock_env(HashMap::from([
@@ -569,22 +622,24 @@ mod tests {
 
         // Wait for change notification
         config_rx.changed().await.unwrap();
+        http_rx.changed().await.unwrap();
 
         // Verify new config values
         let updated = config_rx.borrow();
         assert_eq!(updated.vector_store_addr.to_string(), "192.168.1.100:7070");
         assert_eq!(updated.scylladb_uri, "192.168.1.200:9043");
+        assert_eq!(http_rx.borrow().addr.to_string(), "192.168.1.100:7070");
     }
 
     #[tokio::test]
     async fn config_manager_multiple_watchers() {
         let initial_config = Config::default();
-        let (config_manager, config_rx) = ConfigManager::new(initial_config);
+        let (config_manager, receivers) = ConfigManager::new(initial_config).await.unwrap();
 
         // Clone receivers for multiple watchers
-        let mut rx1 = config_rx.clone();
-        let mut rx2 = config_rx.clone();
-        let mut rx3 = config_rx;
+        let mut rx1 = receivers.config.clone();
+        let mut rx2 = receivers.config.clone();
+        let mut rx3 = receivers.config;
 
         // Spawn tasks to wait for changes
         let task1 = tokio::spawn(async move {

--- a/crates/vector-store/src/httpserver.rs
+++ b/crates/vector-store/src/httpserver.rs
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::Config;
+use crate::config_manager::HttpServerConfig;
 use crate::engine::Engine;
 use crate::httproutes;
 use crate::internals::Internals;
 use crate::metrics::Metrics;
 use crate::node_state::NodeState;
-use crate::tls;
-use crate::tls::TlsServerConfig;
 use axum_server::Handle;
 use axum_server::accept::NoDelayAcceptor;
 use axum_server::tls_rustls::RustlsConfig;
@@ -32,28 +30,9 @@ struct ServerDeps {
     index_engine_version: String,
 }
 
-async fn load_tls_config(config: &Config) -> anyhow::Result<Option<RustlsConfig>> {
-    let (Some(cert_path), Some(key_path)) = (&config.tls_cert_path, &config.tls_key_path) else {
-        return Ok(None);
-    };
-    let identity = tls::ServerIdentity::new(cert_path, key_path)?;
-    let tls_config = TlsServerConfig::new(&identity)?;
-    Ok(Some(RustlsConfig::from_config(Arc::clone(
-        tls_config.server_config(),
-    ))))
-}
-
-fn protocol(tls_config: &Option<RustlsConfig>) -> &'static str {
-    if tls_config.is_some() {
-        "HTTPS"
-    } else {
-        "HTTP"
-    }
-}
-
 /// Retry spawning a server with exponential backoff
 async fn spawn_server_with_retry(
-    config: &Config,
+    config: &HttpServerConfig,
     deps: &ServerDeps,
 ) -> anyhow::Result<(Handle, SocketAddr)> {
     let mut retry_delay = Duration::from_millis(50);
@@ -93,7 +72,7 @@ pub(crate) async fn new(
     metrics: Arc<Metrics>,
     internals: Sender<Internals>,
     index_engine_version: String,
-    mut config_rx: watch::Receiver<Arc<Config>>,
+    mut config_rx: watch::Receiver<Arc<HttpServerConfig>>,
 ) -> anyhow::Result<(Sender<HttpServer>, SocketAddr)> {
     // minimal size as channel is used as a lifetime guard
     const CHANNEL_SIZE: usize = 1;
@@ -115,9 +94,7 @@ pub(crate) async fn new(
     // Spawn supervisor task that monitors config changes and manages server restarts
     tokio::spawn(async move {
         let mut current_handle = initial_handle;
-        let mut current_addr = initial_config.vector_store_addr;
-        let mut current_tls_cert = initial_config.tls_cert_path.clone();
-        let mut current_tls_key = initial_config.tls_key_path.clone();
+        let mut current_config = initial_config;
 
         loop {
             tokio::select! {
@@ -133,31 +110,9 @@ pub(crate) async fn new(
 
                     let new_config = config_rx.borrow().clone();
 
-                    // Check if HTTP server config changed
-                    let addr_changed = current_addr != new_config.vector_store_addr;
-                    let tls_changed = current_tls_cert != new_config.tls_cert_path
-                        || current_tls_key != new_config.tls_key_path;
-
-                    if addr_changed || tls_changed {
-                        let mut changes = Vec::new();
-                        if addr_changed {
-                            changes.push(format!("address {} -> {}", current_addr, new_config.vector_store_addr));
-                        }
-                        if tls_changed {
-                            let old_tls = if current_tls_cert.is_some() && current_tls_key.is_some() {
-                                "enabled"
-                            } else {
-                                "disabled"
-                            };
-                            let new_tls = if new_config.tls_cert_path.is_some() && new_config.tls_key_path.is_some() {
-                                "enabled"
-                            } else {
-                                "disabled"
-                            };
-                            changes.push(format!("TLS {} -> {}", old_tls, new_tls));
-                        }
-
-                        tracing::info!("HTTP server configuration changed ({}), reloading...", changes.join(", "));
+                    if *current_config != *new_config {
+                        let changes = describe_config_changes(&current_config, &new_config);
+                        tracing::info!("HTTP server configuration changed ({changes}), reloading...");
 
                         // Gracefully shutdown old server and wait for it to complete
                         tracing::info!("Shutting down old HTTP server");
@@ -167,12 +122,12 @@ pub(crate) async fn new(
                         match spawn_server_with_retry(&new_config, &deps).await {
                             Ok((handle, new_actual_addr)) => {
                                 current_handle = handle;
-                                current_addr = new_config.vector_store_addr;
-                                current_tls_cert = new_config.tls_cert_path.clone();
-                                current_tls_key = new_config.tls_key_path.clone();
-
-                                let protocol = if new_config.tls_cert_path.is_some() { "HTTPS" } else { "HTTP" };
-                                tracing::info!("{} server reloaded successfully on {}", protocol, new_actual_addr);
+                                current_config = new_config;
+                                tracing::info!(
+                                    "{} server reloaded successfully on {}",
+                                    current_config.protocol_label(),
+                                    new_actual_addr
+                                );
                             }
                             Err(e) => {
                                 tracing::error!("Failed to reload HTTP server: {e}");
@@ -196,10 +151,12 @@ pub(crate) async fn new(
 
 /// Spawn a new HTTP server instance with the given configuration
 /// Returns the handle and the actual bound address
-async fn spawn_server(config: &Config, deps: &ServerDeps) -> anyhow::Result<(Handle, SocketAddr)> {
-    let tls_config = load_tls_config(config).await?;
-    let protocol = protocol(&tls_config);
-    let addr = config.vector_store_addr;
+async fn spawn_server(
+    config: &HttpServerConfig,
+    deps: &ServerDeps,
+) -> anyhow::Result<(Handle, SocketAddr)> {
+    let protocol = config.protocol_label();
+    let addr = config.addr;
 
     let handle = Handle::new();
 
@@ -210,6 +167,11 @@ async fn spawn_server(config: &Config, deps: &ServerDeps) -> anyhow::Result<(Han
         let metrics = deps.metrics.clone();
         let internals = deps.internals.clone();
         let index_engine_version = deps.index_engine_version.clone();
+        let tls_config = config
+            .tls
+            .as_ref()
+            .map(|t| RustlsConfig::from_config(Arc::clone(t.server_config())));
+
         async move {
             let result = match tls_config {
                 Some(tls_config) => {
@@ -260,4 +222,18 @@ async fn spawn_server(config: &Config, deps: &ServerDeps) -> anyhow::Result<(Han
         ))?;
 
     Ok((handle, actual_addr))
+}
+
+fn describe_config_changes(old: &HttpServerConfig, new: &HttpServerConfig) -> String {
+    let mut changes = Vec::new();
+    if old.addr != new.addr {
+        changes.push(format!("address {} -> {}", old.addr, new.addr));
+    }
+    match (&old.tls, &new.tls) {
+        (Some(old_tls), Some(new_tls)) => changes.extend(old_tls.describe_changes(new_tls)),
+        (None, Some(_)) => changes.push("TLS enabled".to_string()),
+        (Some(_), None) => changes.push("TLS disabled".to_string()),
+        (None, None) => {}
+    }
+    changes.join(", ")
 }

--- a/crates/vector-store/src/httpserver.rs
+++ b/crates/vector-store/src/httpserver.rs
@@ -22,6 +22,14 @@ use tokio::time;
 
 pub(crate) enum HttpServer {}
 
+struct ServerDeps {
+    state: Sender<NodeState>,
+    engine: Sender<Engine>,
+    metrics: Arc<Metrics>,
+    internals: Sender<Internals>,
+    index_engine_version: String,
+}
+
 async fn load_tls_config(config: &Config) -> anyhow::Result<Option<RustlsConfig>> {
     match (&config.tls_cert_path, &config.tls_key_path) {
         (Some(cert_path), Some(key_path)) => {
@@ -45,11 +53,7 @@ fn protocol(tls_config: &Option<RustlsConfig>) -> &'static str {
 /// Retry spawning a server with exponential backoff
 async fn spawn_server_with_retry(
     config: &Config,
-    state: Sender<NodeState>,
-    engine: Sender<Engine>,
-    metrics: Arc<Metrics>,
-    internals: Sender<Internals>,
-    index_engine_version: String,
+    deps: &ServerDeps,
 ) -> anyhow::Result<(Handle, SocketAddr)> {
     let mut retry_delay = Duration::from_millis(50);
     let max_retries = 10;
@@ -59,16 +63,7 @@ async fn spawn_server_with_retry(
             time::sleep(retry_delay).await;
         }
 
-        match spawn_server(
-            config,
-            state.clone(),
-            engine.clone(),
-            metrics.clone(),
-            internals.clone(),
-            index_engine_version.clone(),
-        )
-        .await
-        {
+        match spawn_server(config, deps).await {
             Ok(result) => return Ok(result),
             Err(e) => {
                 if attempt < max_retries {
@@ -103,112 +98,96 @@ pub(crate) async fn new(
     const CHANNEL_SIZE: usize = 1;
     let (tx, mut rx) = mpsc::channel(CHANNEL_SIZE);
 
+    let deps = ServerDeps {
+        state,
+        engine,
+        metrics,
+        internals,
+        index_engine_version,
+    };
+
     let initial_config = config_rx.borrow().clone();
 
     // Start initial server and get actual bound address
-    let (initial_handle, actual_addr) = spawn_server_with_retry(
-        &initial_config,
-        state.clone(),
-        engine.clone(),
-        metrics.clone(),
-        internals.clone(),
-        index_engine_version.clone(),
-    )
-    .await?;
+    let (initial_handle, actual_addr) = spawn_server_with_retry(&initial_config, &deps).await?;
 
     // Spawn supervisor task that monitors config changes and manages server restarts
-    tokio::spawn({
-        let state = state.clone();
-        let engine = engine.clone();
-        let metrics = metrics.clone();
-        let index_engine_version = index_engine_version.clone();
+    tokio::spawn(async move {
+        let mut current_handle = initial_handle;
+        let mut current_addr = initial_config.vector_store_addr;
+        let mut current_tls_cert = initial_config.tls_cert_path.clone();
+        let mut current_tls_key = initial_config.tls_key_path.clone();
 
-        async move {
-            let mut current_handle = initial_handle;
-            let mut current_addr = initial_config.vector_store_addr;
-            let mut current_tls_cert = initial_config.tls_cert_path.clone();
-            let mut current_tls_key = initial_config.tls_key_path.clone();
-
-            loop {
-                tokio::select! {
-                    result = rx.recv() => {
-                        if result.is_none() {
-                            break;
-                        }
+        loop {
+            tokio::select! {
+                result = rx.recv() => {
+                    if result.is_none() {
+                        break;
                     }
-                    result = config_rx.changed() => {
-                        if result.is_err() {
-                            break;
+                }
+                result = config_rx.changed() => {
+                    if result.is_err() {
+                        break;
+                    }
+
+                    let new_config = config_rx.borrow().clone();
+
+                    // Check if HTTP server config changed
+                    let addr_changed = current_addr != new_config.vector_store_addr;
+                    let tls_changed = current_tls_cert != new_config.tls_cert_path
+                        || current_tls_key != new_config.tls_key_path;
+
+                    if addr_changed || tls_changed {
+                        let mut changes = Vec::new();
+                        if addr_changed {
+                            changes.push(format!("address {} -> {}", current_addr, new_config.vector_store_addr));
+                        }
+                        if tls_changed {
+                            let old_tls = if current_tls_cert.is_some() && current_tls_key.is_some() {
+                                "enabled"
+                            } else {
+                                "disabled"
+                            };
+                            let new_tls = if new_config.tls_cert_path.is_some() && new_config.tls_key_path.is_some() {
+                                "enabled"
+                            } else {
+                                "disabled"
+                            };
+                            changes.push(format!("TLS {} -> {}", old_tls, new_tls));
                         }
 
-                        let new_config = config_rx.borrow().clone();
+                        tracing::info!("HTTP server configuration changed ({}), reloading...", changes.join(", "));
 
-                        // Check if HTTP server config changed
-                        let addr_changed = current_addr != new_config.vector_store_addr;
-                        let tls_changed = current_tls_cert != new_config.tls_cert_path
-                            || current_tls_key != new_config.tls_key_path;
+                        // Gracefully shutdown old server and wait for it to complete
+                        tracing::info!("Shutting down old HTTP server");
+                        current_handle.graceful_shutdown(Some(Duration::from_secs(10)));
 
-                        if addr_changed || tls_changed {
-                            let mut changes = Vec::new();
-                            if addr_changed {
-                                changes.push(format!("address {} -> {}", current_addr, new_config.vector_store_addr));
+                        // Start new server with retry
+                        match spawn_server_with_retry(&new_config, &deps).await {
+                            Ok((handle, new_actual_addr)) => {
+                                current_handle = handle;
+                                current_addr = new_config.vector_store_addr;
+                                current_tls_cert = new_config.tls_cert_path.clone();
+                                current_tls_key = new_config.tls_key_path.clone();
+
+                                let protocol = if new_config.tls_cert_path.is_some() { "HTTPS" } else { "HTTP" };
+                                tracing::info!("{} server reloaded successfully on {}", protocol, new_actual_addr);
                             }
-                            if tls_changed {
-                                let old_tls = if current_tls_cert.is_some() && current_tls_key.is_some() {
-                                    "enabled"
-                                } else {
-                                    "disabled"
-                                };
-                                let new_tls = if new_config.tls_cert_path.is_some() && new_config.tls_key_path.is_some() {
-                                    "enabled"
-                                } else {
-                                    "disabled"
-                                };
-                                changes.push(format!("TLS {} -> {}", old_tls, new_tls));
-                            }
-
-                            tracing::info!("HTTP server configuration changed ({}), reloading...", changes.join(", "));
-
-                            // Gracefully shutdown old server and wait for it to complete
-                            tracing::info!("Shutting down old HTTP server");
-                            current_handle.graceful_shutdown(Some(Duration::from_secs(10)));
-
-                            // Start new server with retry
-                            match spawn_server_with_retry(
-                                &new_config,
-                                state.clone(),
-                                engine.clone(),
-                                metrics.clone(),
-                                internals.clone(),
-                                index_engine_version.clone(),
-                            )
-                            .await
-                            {
-                                Ok((handle, new_actual_addr)) => {
-                                    current_handle = handle;
-                                    current_addr = new_config.vector_store_addr;
-                                    current_tls_cert = new_config.tls_cert_path.clone();
-                                    current_tls_key = new_config.tls_key_path.clone();
-
-                                    let protocol = if new_config.tls_cert_path.is_some() { "HTTPS" } else { "HTTP" };
-                                    tracing::info!("{} server reloaded successfully on {}", protocol, new_actual_addr);
-                                }
-                                Err(e) => {
-                                    tracing::error!("Failed to reload HTTP server: {e}");
-                                    tracing::error!("HTTP server is now offline - previous server was shut down but new server failed to start");
-                                }
+                            Err(e) => {
+                                tracing::error!("Failed to reload HTTP server: {e}");
+                                tracing::error!("HTTP server is now offline - previous server was shut down but new server failed to start");
                             }
                         }
                     }
                 }
             }
-
-            // Final shutdown
-            tracing::info!("HTTP server shutting down");
-            current_handle.graceful_shutdown(Some(Duration::from_secs(10)));
-            // Brief delay to allow clean shutdown
-            tokio::time::sleep(Duration::from_millis(100)).await;
         }
+
+        // Final shutdown
+        tracing::info!("HTTP server shutting down");
+        current_handle.graceful_shutdown(Some(Duration::from_secs(10)));
+        // Brief delay to allow clean shutdown
+        tokio::time::sleep(Duration::from_millis(100)).await;
     });
 
     Ok((tx, actual_addr))
@@ -216,14 +195,7 @@ pub(crate) async fn new(
 
 /// Spawn a new HTTP server instance with the given configuration
 /// Returns the handle and the actual bound address
-async fn spawn_server(
-    config: &Config,
-    state: Sender<NodeState>,
-    engine: Sender<Engine>,
-    metrics: Arc<Metrics>,
-    internals: Sender<Internals>,
-    index_engine_version: String,
-) -> anyhow::Result<(Handle, SocketAddr)> {
+async fn spawn_server(config: &Config, deps: &ServerDeps) -> anyhow::Result<(Handle, SocketAddr)> {
     let tls_config = load_tls_config(config).await?;
     let protocol = protocol(&tls_config);
     let addr = config.vector_store_addr;
@@ -232,6 +204,11 @@ async fn spawn_server(
 
     tokio::spawn({
         let handle = handle.clone();
+        let state = deps.state.clone();
+        let engine = deps.engine.clone();
+        let metrics = deps.metrics.clone();
+        let internals = deps.internals.clone();
+        let index_engine_version = deps.index_engine_version.clone();
         async move {
             let result = match tls_config {
                 Some(tls_config) => {

--- a/crates/vector-store/src/httpserver.rs
+++ b/crates/vector-store/src/httpserver.rs
@@ -9,6 +9,8 @@ use crate::httproutes;
 use crate::internals::Internals;
 use crate::metrics::Metrics;
 use crate::node_state::NodeState;
+use crate::tls;
+use crate::tls::TlsServerConfig;
 use axum_server::Handle;
 use axum_server::accept::NoDelayAcceptor;
 use axum_server::tls_rustls::RustlsConfig;
@@ -31,15 +33,14 @@ struct ServerDeps {
 }
 
 async fn load_tls_config(config: &Config) -> anyhow::Result<Option<RustlsConfig>> {
-    match (&config.tls_cert_path, &config.tls_key_path) {
-        (Some(cert_path), Some(key_path)) => {
-            let config = RustlsConfig::from_pem_file(cert_path, key_path)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to load TLS config: {e}"))?;
-            Ok(Some(config))
-        }
-        _ => Ok(None),
-    }
+    let (Some(cert_path), Some(key_path)) = (&config.tls_cert_path, &config.tls_key_path) else {
+        return Ok(None);
+    };
+    let identity = tls::ServerIdentity::new(cert_path, key_path)?;
+    let tls_config = TlsServerConfig::new(&identity)?;
+    Ok(Some(RustlsConfig::from_config(Arc::clone(
+        tls_config.server_config(),
+    ))))
 }
 
 fn protocol(tls_config: &Option<RustlsConfig>) -> &'static str {

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -28,6 +28,7 @@ mod primary_key;
 mod similarity;
 mod table;
 mod timestamp;
+pub mod tls;
 mod vector;
 
 pub use crate::config_manager::ConfigManager;

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -32,6 +32,8 @@ pub mod tls;
 mod vector;
 
 pub use crate::config_manager::ConfigManager;
+pub use crate::config_manager::ConfigReceivers;
+pub use crate::config_manager::HttpServerConfig;
 pub use crate::config_manager::load_config;
 pub use crate::distance::Distance;
 pub use crate::index_key::IndexKey;
@@ -635,7 +637,7 @@ pub async fn run(
     db_actor: Sender<Db>,
     internals: Sender<Internals>,
     index_factory: Box<dyn IndexFactory + Send + Sync>,
-    config_rx: watch::Receiver<Arc<Config>>,
+    receivers: ConfigReceivers,
 ) -> anyhow::Result<(impl Sized, SocketAddr)> {
     let metrics: Arc<Metrics> = Arc::new(metrics::Metrics::new());
     let index_engine_version = index_factory.index_engine_version();
@@ -646,13 +648,13 @@ pub async fn run(
             index_factory,
             node_state,
             metrics.clone(),
-            config_rx.clone(),
+            receivers.config,
         )
         .await?,
         metrics,
         internals,
         index_engine_version,
-        config_rx,
+        receivers.http,
     )
     .await
 }

--- a/crates/vector-store/src/main.rs
+++ b/crates/vector-store/src/main.rs
@@ -65,18 +65,17 @@ fn main() -> anyhow::Result<()> {
     tracing::info!("Starting {} version {}", Info::name(), Info::version());
 
     // Create ConfigManager with initial configuration
-    let (config_manager, config_rx) = ConfigManager::new(loaded_config);
-    let config = config_rx.borrow().clone();
-
-    let threads = config.threads;
+    let threads = loaded_config.threads;
 
     vector_store::block_on(threads, async move || {
+        let (config_manager, config_receivers) = ConfigManager::new(loaded_config).await?;
         // Start SIGHUP handler now that we're in the Tokio runtime
         config_manager.start(dotenvy_to_std_var);
 
         let node_state = vector_store::new_node_state().await;
 
-        let opensearch_addr = config.opensearch_addr.clone();
+        let config_rx = config_receivers.config.clone();
+        let opensearch_addr = config_rx.borrow().opensearch_addr.clone();
 
         let index_factory = if let Some(addr) = opensearch_addr {
             tracing::info!("Using OpenSearch index factory at {addr}");
@@ -88,14 +87,14 @@ fn main() -> anyhow::Result<()> {
 
         let internals = vector_store::new_internals();
         let db_actor =
-            vector_store::new_db(node_state.clone(), internals.clone(), config_rx.clone()).await?;
+            vector_store::new_db(node_state.clone(), internals.clone(), config_rx).await?;
 
         let (_server_actor, addr) = vector_store::run(
             node_state,
             db_actor,
             internals,
             index_factory,
-            config_rx.clone(),
+            config_receivers,
         )
         .await?;
         tracing::info!("listening on {addr}");

--- a/crates/vector-store/src/tls.rs
+++ b/crates/vector-store/src/tls.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use rustls::pki_types::CertificateDer;
+use rustls::pki_types::PrivateKeyDer;
+use rustls_pki_types::pem::PemObject;
+use std::path::Path;
+use std::sync::Arc;
+
+#[derive(Clone, PartialEq)]
+pub struct ServerIdentity {
+    cert_pem: Vec<u8>,
+    key_pem: Vec<u8>,
+}
+
+impl ServerIdentity {
+    pub async fn new(cert_path: &Path, key_path: &Path) -> anyhow::Result<Self> {
+        let cert_pem = tokio::fs::read(cert_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read server cert at {cert_path:?}: {e}"))?;
+        let key_pem = tokio::fs::read(key_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read server key at {key_path:?}: {e}"))?;
+        Ok(Self { cert_pem, key_pem })
+    }
+}
+
+#[derive(Clone)]
+pub struct TlsServerConfig {
+    server_config: Arc<rustls::ServerConfig>,
+    identity: ServerIdentity,
+}
+
+impl TlsServerConfig {
+    pub fn new(identity: &ServerIdentity) -> anyhow::Result<Self> {
+        let server_config = build_server_config(identity)?;
+        Ok(Self {
+            server_config,
+            identity: identity.clone(),
+        })
+    }
+
+    pub fn server_config(&self) -> &Arc<rustls::ServerConfig> {
+        &self.server_config
+    }
+
+    pub fn describe_changes(&self, other: &TlsServerConfig) -> Vec<String> {
+        let mut changes = Vec::new();
+        if self.identity != other.identity {
+            changes.push("server identity changed".to_string());
+        }
+        changes
+    }
+}
+
+impl PartialEq for TlsServerConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity == other.identity
+    }
+}
+
+fn build_server_config(identity: &ServerIdentity) -> anyhow::Result<Arc<rustls::ServerConfig>> {
+    let cert_chain = CertificateDer::pem_slice_iter(&identity.cert_pem)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| anyhow::anyhow!("Failed to parse server certificate PEM: {e}"))?;
+
+    let private_key = PrivateKeyDer::from_pem_slice(&identity.key_pem)
+        .map_err(|e| anyhow::anyhow!("Failed to parse server private key PEM: {e}"))?;
+
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(cert_chain, private_key)?;
+
+    Ok(Arc::new(config))
+}

--- a/crates/vector-store/tests/integration/https.rs
+++ b/crates/vector-store/tests/integration/https.rs
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::create_config_channels;
 use crate::db_basic;
+use crate::usearch::test_config;
 use httpapi::PostIndexAnnRequest;
 use rcgen::CertifiedKey;
 use reqwest::StatusCode;
@@ -36,17 +38,17 @@ async fn run_server(
         vector_store_addr: addr,
         tls_cert_path,
         tls_key_path,
-        ..Default::default()
+        ..test_config()
     };
 
-    let (_config_tx, config_rx) = watch::channel(Arc::new(config));
+    let (receivers, senders) = create_config_channels(config).await;
 
     let (server, addr) =
-        vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
             .await
             .unwrap();
 
-    (server, addr, _config_tx)
+    (server, addr, senders)
 }
 
 #[tokio::test]
@@ -64,7 +66,7 @@ async fn test_https_server_responds() {
     let cert_file = create_temp_file(cert.pem().as_bytes());
     let key_file = create_temp_file(signing_key.serialize_pem().as_bytes());
 
-    let (_server, addr, _config_tx) = run_server(
+    let (_server, addr, _config_senders) = run_server(
         addr,
         Some(cert_file.path().to_path_buf()),
         Some(key_file.path().to_path_buf()),

--- a/crates/vector-store/tests/integration/info.rs
+++ b/crates/vector-store/tests/integration/info.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::create_config_channels;
 use crate::usearch::test_config;
 use crate::{db_basic, mock_opensearch};
 use httpclient::HttpClient;
@@ -17,19 +18,18 @@ async fn run_vs(
     let internals = vector_store::new_internals();
     let (db_actor, _) = db_basic::new(node_state.clone());
 
-    let (_config_tx, config_rx) = watch::channel(Arc::new(test_config()));
-
+    let (receivers, senders) = create_config_channels(test_config()).await;
     let (server, addr) =
-        vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
             .await
             .unwrap();
-    (HttpClient::new(addr), server, _config_tx)
+    (HttpClient::new(addr), server, senders)
 }
 
 #[tokio::test]
 async fn get_application_info_usearch() {
     let (_, rx) = watch::channel(Arc::new(Config::default()));
-    let (client, _server, _config_tx) =
+    let (client, _server, _config_senders) =
         run_vs(vector_store::new_index_factory_usearch(rx).unwrap()).await;
 
     let info = client.info().await;
@@ -45,7 +45,7 @@ async fn get_application_info_opensearch() {
     let (_, config_rx) = watch::channel(Arc::new(vector_store::Config::default()));
     let index_factory =
         vector_store::new_index_factory_opensearch(server.base_url(), config_rx).unwrap();
-    let (client, _server, _config_tx) = run_vs(index_factory).await;
+    let (client, _server, _config_senders) = run_vs(index_factory).await;
 
     let info = client.info().await;
 

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -15,13 +15,19 @@ mod routing;
 mod status;
 mod usearch;
 
+use std::sync::Arc;
 use std::sync::Once;
 use std::time::Duration;
+use tokio::sync::watch;
 use tokio::task;
 use tokio::time;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
+use vector_store::Config;
+use vector_store::ConfigReceivers;
+use vector_store::HttpServerConfig;
+use vector_store::tls;
 
 static INIT_TRACING: Once = Once::new();
 
@@ -59,4 +65,36 @@ async fn wait_for_value<T>(mut producer: impl AsyncFnMut() -> Option<T>, msg: &s
     })
     .await
     .unwrap_or_else(|_| panic!("Timeout on: {msg}"))
+}
+
+pub(crate) struct ConfigSenders {
+    #[allow(dead_code)]
+    pub(crate) config: watch::Sender<Arc<Config>>,
+    #[allow(dead_code)]
+    pub(crate) http: watch::Sender<Arc<HttpServerConfig>>,
+}
+
+pub(crate) async fn create_config_channels(config: Config) -> (ConfigReceivers, ConfigSenders) {
+    let tls = match (&config.tls_cert_path, &config.tls_key_path) {
+        (Some(cert), Some(key)) => {
+            let identity = tls::ServerIdentity::new(cert, key).await.unwrap();
+            Some(tls::TlsServerConfig::new(&identity).unwrap())
+        }
+        _ => None,
+    };
+    let http = HttpServerConfig {
+        addr: config.vector_store_addr,
+        tls,
+    };
+    let (config_tx, config_rx) = watch::channel(Arc::new(config));
+    let (http_tx, http_rx) = watch::channel(Arc::new(http));
+    let receivers = ConfigReceivers {
+        config: config_rx,
+        http: http_rx,
+    };
+    let senders = ConfigSenders {
+        config: config_tx,
+        http: http_tx,
+    };
+    (receivers, senders)
 }

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::create_config_channels;
 use crate::db_basic;
 use crate::db_basic::Table;
 use crate::usearch::test_config;
@@ -14,7 +15,6 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use sysinfo::System;
-use tokio::sync::watch;
 use tracing::info;
 use uuid::Uuid;
 use vector_store::Config;
@@ -109,12 +109,12 @@ async fn memory_limit_during_index_build() {
         ..test_config()
     };
 
-    let (_config_tx, config_rx) = watch::channel(Arc::new(config));
-    let index_factory = vector_store::new_index_factory_usearch(config_rx.clone()).unwrap();
+    let (receivers, _senders) = create_config_channels(config).await;
+    let index_factory = vector_store::new_index_factory_usearch(receivers.config.clone()).unwrap();
 
     let node_state = node_state.clone();
     let (_server, addr) =
-        vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
             .await
             .unwrap();
 

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::create_config_channels;
 use crate::db_basic;
 use crate::db_basic::Table;
 use crate::mock_opensearch;
@@ -47,10 +48,9 @@ async fn simple_create_search_delete_index() {
     let index_factory =
         vector_store::new_index_factory_opensearch(server.base_url(), config_rx_factory).unwrap();
 
-    let (_config_tx, config_rx) = watch::channel(Arc::new(test_config()));
-
+    let (receivers, _senders) = create_config_channels(test_config()).await;
     let (_server_actor, addr) =
-        vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
             .await
             .unwrap();
 

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::create_config_channels;
 use crate::db_basic;
 use crate::db_basic::DbBasic;
 use crate::db_basic::ScanFn;
@@ -19,7 +20,6 @@ use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use tokio::sync::watch;
 use uuid::Uuid;
 use vector_store::ColumnName;
 use vector_store::DbIndexType;
@@ -82,13 +82,13 @@ async fn setup() -> (HttpClient, DbBasic, impl Sized) {
     let node_state = vector_store::new_node_state().await;
     let internals = vector_store::new_internals();
     let (db_actor, db) = db_basic::new(node_state.clone());
-    let (config_tx, config_rx) = watch::channel(Arc::new(test_config()));
-    let index_factory = vector_store::new_index_factory_usearch(config_rx.clone()).unwrap();
+    let (receivers, senders) = create_config_channels(test_config()).await;
+    let index_factory = vector_store::new_index_factory_usearch(receivers.config.clone()).unwrap();
     let (server, addr) =
-        vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
             .await
             .unwrap();
-    (HttpClient::new(addr), db, (server, config_tx))
+    (HttpClient::new(addr), db, (server, senders))
 }
 
 fn add_table(

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::Duration;
+use crate::create_config_channels;
 use crate::db_basic;
 use crate::db_basic::DbBasic;
 use crate::db_basic::ScanFn;
@@ -130,18 +131,18 @@ pub(crate) async fn setup_store_with_quantization(
 
     db.add_index(index.clone(), fullscan_fn, cdc_fn).unwrap();
 
-    let (config_tx, config_rx) = watch::channel(Arc::new(config));
-    let index_factory = vector_store::new_index_factory_usearch(config_rx.clone()).unwrap();
+    let (receivers, senders) = create_config_channels(config).await;
+    let index_factory = vector_store::new_index_factory_usearch(receivers.config.clone()).unwrap();
 
     let run = {
         let node_state = node_state.clone();
         async move {
             let (server, addr) =
-                vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+                vector_store::run(node_state, db_actor, internals, index_factory, receivers)
                     .await
                     .unwrap();
 
-            (HttpClient::new(addr), server, config_tx)
+            (HttpClient::new(addr), server, senders)
         }
     };
 
@@ -301,10 +302,9 @@ async fn failed_db_index_create() {
     let (_, rx) = watch::channel(Arc::new(Config::default()));
     let index_factory = vector_store::new_index_factory_usearch(rx).unwrap();
 
-    let (_config_tx, config_rx) = watch::channel(Arc::new(test_config()));
-
+    let (receivers, _senders) = create_config_channels(test_config()).await;
     let (_server_actor, addr) =
-        vector_store::run(node_state, db_actor, internals, index_factory, config_rx)
+        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
             .await
             .unwrap();
 


### PR DESCRIPTION
vector-store: refactor server config (prerequisite for mTLS API server)

Prerequisite refactoring work for adding an optional mTLS API server
alongside the existing HTTP(S) server.
The upcoming mTLS changes will introduce 3rd receiver returned by
config_manager with the configuration for mTLS server.

No user-visible behavior changes in this PR - the goal is to lay the structural groundwork
so the mTLS server can be introduced as a focused, reviewable follow-up.

VECTOR-490