### PR TITLE
benches: prepare pipeline tests for search while updating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "half",
  "lexical-core",
@@ -241,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-backtrace"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +271,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -477,6 +495,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -487,7 +511,7 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e65938ed058ef47d92cf8b346cc76ef48984572ade631927e9937b5ffc7662c7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blowfish",
  "getrandom 0.2.16",
  "subtle",
@@ -639,6 +663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,7 +762,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -740,6 +770,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -770,6 +809,55 @@ name = "compression-core"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9b614a5787ef0c8802a55766480563cb3a93b435898c422ed2a359cf811582"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "console-api"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4915b7d8dd960457a1b6c380114c2944f728e7c65294ab247ae6b6f1f37592"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "hyper-util",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "const-hex"
@@ -896,6 +984,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -1194,6 +1291,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1474,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1379,6 +1524,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1688,10 +1843,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1773,6 +1947,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e05f6bebaf5e4ae9ffac23c348518ceda3775c3b5edabdd95c3c0abee0c040"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "hotpath"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28594d8a3d30371e1488dcd6ba545bf07e9ce9dff6d8a57d70dbbaa221d3246d"
+dependencies = [
+ "arc-swap",
+ "async-channel",
+ "cfg-if",
+ "clap",
+ "colored",
+ "crossbeam-channel",
+ "eyre",
+ "futures-channel",
+ "futures-util",
+ "hdrhistogram",
+ "hotpath-macros",
+ "libc",
+ "mach2",
+ "pin-project-lite",
+ "prettytable-rs",
+ "quanta",
+ "regex",
+ "serde",
+ "serde_json",
+ "tiny_http",
+ "tokio",
+]
+
+[[package]]
+name = "hotpath-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7b87d58f92c09858091f328521db329955e9fc960c3c9c55e5dc0ef228a37b0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1894,12 +2108,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2055,6 +2282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,6 +2351,17 @@ checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2313,6 +2557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,6 +2639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "macros"
 version = "0.0.0-dev"
 dependencies = [
@@ -2438,6 +2697,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2514,6 +2779,16 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2727,7 +3002,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62b025c3503d3d53eaba3b6f14adb955af9f69fc71141b4d030a4e5331f5d42"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "dyn-clone",
  "lazy_static",
@@ -2759,6 +3034,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2797,7 +3078,7 @@ dependencies = [
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
@@ -2830,7 +3111,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2988,6 +3269,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3352,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3401,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -3218,6 +3559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,6 +3607,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3315,7 +3676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3760,7 +4121,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3989,6 +4350,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4009,6 +4381,7 @@ version = "0.0.0-dev"
 dependencies = [
  "axum",
  "axum-test",
+ "hotpath",
  "httpapi",
 ]
 
@@ -4113,6 +4486,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,6 +4546,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4262,6 +4648,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,9 +4695,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.12.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4284,7 +4713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "bytes",
  "futures-core",
@@ -4477,6 +4906,12 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -4572,7 +5007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -4673,12 +5108,14 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "clap",
+ "console-subscriber",
  "const-hex",
  "criterion",
  "dashmap 6.1.0",
  "derive_more",
  "dotenvy",
  "futures",
+ "hotpath",
  "httpapi",
  "httpclient",
  "humantime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,6 +4004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "testclient"
+version = "0.0.0-dev"
+dependencies = [
+ "axum",
+ "axum-test",
+ "httpapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4705,6 +4705,7 @@ dependencies = [
  "tap",
  "temp-env",
  "tempfile",
+ "testclient",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -264,7 +264,7 @@ checksum = "affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -404,17 +404,18 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "axum-server"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -422,7 +423,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -431,9 +431,8 @@ dependencies = [
 
 [[package]]
 name = "axum-server-dual-protocol"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2164551db024e87f20316d164eab9f5ad342d8188b08051ceb15ca92a60ea7b7"
+version = "0.8.0"
+source = "git+https://github.com/vinchona/axum-server-dual-protocol?rev=ca6db055254255b74238673ce4135698e347d71c#ca6db055254255b74238673ce4135698e347d71c"
 dependencies = [
  "axum-server",
  "bytes",
@@ -446,6 +445,34 @@ dependencies = [
  "tokio-util",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-test"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a86bfe2ef15bee102ac34912f7f4542b0bb37dc464fa55461763999c4d625e7"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "expect-json",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -482,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -551,6 +578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -673,7 +706,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -777,6 +810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -922,7 +965,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -936,7 +979,7 @@ dependencies = [
  "indexmap 2.12.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -954,7 +997,7 @@ dependencies = [
  "indexmap 2.12.0",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -988,7 +1031,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1002,7 +1045,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1013,7 +1056,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1024,7 +1067,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1078,7 +1121,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1099,7 +1142,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1109,7 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1130,9 +1173,15 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1152,7 +1201,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1268,10 +1317,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -1281,6 +1350,35 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "expect-json"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869f97f4abe8e78fc812a94ad6b721d72c4fb5532877c79610f2c238d7ccf6c4"
+dependencies = [
+ "chrono",
+ "email_address",
+ "expect-json-macros",
+ "num",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "typetag",
+ "uuid",
+]
+
+[[package]]
+name = "expect-json-macros"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6fdf550180a6c29a28cb9aac262dc0064c25735641d2317f670075e9a469d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1382,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1392,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -1409,38 +1507,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1450,7 +1548,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1527,7 +1624,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1619,7 +1716,7 @@ dependencies = [
  "ipnet",
  "jni",
  "rand 0.10.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1640,7 +1737,7 @@ dependencies = [
  "rand 0.10.1",
  "ring",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -1662,7 +1759,7 @@ dependencies = [
  "ipnet",
  "prefix-trie",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-util",
@@ -1680,12 +1777,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1760,9 +1856,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1775,7 +1871,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1800,14 +1895,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1999,6 +2093,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,7 +2162,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -2074,7 +2177,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2093,7 +2196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2108,10 +2211,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2285,7 +2390,7 @@ name = "macros"
 version = "0.0.0-dev"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2378,7 +2483,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2408,7 +2513,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2572,7 +2677,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2752,7 +2857,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2760,12 +2865,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2869,13 +2968,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2906,14 +3015,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2930,7 +3039,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2941,7 +3050,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2982,7 +3091,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2997,13 +3106,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3025,9 +3134,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3046,9 +3155,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
@@ -3167,14 +3276,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3241,6 +3350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "reserve-port"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,7 +3392,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.110",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -3286,6 +3404,21 @@ checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "sha2",
  "walkdir",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdaa068902270ca7fa8619775e1838e23a63620abac0947ce0f715819b8cec"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "mime",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3336,15 +3469,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -3447,13 +3571,13 @@ dependencies = [
  "hashbrown 0.15.5",
  "histogram",
  "itertools 0.14.0",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_pcg",
  "rustls",
  "scylla-cql",
  "smallvec",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -3495,7 +3619,7 @@ dependencies = [
  "scylla-macros",
  "snap",
  "stable_deref_trait",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "uuid",
@@ -3511,7 +3635,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3526,9 +3650,9 @@ dependencies = [
  "chrono",
  "futures",
  "num-bigint 0.3.3",
- "rand 0.9.3",
+ "rand 0.9.4",
  "scylla-cql",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -3582,20 +3706,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3658,7 +3782,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3793,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3819,7 +3943,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3890,11 +4014,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3905,18 +4029,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4016,9 +4140,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4039,7 +4163,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4130,9 +4254,9 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4146,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64",
@@ -4207,7 +4331,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4267,7 +4391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4283,10 +4407,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "unarray"
@@ -4332,14 +4486,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4398,7 +4553,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4428,12 +4583,12 @@ checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4456,7 +4611,7 @@ dependencies = [
  "humantime",
  "itertools 0.14.0",
  "parquet",
- "rand 0.9.3",
+ "rand 0.10.1",
  "scylla",
  "serde",
  "tap",
@@ -4505,6 +4660,7 @@ dependencies = [
  "axum",
  "axum-server",
  "axum-server-dual-protocol",
+ "axum-test",
  "bigdecimal",
  "chrono",
  "clap",
@@ -4524,7 +4680,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "opensearch",
  "prometheus",
- "rand 0.9.3",
+ "rand 0.10.1",
  "rayon",
  "rcgen",
  "regex",
@@ -4540,7 +4696,7 @@ dependencies = [
  "tap",
  "temp-env",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tower-http",
@@ -4611,9 +4767,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4624,22 +4780,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4647,22 +4800,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -4703,9 +4856,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4824,7 +4977,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4835,7 +4988,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5145,7 +5298,7 @@ dependencies = [
  "heck",
  "indexmap 2.12.0",
  "prettyplease",
- "syn 2.0.110",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5161,7 +5314,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5210,6 +5363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5237,7 +5396,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5258,7 +5417,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5278,7 +5437,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -5318,7 +5477,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5340,6 +5499,12 @@ name = "zlib-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ bigdecimal = "0.4"
 const-hex = "1.18.1"
 clap = { version = "4.5.40", features = ["derive"] }
 chrono = "0.4.43"
+console-subscriber = "0.5.0"
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
@@ -38,6 +39,7 @@ e2etest-tls = { path = "crates/e2etest-tls" }
 e2etest-vector-store-cluster = { path = "crates/e2etest-vector-store-cluster" }
 futures = "0.3.31"
 hickory-server = "0.26.1"
+hotpath = { version = "0.15.0", features = ["tokio", "futures", "async-channel"] }
 httpapi = { path = "crates/httpapi" }
 httpclient = { path = "crates/httpclient" }
 humantime = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ anyhow = "1.0.97"
 arrow-array = "56.0.0"
 async-backtrace = "0.2.7"
 async-trait = "0.1.88"
-axum = { version = "0.8.1", features = ["macros"] }
-axum-server = { version = "0.7.2", features = ["tls-rustls"] }
-axum-server-dual-protocol = "0.7.0"
+axum = { version = "0.8.8", features = ["macros"] }
+axum-server = { version = "0.8.0", features = ["tls-rustls"] }
+axum-server-dual-protocol = "0.8.0"
+axum-test = "20.0.0"
 bcrypt = "0.15"
 bigdecimal = "0.4"
 const-hex = "1.18.1"
@@ -53,7 +54,7 @@ opensearch = { version = "2.3.0", default-features = false, features = ["rustls-
 parquet = { version = "56.0.0", features = ["async"] }
 prometheus = "0.14"
 quote = "1.0"
-rand = "0.9.2"
+rand = "0.10.1"
 rcgen = "0.14.5"
 regex = "1.11.1"
 reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls"] }
@@ -83,3 +84,7 @@ uuid = "1.16.0"
 vector-store = { path = "crates/vector-store" }
 secrecy = "0.10.3"
 rayon = "1.11.0"
+
+[patch.crates-io]
+# Currently, axum-server-dual-protocol doesn't have a published version that supports axum 0.8, so we need to use the git version from the PR.
+axum-server-dual-protocol = { git = "https://github.com/vinchona/axum-server-dual-protocol", rev = "ca6db055254255b74238673ce4135698e347d71c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ syn = { version = "2.0", features = ["full"] }
 sysinfo = "0.37.2"
 tap = "1.0.1"
 tempfile = "3.20.0"
+testclient = { path = "crates/testclient" }
 thiserror = "2.0.12"
 time = { version = "0.3.41", features = ["formatting", "parsing"] }
 tokio = { version = "1.44.2", features = ["full"] }

--- a/crates/testclient/Cargo.toml
+++ b/crates/testclient/Cargo.toml
@@ -7,7 +7,11 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+hotpath = ["hotpath/hotpath"]
+
 [dependencies]
 axum.workspace = true
 axum-test.workspace = true
+hotpath.workspace = true
 httpapi.workspace = true

--- a/crates/testclient/Cargo.toml
+++ b/crates/testclient/Cargo.toml
@@ -1,0 +1,13 @@
+# Copyright 2026-present ScyllaDB
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+[package]
+name = "testclient"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+axum.workspace = true
+axum-test.workspace = true
+httpapi.workspace = true

--- a/crates/testclient/src/lib.rs
+++ b/crates/testclient/src/lib.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use axum::Router;
+use axum_test::TestResponse;
+use axum_test::TestServer;
+use httpapi::IndexName;
+use httpapi::KeyspaceName;
+use httpapi::Limit;
+use httpapi::PostIndexAnnFilter;
+use httpapi::PostIndexAnnRequest;
+use httpapi::Vector;
+
+#[derive(Debug)]
+pub struct TestClient {
+    test_server: TestServer,
+    url_api: String,
+}
+
+impl TestClient {
+    pub fn new(router: Router) -> Self {
+        Self {
+            url_api: "/api/v1".to_string(),
+            test_server: TestServer::new(router),
+        }
+    }
+
+    pub async fn index_status(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+    ) -> TestResponse {
+        self.test_server
+            .get(&format!(
+                "{}/indexes/{}/{}/status",
+                self.url_api, keyspace_name, index_name
+            ))
+            .await
+    }
+
+    pub async fn ann(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+        vector: Vector,
+        filter: Option<PostIndexAnnFilter>,
+        limit: Limit,
+    ) -> TestResponse {
+        self.test_server
+            .post(&format!(
+                "{}/indexes/{}/{}/ann",
+                self.url_api, keyspace_name, index_name
+            ))
+            .json(&PostIndexAnnRequest {
+                vector,
+                filter,
+                limit,
+            })
+            .await
+    }
+}

--- a/crates/testclient/src/lib.rs
+++ b/crates/testclient/src/lib.rs
@@ -27,6 +27,7 @@ impl TestClient {
         }
     }
 
+    #[hotpath::measure]
     pub async fn index_status(
         &self,
         keyspace_name: &KeyspaceName,
@@ -40,6 +41,7 @@ impl TestClient {
             .await
     }
 
+    #[hotpath::measure]
     pub async fn ann(
         &self,
         keyspace_name: &KeyspaceName,

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -78,5 +78,6 @@ reqwest.workspace = true
 httpclient.workspace = true
 tempfile.workspace = true
 temp-env = "0.3.6"
+testclient.workspace = true
 tracing-test.workspace = true
 rcgen.workspace = true

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -22,6 +22,8 @@ harness = false
 [features]
 default = []
 dev-tools = []
+hotpath = ["hotpath/hotpath"]
+console = ["console-subscriber"]
 slow-test-hooks = []
 
 [dependencies]
@@ -34,10 +36,12 @@ bigdecimal.workspace = true
 clap.workspace = true
 chrono.workspace = true
 const-hex.workspace = true
+console-subscriber = {workspace = true, optional = true}
 dashmap.workspace = true
 derive_more.workspace = true
 dotenvy.workspace = true
 futures.workspace = true
+hotpath.workspace = true
 httpapi.workspace = true
 humantime.workspace = true
 itertools.workspace = true

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -70,6 +70,7 @@ uuid.workspace = true
 rayon.workspace = true
 
 [dev-dependencies]
+axum-test.workspace = true
 criterion.workspace = true
 mockall.workspace = true
 ntest.workspace = true

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -20,6 +20,7 @@ use futures::StreamExt;
 use futures::stream;
 use httpapi::IndexStatus;
 use httpapi::IndexStatusResponse;
+use itertools::Itertools;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
 use std::cell::RefCell;
@@ -28,6 +29,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Once;
 use std::sync::atomic::AtomicI64;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
@@ -35,7 +37,6 @@ use tap::Pipe;
 use testclient::TestClient;
 use tokio::runtime::Runtime;
 use tokio::sync::Notify;
-use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
@@ -490,18 +491,25 @@ where
     F: Fn(u64) -> Fut + Clone + Send + Sync + 'static,
     Fut: std::future::Future<Output = Duration> + Send + 'static,
 {
-    let semaphore = Arc::new(Semaphore::new(concurrency));
-    let mut tasks = Vec::new();
-    for it in 0..iters {
-        let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
-        let f = f.clone();
-        tasks.push(tokio::spawn(async move {
-            let duration = f(it).await;
-            drop(permit);
-            duration
-        }));
-    }
-    _ = semaphore.acquire_many(concurrency as u32).await.unwrap();
+    let counter = Arc::new(AtomicU64::new(0));
+    let tasks = (0..concurrency)
+        .map(|_| {
+            let counter = Arc::clone(&counter);
+            let f = f.clone();
+            tokio::spawn(async move {
+                let mut durations = Vec::new();
+                loop {
+                    let it = counter.fetch_add(1, Ordering::Relaxed);
+                    if it >= iters {
+                        break;
+                    }
+                    let duration = f(it).await;
+                    durations.push(duration);
+                }
+                durations.into_iter().fold(Duration::ZERO, |acc, x| acc + x)
+            })
+        })
+        .collect_vec();
     stream::iter(tasks.into_iter())
         .then(|task| async move { task.await.unwrap() })
         .fold(Duration::ZERO, |acc, x| async move { acc + x })

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -11,7 +11,6 @@ use axum::http::StatusCode;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::criterion_group;
-use criterion::criterion_main;
 use db_basic::DbBasic;
 use db_basic::ScanFn;
 use db_basic::Table;
@@ -41,9 +40,6 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task;
-use tracing_subscriber::EnvFilter;
-use tracing_subscriber::fmt;
-use tracing_subscriber::prelude::*;
 use uuid::Uuid;
 use vector_store::AsyncInProgress;
 use vector_store::ColumnName;
@@ -76,10 +72,20 @@ fn init() {
     INIT.call_once(|| {
         _ = dotenvy::dotenv();
 
-        tracing_subscriber::registry()
-            .with(EnvFilter::try_new("none").unwrap())
-            .with(fmt::layer().with_target(false))
-            .init();
+        #[cfg(feature = "console")]
+        console_subscriber::init();
+
+        #[cfg(not(feature = "console"))]
+        {
+            use tracing_subscriber::EnvFilter;
+            use tracing_subscriber::fmt;
+            use tracing_subscriber::prelude::*;
+
+            tracing_subscriber::registry()
+                .with(EnvFilter::try_new("none").unwrap())
+                .with(fmt::layer().with_target(false))
+                .init();
+        }
     });
 }
 
@@ -102,7 +108,7 @@ fn default_runtime() -> Runtime {
             .unwrap();
     });
 
-    tokio::runtime::Builder::new_multi_thread()
+    let runtime = tokio::runtime::Builder::new_multi_thread()
         .pipe(|mut b| {
             if let Some(threads) = threads {
                 b.worker_threads(threads);
@@ -111,7 +117,9 @@ fn default_runtime() -> Runtime {
         })
         .enable_all()
         .build()
-        .unwrap()
+        .unwrap();
+    hotpath::tokio_runtime!(runtime.handle());
+    runtime
 }
 
 fn default_index_metadata(dimensions: usize) -> IndexMetadata {
@@ -486,6 +494,7 @@ fn search(c: &mut Criterion) {
     }
 }
 
+#[hotpath::measure]
 async fn run_with_concurrency<F, Fut>(concurrency: usize, iters: u64, f: F) -> Duration
 where
     F: Fn(u64) -> Fut + Clone + Send + Sync + 'static,
@@ -517,4 +526,10 @@ where
 }
 
 criterion_group!(benches, fullscan_add, search);
-criterion_main!(benches);
+
+#[hotpath::main]
+fn main() {
+    benches();
+
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -7,6 +7,7 @@
 #[allow(dead_code)]
 mod db_basic;
 
+use axum::http::StatusCode;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::criterion_group;
@@ -18,9 +19,10 @@ use futures::FutureExt;
 use futures::StreamExt;
 use futures::stream;
 use httpapi::IndexStatus;
-use httpclient::HttpClient;
+use httpapi::IndexStatusResponse;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
+use std::cell::RefCell;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -30,6 +32,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 use tap::Pipe;
+use testclient::TestClient;
 use tokio::runtime::Runtime;
 use tokio::sync::Notify;
 use tokio::sync::Semaphore;
@@ -51,6 +54,7 @@ use vector_store::DbIndexType;
 use vector_store::ExpansionAdd;
 use vector_store::ExpansionSearch;
 use vector_store::HttpServerConfig;
+use vector_store::HttpServerExt;
 use vector_store::IndexMetadata;
 use vector_store::PrimaryKey;
 use vector_store::Quantization;
@@ -180,7 +184,7 @@ async fn run_vector_store(
     config: watch::Receiver<Arc<Config>>,
     node_state: mpsc::Sender<NodeState>,
     db: mpsc::Sender<Db>,
-) -> (impl Sized, HttpClient) {
+) -> (impl Sized, Arc<TestClient>) {
     let internals = vector_store::new_internals();
     let index_factory = vector_store::new_index_factory_usearch(config.clone()).unwrap();
 
@@ -191,48 +195,54 @@ async fn run_vector_store(
         http: http_rx,
     };
 
-    let (server, addr) = vector_store::run(node_state, db, internals, index_factory, receivers)
+    let (server, _) = vector_store::run(node_state, db, internals, index_factory, receivers)
         .await
         .unwrap();
 
-    ((http_tx, server), HttpClient::new(addr))
+    let client = Arc::new(TestClient::new(server.router().await));
+    ((http_tx, server), client)
 }
 
 async fn wait_until_index_is_created(
-    client: &HttpClient,
+    client: &TestClient,
     keyspace_name: &httpapi::KeyspaceName,
     index_name: &httpapi::IndexName,
 ) {
-    while client
-        .index_status(keyspace_name, index_name)
-        .await
-        .is_err()
-    {
+    loop {
+        let response = client.index_status(keyspace_name, index_name).await;
+        if response.status_code() == StatusCode::OK {
+            break;
+        }
         task::yield_now().await;
     }
 }
 
 async fn wait_until_index_is_ready(
-    client: &HttpClient,
+    client: &TestClient,
     keyspace_name: &httpapi::KeyspaceName,
     index_name: &httpapi::IndexName,
 ) {
-    while client
-        .index_status(keyspace_name, index_name)
-        .await
-        .map(|status| status.status != IndexStatus::Serving)
-        .unwrap_or(true)
-    {
+    loop {
+        let response = client.index_status(keyspace_name, index_name).await;
+        if response.status_code() == StatusCode::OK
+            && response.json::<IndexStatusResponse>().status == IndexStatus::Serving
+        {
+            break;
+        }
         task::yield_now().await;
     }
 }
 
 async fn wait_until_index_is_removed(
-    client: &HttpClient,
+    client: &TestClient,
     keyspace_name: &httpapi::KeyspaceName,
     index_name: &httpapi::IndexName,
 ) {
-    while client.index_status(keyspace_name, index_name).await.is_ok() {
+    loop {
+        let response = client.index_status(keyspace_name, index_name).await;
+        if response.status_code() != StatusCode::OK {
+            break;
+        }
         task::yield_now().await;
     }
 }
@@ -283,7 +293,7 @@ fn fullscan_add(c: &mut Criterion) {
     let fixture = LazyLock::new(|| {
         let runtime = default_runtime();
         let notify_stop = Arc::new(Notify::new());
-        let (tx_db_client, rx_db_client) = oneshot::channel();
+        let (tx_fixture, rx_fixture) = oneshot::channel();
         runtime.spawn({
             let index_metadata = index_metadata.clone();
             let notify_stop = notify_stop.clone();
@@ -307,12 +317,12 @@ fn fullscan_add(c: &mut Criterion) {
                 let index_name = index_metadata.index_name.clone().into();
                 wait_until_index_is_created(&client, &keyspace_name, &index_name).await;
 
-                tx_db_client.send((db, client, tx)).unwrap();
+                tx_fixture.send((db, client, tx)).unwrap();
                 notify_stop.notified().await;
             }
         });
-        let (db, client, tx) = rx_db_client.blocking_recv().unwrap();
-        (runtime, notify_stop, db, client, tx)
+        let (db, client, tx) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, db, client, tx)))
     });
 
     let next_pk = Arc::new(AtomicI64::new(0));
@@ -320,7 +330,8 @@ fn fullscan_add(c: &mut Criterion) {
         BenchmarkId::new("fullscan-add", concurrency),
         &concurrency,
         |b, concurrency| {
-            let (runtime, _, _, _, tx) = &*fixture;
+            let fixture = fixture.borrow();
+            let (runtime, _, _, _, tx) = fixture.as_ref().unwrap();
             b.to_async(runtime).iter_custom(|iters| {
                 let tx = tx.clone();
                 let next_pk = Arc::clone(&next_pk);
@@ -349,17 +360,19 @@ fn fullscan_add(c: &mut Criterion) {
         },
     );
 
-    if let Some((runtime, notify_stop, db, client, _)) = LazyLock::get(&fixture) {
-        delete_index(db, &index_metadata);
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, db, client, _) = fixture.take().unwrap();
+        delete_index(&db, &index_metadata);
         let keyspace_name = index_metadata.keyspace_name.clone().into();
         let index_name = index_metadata.index_name.clone().into();
         runtime.block_on(wait_until_index_is_removed(
-            client,
+            &client,
             &keyspace_name,
             &index_name,
         ));
         notify_stop.notify_one();
-        wait_until_all_tasks_finished(runtime);
+        drop(client);
+        wait_until_all_tasks_finished(&runtime);
     }
 }
 
@@ -377,7 +390,7 @@ fn search(c: &mut Criterion) {
     let fixture = LazyLock::new(|| {
         let runtime = default_runtime();
         let notify_stop = Arc::new(Notify::new());
-        let (tx_client, rx_client) = oneshot::channel();
+        let (tx_fixture, rx_fixture) = oneshot::channel();
         let (tx, rx) = mpsc::channel(runtime.metrics().num_workers() * 2);
         runtime.spawn({
             let notify_stop = notify_stop.clone();
@@ -416,21 +429,21 @@ fn search(c: &mut Criterion) {
                 let index_name = index_metadata.index_name.clone().into();
                 wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
 
-                tx_client.send((db, client)).unwrap();
+                tx_fixture.send((db, client)).unwrap();
                 notify_stop.notified().await;
             }
         });
-        let (db, client) = rx_client.blocking_recv().unwrap();
-        (runtime, notify_stop, db, client)
+        let (db, client) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, db, client)))
     });
 
     group.bench_with_input(
         BenchmarkId::new("search", concurrency),
         &concurrency,
         |b, concurrency| {
-            let (runtime, _, _, client) = &*fixture;
+            let fixture = fixture.borrow();
+            let (runtime, _, _, client) = fixture.as_ref().unwrap();
             let index_metadata = index_metadata.clone();
-            let client = client.clone();
             b.to_async(runtime).iter_custom(|iters| {
                 let index_metadata = index_metadata.clone();
                 let client = client.clone();
@@ -442,10 +455,12 @@ fn search(c: &mut Criterion) {
                         async move {
                             let vector = vec![it as f32; DIMENSIONS];
                             let start = Instant::now();
-                            _ = client
+                            let response = client
                                 .ann(&keyspace_name, &index_name, vector.into(), None, limit)
                                 .await;
-                            start.elapsed()
+                            let elapsed = start.elapsed();
+                            response.assert_status_ok();
+                            elapsed
                         }
                     })
                     .await
@@ -454,17 +469,19 @@ fn search(c: &mut Criterion) {
         },
     );
 
-    if let Some((runtime, notify_stop, db, client)) = LazyLock::get(&fixture) {
-        delete_index(db, &index_metadata);
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, db, client) = fixture.take().unwrap();
+        delete_index(&db, &index_metadata);
         let keyspace_name = index_metadata.keyspace_name.clone().into();
         let index_name = index_metadata.index_name.clone().into();
         runtime.block_on(wait_until_index_is_removed(
-            client,
+            &client,
             &keyspace_name,
             &index_name,
         ));
         notify_stop.notify_one();
-        wait_until_all_tasks_finished(runtime);
+        drop(client);
+        wait_until_all_tasks_finished(&runtime);
     }
 }
 

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -153,6 +153,7 @@ fn default_concurrency() -> usize {
         .and_then(|s| s.parse().ok())
         .unwrap_or(1)
 }
+
 fn setup_table(
     db: &DbBasic,
     index: &IndexMetadata,
@@ -494,6 +495,638 @@ fn search(c: &mut Criterion) {
     }
 }
 
+fn cdc_add(c: &mut Criterion) {
+    init();
+
+    const DIMENSIONS: usize = 128;
+    let concurrency = default_concurrency();
+    let index_metadata = default_index_metadata(DIMENSIONS);
+
+    let mut group = c.benchmark_group("pipeline");
+    group.throughput(criterion::Throughput::Elements(concurrency as u64));
+
+    let fixture = LazyLock::new(|| {
+        let runtime = default_runtime();
+        let notify_stop = Arc::new(Notify::new());
+        let (tx_fixture, rx_fixture) = oneshot::channel();
+        runtime.spawn({
+            let index_metadata = index_metadata.clone();
+            let notify_stop = notify_stop.clone();
+            async move {
+                let node_state = vector_store::new_node_state().await;
+                let (db_actor, db) = db_basic::new(node_state.clone());
+                setup_table(
+                    &db,
+                    &index_metadata,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                let (_config_tx, config_rx) = watch::channel(default_config().await);
+                let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
+
+                let (tx, rx) = mpsc::channel(concurrency);
+
+                setup_index(&db, index_metadata.clone(), None, Some(scan_fn_mpsc(rx)));
+                let keyspace_name = index_metadata.keyspace_name.clone().into();
+                let index_name = index_metadata.index_name.clone().into();
+                wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
+
+                tx_fixture.send((db, client, tx)).unwrap();
+                notify_stop.notified().await;
+            }
+        });
+        let (db, client, tx) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, db, client, tx)))
+    });
+
+    let next_pk = Arc::new(AtomicI64::new(0));
+    group.bench_with_input(
+        BenchmarkId::new("cdc-add", concurrency),
+        &concurrency,
+        |b, concurrency| {
+            let fixture = fixture.borrow();
+            let (runtime, _, _, _, tx) = fixture.as_ref().unwrap();
+            b.to_async(runtime).iter_custom(|iters| {
+                let tx = tx.clone();
+                let next_pk = Arc::clone(&next_pk);
+                async move {
+                    run_with_concurrency(*concurrency, iters, move |it| {
+                        let tx = tx.clone();
+                        let pk = next_pk.fetch_add(1, Ordering::Relaxed);
+                        async move {
+                            let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                            let request = (
+                                [(CqlValue::BigInt(pk))].into_iter().collect(),
+                                Some(vec![it as f32; DIMENSIONS].into()),
+                                Timestamp::from_unix_timestamp(0),
+                                Some(tx_in_progress.into()),
+                            );
+                            let start = Instant::now();
+                            tx.send(request).await.unwrap();
+                            // wait until in-progress marker is dropped
+                            while rx_in_progress.recv().await.is_some() {}
+                            start.elapsed()
+                        }
+                    })
+                    .await
+                }
+            });
+        },
+    );
+
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, db, client, _) = fixture.take().unwrap();
+        delete_index(&db, &index_metadata);
+        let keyspace_name = index_metadata.keyspace_name.clone().into();
+        let index_name = index_metadata.index_name.clone().into();
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name,
+            &index_name,
+        ));
+        notify_stop.notify_one();
+        drop(client);
+        wait_until_all_tasks_finished(&runtime);
+    }
+}
+
+fn cdc_update(c: &mut Criterion) {
+    init();
+
+    const DIMENSIONS: usize = 1536;
+    const INDEX_SIZE: usize = 100000;
+    let concurrency = default_concurrency();
+    let index_metadata = default_index_metadata(DIMENSIONS);
+
+    let mut group = c.benchmark_group("pipeline");
+    group.throughput(criterion::Throughput::Elements(concurrency as u64));
+
+    let fixture = LazyLock::new(|| {
+        let runtime = default_runtime();
+        let notify_stop = Arc::new(Notify::new());
+        let (tx_fixture, rx_fixture) = oneshot::channel();
+        let (tx_fullscan, rx_fullscan) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let (tx_cdc, rx_cdc) = mpsc::channel(concurrency);
+        runtime.spawn({
+            let notify_stop = notify_stop.clone();
+            let index_metadata = index_metadata.clone();
+            async move {
+                let node_state = vector_store::new_node_state().await;
+                let (db_actor, db) = db_basic::new(node_state.clone());
+                setup_table(
+                    &db,
+                    &index_metadata,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                setup_index(
+                    &db,
+                    index_metadata.clone(),
+                    Some(scan_fn_mpsc(rx_fullscan)),
+                    Some(scan_fn_mpsc(rx_cdc)),
+                );
+                let (_config_tx, config_rx) = watch::channel(default_config().await);
+                let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
+
+                let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                for it in 0..INDEX_SIZE {
+                    tx_fullscan
+                        .send((
+                            [(CqlValue::BigInt(it as i64))].into_iter().collect(),
+                            Some(vec![it as f32; DIMENSIONS].into()),
+                            Timestamp::from_unix_timestamp(0),
+                            Some(tx_in_progress.clone().into()),
+                        ))
+                        .await
+                        .unwrap();
+                }
+                // wait until all in-progress markers are dropped
+                drop(tx_in_progress);
+                while rx_in_progress.recv().await.is_some() {}
+
+                drop(tx_fullscan);
+                let keyspace_name = index_metadata.keyspace_name.clone().into();
+                let index_name = index_metadata.index_name.clone().into();
+                wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
+
+                tx_fixture.send((db, client)).unwrap();
+                notify_stop.notified().await;
+            }
+        });
+        let (db, client) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, db, client, tx_cdc)))
+    });
+
+    let next_timestamp = Arc::new(AtomicU64::new(0));
+    group.bench_with_input(
+        BenchmarkId::new("cdc-update", concurrency),
+        &concurrency,
+        |b, concurrency| {
+            let fixture = fixture.borrow();
+            let (runtime, _, _, _, tx_cdc) = fixture.as_ref().unwrap();
+            let next_timestamp = Arc::clone(&next_timestamp);
+            b.to_async(runtime).iter_custom(|iters| {
+                let next_timestamp = Arc::clone(&next_timestamp);
+                let tx_cdc = tx_cdc.clone();
+                async move {
+                    run_with_concurrency(*concurrency, iters, move |it| {
+                        let next_timestamp = Arc::clone(&next_timestamp);
+                        let tx_cdc = tx_cdc.clone();
+                        async move {
+                            let id = rand::random_range(0..INDEX_SIZE) as i64;
+                            let vector = vec![it as f32; DIMENSIONS].into();
+                            let timestamp = next_timestamp.fetch_add(1, Ordering::Relaxed);
+                            let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                            let start = Instant::now();
+                            tx_cdc
+                                .send((
+                                    [(CqlValue::BigInt(id))].into_iter().collect(),
+                                    Some(vector),
+                                    Timestamp::from_unix_timestamp(timestamp),
+                                    Some(tx_in_progress.clone().into()),
+                                ))
+                                .await
+                                .unwrap();
+                            // wait until the in-progress marker is dropped
+                            drop(tx_in_progress);
+                            while rx_in_progress.recv().await.is_some() {}
+                            start.elapsed()
+                        }
+                    })
+                    .await
+                }
+            })
+        },
+    );
+
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, db, client, _) = fixture.take().unwrap();
+        delete_index(&db, &index_metadata);
+        let keyspace_name = index_metadata.keyspace_name.clone().into();
+        let index_name = index_metadata.index_name.clone().into();
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name,
+            &index_name,
+        ));
+        notify_stop.notify_one();
+        drop(client);
+        wait_until_all_tasks_finished(&runtime);
+    }
+}
+
+fn search_while_updating(c: &mut Criterion) {
+    init();
+
+    const DIMENSIONS: usize = 1536;
+    const INDEX_SIZE: usize = 100000;
+    let concurrency = default_concurrency();
+    let index_metadata = default_index_metadata(DIMENSIONS);
+    let index_metadata_bg = IndexMetadata {
+        table_name: "tbl_bg".into(),
+        index_name: "idx_bg".into(),
+        ..default_index_metadata(DIMENSIONS)
+    };
+    let limit = NonZeroUsize::new(1).unwrap().into();
+
+    let mut group = c.benchmark_group("pipeline");
+    group.throughput(criterion::Throughput::Elements(concurrency as u64));
+
+    let fixture = LazyLock::new(|| {
+        let runtime = default_runtime();
+        let notify_stop = Arc::new(Notify::new());
+        let (tx_fixture, rx_fixture) = oneshot::channel();
+        let (tx_fullscan, rx_fullscan) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let (tx_cdc, rx_cdc) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let (tx_fullscan_bg, rx_fullscan_bg) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let (tx_cdc_bg, rx_cdc_bg) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        runtime.spawn({
+            let notify_stop = notify_stop.clone();
+            let index_metadata = index_metadata.clone();
+            let index_metadata_bg = index_metadata_bg.clone();
+            async move {
+                let node_state = vector_store::new_node_state().await;
+                let (db_actor, db) = db_basic::new(node_state.clone());
+
+                setup_table(
+                    &db,
+                    &index_metadata,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                setup_index(
+                    &db,
+                    index_metadata.clone(),
+                    Some(scan_fn_mpsc(rx_fullscan)),
+                    Some(scan_fn_mpsc(rx_cdc)),
+                );
+
+                setup_table(
+                    &db,
+                    &index_metadata_bg,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                setup_index(
+                    &db,
+                    index_metadata_bg.clone(),
+                    Some(scan_fn_mpsc(rx_fullscan_bg)),
+                    Some(scan_fn_mpsc(rx_cdc_bg)),
+                );
+
+                let (config_tx, config_rx) = watch::channel(default_config().await);
+                let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
+
+                let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                for it in 0..INDEX_SIZE {
+                    tx_fullscan
+                        .send((
+                            [(CqlValue::BigInt(it as i64))].into_iter().collect(),
+                            Some(vec![it as f32; DIMENSIONS].into()),
+                            Timestamp::from_unix_timestamp(0),
+                            Some(tx_in_progress.clone().into()),
+                        ))
+                        .await
+                        .unwrap();
+                    tx_fullscan_bg
+                        .send((
+                            [(CqlValue::BigInt(it as i64))].into_iter().collect(),
+                            Some(vec![it as f32; DIMENSIONS].into()),
+                            Timestamp::from_unix_timestamp(0),
+                            Some(tx_in_progress.clone().into()),
+                        ))
+                        .await
+                        .unwrap();
+                }
+                // wait until all in-progress markers are dropped
+                drop(tx_in_progress);
+                while rx_in_progress.recv().await.is_some() {}
+
+                let keyspace_name = index_metadata.keyspace_name.clone().into();
+                let index_name = index_metadata.index_name.clone().into();
+                let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
+                let index_name_bg = index_metadata_bg.index_name.clone().into();
+
+                drop(tx_fullscan);
+                wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
+                drop(tx_fullscan_bg);
+                wait_until_index_is_ready(&client, &keyspace_name_bg, &index_name_bg).await;
+
+                // run updates in the background while searching
+                let cdc_task = tokio::spawn(async move {
+                    let mut next_timestamp = 0;
+                    let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                    while Arc::clone(&notify_stop).notified().now_or_never().is_none() {
+                        let id = rand::random_range(0..INDEX_SIZE) as i64;
+                        let vector = vec![next_timestamp as f32; DIMENSIONS].into();
+                        let timestamp = next_timestamp;
+                        next_timestamp += 1;
+                        if tx_cdc
+                            .send((
+                                [(CqlValue::BigInt(id))].into_iter().collect(),
+                                Some(vector),
+                                Timestamp::from_unix_timestamp(timestamp),
+                                Some(tx_in_progress.clone().into()),
+                            ))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    // wait until all in-progress markers are dropped
+                    drop(tx_in_progress);
+                    while rx_in_progress.recv().await.is_some() {}
+                });
+                let stop_bg = Arc::new(Notify::new());
+                let cdc_task_bg = tokio::spawn({
+                    let stop_bg = Arc::clone(&stop_bg);
+                    async move {
+                        let mut next_timestamp = 0;
+                        let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                        while Arc::clone(&stop_bg).notified().now_or_never().is_none() {
+                            let id = rand::random_range(0..INDEX_SIZE) as i64;
+                            let vector = vec![next_timestamp as f32; DIMENSIONS].into();
+                            let timestamp = next_timestamp;
+                            next_timestamp += 1;
+                            if tx_cdc_bg
+                                .send((
+                                    [(CqlValue::BigInt(id))].into_iter().collect(),
+                                    Some(vector),
+                                    Timestamp::from_unix_timestamp(timestamp),
+                                    Some(tx_in_progress.clone().into()),
+                                ))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        // wait until all in-progress markers are dropped
+                        drop(tx_in_progress);
+                        while rx_in_progress.recv().await.is_some() {}
+                    }
+                });
+                tx_fixture.send((client, config_tx)).unwrap();
+
+                cdc_task.await.unwrap();
+                stop_bg.notify_one();
+                cdc_task_bg.await.unwrap();
+                delete_index(&db, &index_metadata);
+                delete_index(&db, &index_metadata_bg);
+            }
+        });
+        let (client, config_tx) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, client, config_tx)))
+    });
+
+    group.bench_with_input(
+        BenchmarkId::new("search-while-updating", concurrency),
+        &concurrency,
+        |b, concurrency| {
+            let fixture = fixture.borrow();
+            let (runtime, _, client, _) = fixture.as_ref().unwrap();
+            let index_metadata = index_metadata.clone();
+            let client = client.clone();
+            b.to_async(runtime).iter_custom(|iters| {
+                let index_metadata = index_metadata.clone();
+                let client = client.clone();
+                async move {
+                    run_with_concurrency(*concurrency, iters, move |it| {
+                        let keyspace_name = index_metadata.keyspace_name.clone().into();
+                        let index_name = index_metadata.index_name.clone().into();
+                        let client = client.clone();
+                        async move {
+                            let vector = vec![it as f32; DIMENSIONS];
+                            let start = Instant::now();
+                            _ = client
+                                .ann(&keyspace_name, &index_name, vector.into(), None, limit)
+                                .await;
+                            start.elapsed()
+                        }
+                    })
+                    .await
+                }
+            });
+        },
+    );
+
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, client, config_tx) = fixture.take().unwrap();
+        notify_stop.notify_one();
+        let keyspace_name = index_metadata.keyspace_name.clone().into();
+        let index_name = index_metadata.index_name.clone().into();
+        let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
+        let index_name_bg = index_metadata_bg.index_name.clone().into();
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name,
+            &index_name,
+        ));
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name_bg,
+            &index_name_bg,
+        ));
+        drop(client);
+        drop(config_tx);
+        wait_until_all_tasks_finished(&runtime);
+    }
+}
+
+fn search_while_inserting(c: &mut Criterion) {
+    init();
+
+    const DIMENSIONS: usize = 1536;
+    let concurrency = default_concurrency();
+    let index_metadata = default_index_metadata(DIMENSIONS);
+    let index_metadata_bg = IndexMetadata {
+        table_name: "tbl_bg".into(),
+        index_name: "idx_bg".into(),
+        ..default_index_metadata(DIMENSIONS)
+    };
+    let limit = NonZeroUsize::new(1).unwrap().into();
+
+    let mut group = c.benchmark_group("pipeline");
+    group.throughput(criterion::Throughput::Elements(concurrency as u64));
+
+    let fixture = LazyLock::new(|| {
+        let runtime = default_runtime();
+        let notify_stop = Arc::new(Notify::new());
+        let (tx_fixture, rx_fixture) = oneshot::channel();
+        let (tx_cdc, rx_cdc) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let (tx_cdc_bg, rx_cdc_bg) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        runtime.spawn({
+            let notify_stop = notify_stop.clone();
+            let index_metadata = index_metadata.clone();
+            let index_metadata_bg = index_metadata_bg.clone();
+            async move {
+                let node_state = vector_store::new_node_state().await;
+                let (db_actor, db) = db_basic::new(node_state.clone());
+
+                setup_table(
+                    &db,
+                    &index_metadata,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                setup_index(
+                    &db,
+                    index_metadata.clone(),
+                    None,
+                    Some(scan_fn_mpsc(rx_cdc)),
+                );
+
+                setup_table(
+                    &db,
+                    &index_metadata_bg,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                setup_index(
+                    &db,
+                    index_metadata_bg.clone(),
+                    None,
+                    Some(scan_fn_mpsc(rx_cdc_bg)),
+                );
+
+                let (config_tx, config_rx) = watch::channel(default_config().await);
+                let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
+
+                let keyspace_name = index_metadata.keyspace_name.clone().into();
+                let index_name = index_metadata.index_name.clone().into();
+                let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
+                let index_name_bg = index_metadata_bg.index_name.clone().into();
+
+                wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
+                wait_until_index_is_ready(&client, &keyspace_name_bg, &index_name_bg).await;
+
+                // run inserts in the background while searching
+                let cdc_task = tokio::spawn(async move {
+                    let pk = Arc::new(AtomicI64::new(0));
+                    let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                    while Arc::clone(&notify_stop).notified().now_or_never().is_none() {
+                        let pk = pk.fetch_add(1, Ordering::Relaxed);
+                        let vector = vec![pk as f32; DIMENSIONS].into();
+                        let timestamp = Timestamp::from_unix_timestamp(0);
+                        if tx_cdc
+                            .send((
+                                [(CqlValue::BigInt(pk))].into_iter().collect(),
+                                Some(vector),
+                                timestamp,
+                                Some(tx_in_progress.clone().into()),
+                            ))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    // wait until all in-progress markers are dropped
+                    drop(tx_in_progress);
+                    while rx_in_progress.recv().await.is_some() {}
+                });
+                let stop_bg = Arc::new(Notify::new());
+                let cdc_task_bg = tokio::spawn({
+                    let stop_bg = Arc::clone(&stop_bg);
+                    async move {
+                        let pk = Arc::new(AtomicI64::new(0));
+                        let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                        while Arc::clone(&stop_bg).notified().now_or_never().is_none() {
+                            let pk = pk.fetch_add(1, Ordering::Relaxed);
+                            let vector = vec![pk as f32; DIMENSIONS].into();
+                            let timestamp = Timestamp::from_unix_timestamp(0);
+                            if tx_cdc_bg
+                                .send((
+                                    [(CqlValue::BigInt(pk))].into_iter().collect(),
+                                    Some(vector),
+                                    timestamp,
+                                    Some(tx_in_progress.clone().into()),
+                                ))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        // wait until all in-progress markers are dropped
+                        drop(tx_in_progress);
+                        while rx_in_progress.recv().await.is_some() {}
+                    }
+                });
+                tx_fixture.send((client, config_tx)).unwrap();
+
+                cdc_task.await.unwrap();
+                stop_bg.notify_one();
+                cdc_task_bg.await.unwrap();
+                delete_index(&db, &index_metadata);
+                delete_index(&db, &index_metadata_bg);
+            }
+        });
+        let (client, config_tx) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, client, config_tx)))
+    });
+
+    group.bench_with_input(
+        BenchmarkId::new("search-while-inserting", concurrency),
+        &concurrency,
+        |b, concurrency| {
+            let fixture = fixture.borrow();
+            let (runtime, _, client, _) = fixture.as_ref().unwrap();
+            let index_metadata = index_metadata.clone();
+            let client = client.clone();
+            b.to_async(runtime).iter_custom(|iters| {
+                let index_metadata = index_metadata.clone();
+                let client = client.clone();
+                async move {
+                    run_with_concurrency(*concurrency, iters, move |it| {
+                        let keyspace_name = index_metadata.keyspace_name.clone().into();
+                        let index_name = index_metadata.index_name.clone().into();
+                        let client = client.clone();
+                        async move {
+                            let vector = vec![it as f32; DIMENSIONS];
+                            let start = Instant::now();
+                            _ = client
+                                .ann(&keyspace_name, &index_name, vector.into(), None, limit)
+                                .await;
+                            start.elapsed()
+                        }
+                    })
+                    .await
+                }
+            });
+        },
+    );
+
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, client, config_tx) = fixture.take().unwrap();
+        notify_stop.notify_one();
+        let keyspace_name = index_metadata.keyspace_name.clone().into();
+        let index_name = index_metadata.index_name.clone().into();
+        let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
+        let index_name_bg = index_metadata_bg.index_name.clone().into();
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name,
+            &index_name,
+        ));
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name_bg,
+            &index_name_bg,
+        ));
+        drop(client);
+        drop(config_tx);
+        wait_until_all_tasks_finished(&runtime);
+    }
+}
+
 #[hotpath::measure]
 async fn run_with_concurrency<F, Fut>(concurrency: usize, iters: u64, f: F) -> Duration
 where
@@ -525,7 +1158,15 @@ where
         .await
 }
 
-criterion_group!(benches, fullscan_add, search);
+criterion_group!(
+    benches,
+    fullscan_add,
+    search,
+    cdc_add,
+    cdc_update,
+    search_while_updating,
+    search_while_inserting,
+);
 
 #[hotpath::main]
 fn main() {

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -493,6 +493,7 @@ If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
         )
     )
 )]
+#[hotpath::measure]
 async fn post_index_ann(
     State(state): State<RoutesInnerState>,
     extensions: Extensions,

--- a/crates/vector-store/src/httpserver.rs
+++ b/crates/vector-store/src/httpserver.rs
@@ -53,7 +53,7 @@ struct ServerDeps {
 async fn spawn_server_with_retry(
     config: &HttpServerConfig,
     deps: &ServerDeps,
-) -> anyhow::Result<(Handle, SocketAddr, Router)> {
+) -> anyhow::Result<(Handle<SocketAddr>, SocketAddr, Router)> {
     let mut retry_delay = Duration::from_millis(50);
     let max_retries = 10;
 
@@ -181,7 +181,7 @@ pub(crate) async fn new(
 async fn spawn_server(
     config: &HttpServerConfig,
     deps: &ServerDeps,
-) -> anyhow::Result<(Handle, SocketAddr, Router)> {
+) -> anyhow::Result<(Handle<SocketAddr>, SocketAddr, Router)> {
     let protocol = config.protocol_label();
     let addr = config.addr;
 

--- a/crates/vector-store/src/httpserver.rs
+++ b/crates/vector-store/src/httpserver.rs
@@ -9,6 +9,7 @@ use crate::httproutes;
 use crate::internals::Internals;
 use crate::metrics::Metrics;
 use crate::node_state::NodeState;
+use axum::Router;
 use axum_server::Handle;
 use axum_server::accept::NoDelayAcceptor;
 use axum_server::tls_rustls::RustlsConfig;
@@ -17,10 +18,28 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::time;
 
-pub(crate) enum HttpServer {}
+pub enum HttpServer {
+    Router { tx: oneshot::Sender<Router> },
+}
+
+pub trait HttpServerExt {
+    fn router(&self) -> impl Future<Output = Router>;
+}
+
+impl HttpServerExt for Sender<HttpServer> {
+    async fn router(&self) -> Router {
+        let (tx, rx) = oneshot::channel();
+        self.send(HttpServer::Router { tx })
+            .await
+            .expect("HttpServerExt::router: internal actor should receive request");
+        rx.await
+            .expect("HttpServerExt::router: internal actor should send response")
+    }
+}
 
 struct ServerDeps {
     state: Sender<NodeState>,
@@ -34,7 +53,7 @@ struct ServerDeps {
 async fn spawn_server_with_retry(
     config: &HttpServerConfig,
     deps: &ServerDeps,
-) -> anyhow::Result<(Handle, SocketAddr)> {
+) -> anyhow::Result<(Handle, SocketAddr, Router)> {
     let mut retry_delay = Duration::from_millis(50);
     let max_retries = 10;
 
@@ -89,7 +108,8 @@ pub(crate) async fn new(
     let initial_config = config_rx.borrow().clone();
 
     // Start initial server and get actual bound address
-    let (initial_handle, actual_addr) = spawn_server_with_retry(&initial_config, &deps).await?;
+    let (initial_handle, actual_addr, mut router) =
+        spawn_server_with_retry(&initial_config, &deps).await?;
 
     // Spawn supervisor task that monitors config changes and manages server restarts
     tokio::spawn(async move {
@@ -98,11 +118,17 @@ pub(crate) async fn new(
 
         loop {
             tokio::select! {
-                result = rx.recv() => {
-                    if result.is_none() {
-                        break;
+                msg = rx.recv() => {
+                    let Some(msg) = msg else {
+                         break;
+                    };
+                    match msg {
+                        HttpServer::Router { tx } => {
+                            _ = tx.send(router.clone());
+                        }
                     }
                 }
+
                 result = config_rx.changed() => {
                     if result.is_err() {
                         break;
@@ -120,9 +146,10 @@ pub(crate) async fn new(
 
                         // Start new server with retry
                         match spawn_server_with_retry(&new_config, &deps).await {
-                            Ok((handle, new_actual_addr)) => {
+                            Ok((handle, new_actual_addr, new_router)) => {
                                 current_handle = handle;
                                 current_config = new_config;
+                                router = new_router;
                                 tracing::info!(
                                     "{} server reloaded successfully on {}",
                                     current_config.protocol_label(),
@@ -154,57 +181,42 @@ pub(crate) async fn new(
 async fn spawn_server(
     config: &HttpServerConfig,
     deps: &ServerDeps,
-) -> anyhow::Result<(Handle, SocketAddr)> {
+) -> anyhow::Result<(Handle, SocketAddr, Router)> {
     let protocol = config.protocol_label();
     let addr = config.addr;
 
     let handle = Handle::new();
 
+    let tls_config = config
+        .tls
+        .as_ref()
+        .map(|t| RustlsConfig::from_config(Arc::clone(t.server_config())));
+
+    let router = httproutes::new(
+        deps.engine.clone(),
+        deps.metrics.clone(),
+        deps.state.clone(),
+        deps.internals.clone(),
+        deps.index_engine_version.clone(),
+        tls_config.is_some(),
+    );
     tokio::spawn({
         let handle = handle.clone();
-        let state = deps.state.clone();
-        let engine = deps.engine.clone();
-        let metrics = deps.metrics.clone();
-        let internals = deps.internals.clone();
-        let index_engine_version = deps.index_engine_version.clone();
-        let tls_config = config
-            .tls
-            .as_ref()
-            .map(|t| RustlsConfig::from_config(Arc::clone(t.server_config())));
+        let router = router.clone();
 
         async move {
             let result = match tls_config {
                 Some(tls_config) => {
                     axum_server_dual_protocol::bind_dual_protocol(addr, tls_config)
                         .handle(handle)
-                        .serve(
-                            httproutes::new(
-                                engine,
-                                metrics,
-                                state,
-                                internals,
-                                index_engine_version,
-                                true,
-                            )
-                            .into_make_service(),
-                        )
+                        .serve(router.into_make_service())
                         .await
                 }
                 _ => {
                     axum_server::bind(addr)
                         .handle(handle)
                         .acceptor(NoDelayAcceptor::new())
-                        .serve(
-                            httproutes::new(
-                                engine,
-                                metrics,
-                                state,
-                                internals,
-                                index_engine_version,
-                                false,
-                            )
-                            .into_make_service(),
-                        )
+                        .serve(router.into_make_service())
                         .await
                 }
             };
@@ -221,7 +233,7 @@ async fn spawn_server(
             "server failed to start - listening notification not received"
         ))?;
 
-    Ok((handle, actual_addr))
+    Ok((handle, actual_addr, router))
 }
 
 fn describe_config_changes(old: &HttpServerConfig, new: &HttpServerConfig) -> String {

--- a/crates/vector-store/src/index/actor.rs
+++ b/crates/vector-store/src/index/actor.rs
@@ -79,6 +79,7 @@ pub(crate) trait IndexExt {
 }
 
 impl IndexExt for mpsc::Sender<Index> {
+    #[hotpath::measure]
     async fn add_vector(
         &self,
         partition_id: PartitionId,
@@ -96,6 +97,7 @@ impl IndexExt for mpsc::Sender<Index> {
         .expect("internal actor should receive request");
     }
 
+    #[hotpath::measure]
     async fn remove_vector(
         &self,
         partition_id: PartitionId,
@@ -111,12 +113,14 @@ impl IndexExt for mpsc::Sender<Index> {
         .expect("internal actor should receive request");
     }
 
+    #[hotpath::measure]
     async fn remove_partition(&self, partition_id: PartitionId) {
         self.send(Index::RemovePartition { partition_id })
             .await
             .expect("internal actor should receive request");
     }
 
+    #[hotpath::measure]
     async fn ann(&self, index_key: IndexKey, embedding: Vector, limit: Limit) -> AnnR {
         let (tx, rx) = oneshot::channel();
         self.send(Index::Ann {
@@ -129,6 +133,7 @@ impl IndexExt for mpsc::Sender<Index> {
         rx.await?
     }
 
+    #[hotpath::measure]
     async fn filtered_ann(
         &self,
         index_key: IndexKey,
@@ -148,6 +153,7 @@ impl IndexExt for mpsc::Sender<Index> {
         rx.await?
     }
 
+    #[hotpath::measure]
     async fn count(&self, index_key: IndexKey) -> CountR {
         let (tx, rx) = oneshot::channel();
         self.send(Index::Count { index_key, tx }).await?;

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -27,8 +27,7 @@ use crate::table::Table;
 use crate::table::TableSearch;
 use anyhow::anyhow;
 use std::collections::BTreeMap;
-use std::collections::HashSet;
-use std::iter;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::AtomicUsize;
@@ -260,7 +259,8 @@ struct Simulator {
     search: Duration,
     add_remove: Duration,
     reserve: Duration,
-    keys: RwLock<HashSet<PrimaryId>>,
+    keys: RwLock<BTreeSet<PrimaryId>>,
+    capacity: AtomicUsize,
     notify: Arc<Notify>,
 }
 
@@ -279,7 +279,8 @@ impl Simulator {
             search: Duration::ZERO,
             add_remove: Duration::ZERO,
             reserve: Duration::ZERO,
-            keys: RwLock::new(HashSet::new()),
+            keys: RwLock::new(BTreeSet::new()),
+            capacity: AtomicUsize::new(0),
             notify: Arc::new(Notify::new()),
         };
         sim.update(config);
@@ -360,9 +361,7 @@ impl UsearchIndex for RwLock<Simulator> {
         #[allow(clippy::readonly_write_lock)]
         let sim = self.write().unwrap();
         {
-            let mut keys = sim.keys.write().unwrap();
-            let len = keys.len();
-            keys.reserve(size - len);
+            sim.capacity.store(size, Ordering::Relaxed);
         }
 
         sim.wait_reserve(start);
@@ -370,7 +369,7 @@ impl UsearchIndex for RwLock<Simulator> {
     }
 
     fn capacity(&self) -> usize {
-        self.read().unwrap().keys.read().unwrap().capacity()
+        self.read().unwrap().capacity.load(Ordering::Relaxed)
     }
 
     fn size(&self) -> usize {
@@ -406,15 +405,16 @@ impl UsearchIndex for RwLock<Simulator> {
 
         let sim = self.read().unwrap();
         let keys = {
-            let len = sim.keys.read().unwrap().len() as u64;
+            let len = sim.keys.read().unwrap().len();
             if len == 0 {
                 Vec::new()
             } else {
-                let keys = sim.keys.read().unwrap();
-                iter::repeat_with(|| rand::random_range(0..len))
-                    .map(PrimaryId::from)
-                    .filter(|row_id| keys.contains(row_id))
+                sim.keys
+                    .read()
+                    .unwrap()
+                    .iter()
                     .take(limit.0.get())
+                    .cloned()
                     .collect()
             }
         };

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -355,6 +355,7 @@ impl Simulator {
 }
 
 impl UsearchIndex for RwLock<Simulator> {
+    #[hotpath::measure]
     fn reserve(&self, size: usize) -> anyhow::Result<()> {
         let start = Instant::now();
 
@@ -369,14 +370,17 @@ impl UsearchIndex for RwLock<Simulator> {
         Ok(())
     }
 
+    #[hotpath::measure]
     fn capacity(&self) -> usize {
         self.read().unwrap().capacity.load(Ordering::Relaxed)
     }
 
+    #[hotpath::measure]
     fn size(&self) -> usize {
         self.read().unwrap().keys.read().unwrap().len()
     }
 
+    #[hotpath::measure]
     fn add(&self, row_id: PrimaryId, _: &Vector) -> anyhow::Result<()> {
         let start = Instant::now();
 
@@ -387,6 +391,7 @@ impl UsearchIndex for RwLock<Simulator> {
         Ok(())
     }
 
+    #[hotpath::measure]
     fn remove(&self, row_id: PrimaryId) -> anyhow::Result<()> {
         let start = Instant::now();
 
@@ -397,6 +402,7 @@ impl UsearchIndex for RwLock<Simulator> {
         Ok(())
     }
 
+    #[hotpath::measure]
     fn search(
         &self,
         _: &Vector,
@@ -425,6 +431,7 @@ impl UsearchIndex for RwLock<Simulator> {
         Ok(keys.into_iter().map(move |row_id| Ok((row_id, distance))))
     }
 
+    #[hotpath::measure]
     fn filtered_search(
         &self,
         vector: &Vector,
@@ -434,6 +441,7 @@ impl UsearchIndex for RwLock<Simulator> {
         self.search(vector, limit)
     }
 
+    #[hotpath::measure]
     fn stop(&self) {
         self.read().unwrap().notify.notify_one();
     }
@@ -615,15 +623,18 @@ mod operation {
             }
         }
 
+        #[hotpath::measure]
         pub(super) async fn permit_for_message(&mut self, msg: &Index) -> Permit {
             self.permit(msg.into()).await
         }
 
+        #[hotpath::measure]
         pub(super) async fn permit_for_reserve(&mut self) -> Permit {
             self.permit(Mode::Reserve).await
         }
 
         /// Capacity and size permit cannot be concurrent only with reserve mode.
+        #[hotpath::measure]
         pub(super) async fn permit_for_capacity_and_size(&mut self) -> Permit {
             while self.mode == Mode::Reserve {
                 if self.counter.load(Ordering::Relaxed) == 0 {
@@ -741,6 +752,7 @@ fn new<I: UsearchIndex + Send + Sync + 'static>(
     Ok(tx)
 }
 
+#[hotpath::measure]
 fn preprocess<'a, I, T>(
     index_fn: impl FnOnce() -> anyhow::Result<Arc<I>>,
     states: &'a mut BTreeMap<IndexId, IndexState>,
@@ -894,6 +906,7 @@ where
     }
 }
 
+#[hotpath::measure]
 async fn dispatch_task<I, T>(
     state: &mut IndexState,
     partition: Arc<PartitionState<I>>,
@@ -946,10 +959,12 @@ async fn dispatch_task<I, T>(
     });
 }
 
+#[hotpath::measure]
 fn should_run_on_tokio(msg: &Index) -> bool {
     matches!(msg, Index::Ann { .. })
 }
 
+#[hotpath::measure]
 fn process<I, T>(
     partition: Arc<PartitionState<I>>,
     table: Arc<RwLock<T>>,
@@ -1003,6 +1018,7 @@ fn process<I, T>(
     }
 }
 
+#[hotpath::measure]
 fn reserve(idx: &impl UsearchIndex, capacity: usize) {
     let result = idx.reserve(capacity);
     if let Err(err) = &result {
@@ -1012,6 +1028,7 @@ fn reserve(idx: &impl UsearchIndex, capacity: usize) {
     }
 }
 
+#[hotpath::measure]
 fn needs_more_capacity(idx: &impl UsearchIndex, is_global: bool) -> Option<usize> {
     let capacity = idx.capacity();
     let free_space = capacity - idx.size();
@@ -1028,6 +1045,7 @@ fn needs_more_capacity(idx: &impl UsearchIndex, is_global: bool) -> Option<usize
     }
 }
 
+#[hotpath::measure]
 fn add(idx: &impl UsearchIndex, primary_id: PrimaryId, embedding: &Vector, size: &AtomicUsize) {
     if let Err(err) = idx.add(primary_id, embedding) {
         warn!("add: unable to add embedding: {err}");
@@ -1036,6 +1054,7 @@ fn add(idx: &impl UsearchIndex, primary_id: PrimaryId, embedding: &Vector, size:
     }
 }
 
+#[hotpath::measure]
 fn remove(idx: &impl UsearchIndex, row_id: PrimaryId, size: &AtomicUsize) {
     if let Err(err) = idx.remove(row_id) {
         warn!("remove: unable to remove embeddings: {err}");
@@ -1044,6 +1063,7 @@ fn remove(idx: &impl UsearchIndex, row_id: PrimaryId, size: &AtomicUsize) {
     }
 }
 
+#[hotpath::measure]
 fn validate_dimensions(
     tx_ann: oneshot::Sender<AnnR>,
     embedding: &Vector,
@@ -1059,6 +1079,7 @@ fn validate_dimensions(
     }
 }
 
+#[hotpath::measure]
 fn ann<I>(
     partition: Arc<PartitionState<I>>,
     tx_ann: oneshot::Sender<AnnR>,
@@ -1098,6 +1119,7 @@ fn ann<I>(
         .unwrap_or_else(|_| trace!("ann: unable to send response"));
 }
 
+#[hotpath::measure]
 fn filtered_ann<I>(
     partition: Arc<PartitionState<I>>,
     tx_ann: oneshot::Sender<AnnR>,
@@ -1146,6 +1168,7 @@ fn filtered_ann<I>(
         .unwrap_or_else(|_| trace!("ann: unable to send response"));
 }
 
+#[hotpath::measure]
 async fn check_memory_allocation(
     msg: &Index,
     memory: &mpsc::Sender<Memory>,

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -26,6 +26,7 @@ use crate::table::PrimaryId;
 use crate::table::Table;
 use crate::table::TableSearch;
 use anyhow::anyhow;
+use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -1069,21 +1070,25 @@ fn ann<I>(
 {
     tx_ann
         .send(
-            partition.idx.search(&embedding, limit)
+            partition
+                .idx
+                .search(&embedding, limit)
                 .map_err(|err| anyhow!("ann: search failed: {err}"))
                 .and_then(|matches| {
                     let table = table.read().unwrap();
                     let (primary_keys, distances) = itertools::process_results(
-                        matches.map(|result| {
-                            result.and_then(|(primary_id, distance)| {
-                                table
-                                    .primary_key(partition.partition_id, primary_id)
-                                    .ok_or(anyhow!(
-                                        "not defined primary_key for partition_id {partition_id:?} and primary_id {primary_id:?}",
+                        matches.filter_map_ok(|(primary_id, distance)| {
+                            table
+                                .primary_key(partition.partition_id, primary_id)
+                                .or_else(|| {
+                                    debug!(
+                                        "not defined primary key for partition_id {partition_id:?} \
+                                        and primary_id {primary_id:?}",
                                         partition_id = partition.partition_id,
-                                    ))
-                                    .map(|primary_key| (primary_key, distance))
-                            })
+                                    );
+                                    None
+                                })
+                                .map(|primary_key| (primary_key, distance))
                         }),
                         |it| it.unzip(),
                     )?;
@@ -1113,21 +1118,25 @@ fn filtered_ann<I>(
 
     tx_ann
         .send(
-            partition.idx.filtered_search(&embedding, limit, id_ok)
+            partition
+                .idx
+                .filtered_search(&embedding, limit, id_ok)
                 .map_err(|err| anyhow!("ann: search failed: {err}"))
                 .and_then(|matches| {
                     let table = table.read().unwrap();
                     let (primary_keys, distances) = itertools::process_results(
-                        matches.map(|result| {
-                            result.and_then(|(primary_id, distance)| {
-                                table
-                                    .primary_key(partition.partition_id, primary_id)
-                                    .ok_or(anyhow!(
-                                        "not defined primary key for partition_id {partition_id:?} and primary_id {primary_id:?}",
+                        matches.filter_map_ok(|(primary_id, distance)| {
+                            table
+                                .primary_key(partition.partition_id, primary_id)
+                                .or_else(|| {
+                                    debug!(
+                                        "not defined primary key for partition_id {partition_id:?} \
+                                        and primary_id {primary_id:?}",
                                         partition_id = partition.partition_id,
-                                    ))
-                                    .map(|primary_key| (primary_key, distance))
-                            })
+                                    );
+                                    None
+                                })
+                                .map(|primary_key| (primary_key, distance))
                         }),
                         |it| it.unzip(),
                     )?;

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -36,6 +36,8 @@ pub use crate::config_manager::ConfigReceivers;
 pub use crate::config_manager::HttpServerConfig;
 pub use crate::config_manager::load_config;
 pub use crate::distance::Distance;
+pub use crate::httpserver::HttpServer;
+pub use crate::httpserver::HttpServerExt;
 pub use crate::index_key::IndexKey;
 pub use crate::info::Info;
 use crate::internals::Internals;
@@ -638,7 +640,7 @@ pub async fn run(
     internals: Sender<Internals>,
     index_factory: Box<dyn IndexFactory + Send + Sync>,
     receivers: ConfigReceivers,
-) -> anyhow::Result<(impl Sized, SocketAddr)> {
+) -> anyhow::Result<(Sender<HttpServer>, SocketAddr)> {
     let metrics: Arc<Metrics> = Arc::new(metrics::Metrics::new());
     let index_engine_version = index_factory.index_engine_version();
     httpserver::new(

--- a/crates/vector-store/src/table.rs
+++ b/crates/vector-store/src/table.rs
@@ -1071,6 +1071,7 @@ pub(crate) trait TableAdd {
 }
 
 impl TableAdd for Table {
+    #[hotpath::measure]
     fn add(
         &mut self,
         _index_key: &IndexKey,
@@ -1218,10 +1219,12 @@ pub(crate) trait TableSearch {
 }
 
 impl TableSearch for Table {
+    #[hotpath::measure]
     fn index_id(&self, index_key: &IndexKey) -> Option<IndexId> {
         self.index_ids.get(index_key).copied()
     }
 
+    #[hotpath::measure]
     fn partition_id(
         &self,
         index_key: &IndexKey,
@@ -1245,6 +1248,7 @@ impl TableSearch for Table {
         }
     }
 
+    #[hotpath::measure]
     fn primary_key(&self, partition_id: PartitionId, primary_id: PrimaryId) -> Option<PrimaryKey> {
         if !self.is_valid_primary_id(partition_id, primary_id) {
             return None;
@@ -1252,6 +1256,7 @@ impl TableSearch for Table {
         self.primary_keys.get(primary_id).cloned().flatten()
     }
 
+    #[hotpath::measure]
     fn is_valid_for(
         &self,
         partition_id: PartitionId,

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -386,7 +386,12 @@ pub(crate) fn new_db_index(
                         let Some(msg) = msg else {
                             break;
                         };
-                        process_db_index(&db, &metadata, &fullscan_finished, msg).await;
+                        spawn_process_db_index(
+                            db.clone(),
+                            metadata.clone(),
+                            Arc::clone(&fullscan_finished),
+                            msg
+                        ).await;
                     }
                 }
             }
@@ -414,13 +419,24 @@ pub(crate) fn new_db_index(
                         let Some(msg) = msg else {
                             break;
                         };
-                        process_db_index(&db, &metadata, &fullscan_finished, msg).await;
+                        spawn_process_db_index(
+                            db.clone(),
+                            metadata.clone(),
+                            Arc::clone(&fullscan_finished),
+                            msg
+                        ).await;
                     }
                 }
             }
 
             while let Some(msg) = rx_index.recv().await {
-                process_db_index(&db, &metadata, &fullscan_finished, msg).await;
+                spawn_process_db_index(
+                    db.clone(),
+                    metadata.clone(),
+                    Arc::clone(&fullscan_finished),
+                    msg,
+                )
+                .await;
             }
             drop(tx_embeddings);
         }
@@ -446,64 +462,66 @@ fn cdc(db: &mut DbBasic, metadata: &IndexMetadata) -> Option<ScanFn> {
         .and_then(|index| index.cdc_fn.take())
 }
 
-async fn process_db_index(
-    db: &DbBasic,
-    metadata: &IndexMetadata,
-    fullscan_finished: &Arc<AtomicBool>,
+async fn spawn_process_db_index(
+    db: DbBasic,
+    metadata: IndexMetadata,
+    fullscan_finished: Arc<AtomicBool>,
     msg: DbIndex,
 ) {
-    match msg {
-        DbIndex::GetPrimaryKeyColumns { tx } => tx
-            .send(
-                db.0.read()
-                    .unwrap()
-                    .keyspaces
-                    .get(&metadata.keyspace_name)
-                    .and_then(|keyspace| keyspace.tables.get(&metadata.table_name))
-                    .map(|table| table.primary_keys.clone())
-                    .unwrap_or_default(),
-            )
-            .map_err(|_| anyhow!("DbIndex::GetPrimaryKeyColumns: unable to send response"))
-            .unwrap(),
+    tokio::spawn(async move {
+        match msg {
+            DbIndex::GetPrimaryKeyColumns { tx } => tx
+                .send(
+                    db.0.read()
+                        .unwrap()
+                        .keyspaces
+                        .get(&metadata.keyspace_name)
+                        .and_then(|keyspace| keyspace.tables.get(&metadata.table_name))
+                        .map(|table| table.primary_keys.clone())
+                        .unwrap_or_default(),
+                )
+                .map_err(|_| anyhow!("DbIndex::GetPrimaryKeyColumns: unable to send response"))
+                .unwrap(),
 
-        DbIndex::GetPartitionKeyCount { tx } => tx
-            .send(
-                db.0.read()
-                    .unwrap()
-                    .keyspaces
-                    .get(&metadata.keyspace_name)
-                    .and_then(|keyspace| keyspace.tables.get(&metadata.table_name))
-                    .map(|table| table.partition_key_count)
-                    .unwrap_or(1),
-            )
-            .map_err(|_| anyhow!("DbIndex::GetPartitionKeyCount: unable to send response"))
-            .unwrap(),
+            DbIndex::GetPartitionKeyCount { tx } => tx
+                .send(
+                    db.0.read()
+                        .unwrap()
+                        .keyspaces
+                        .get(&metadata.keyspace_name)
+                        .and_then(|keyspace| keyspace.tables.get(&metadata.table_name))
+                        .map(|table| table.partition_key_count)
+                        .unwrap_or(1),
+                )
+                .map_err(|_| anyhow!("DbIndex::GetPartitionKeyCount: unable to send response"))
+                .unwrap(),
 
-        DbIndex::GetTableColumns { tx } => tx
-            .send(
-                db.0.read()
-                    .unwrap()
-                    .keyspaces
-                    .get(&metadata.keyspace_name)
-                    .and_then(|keyspace| keyspace.tables.get(&metadata.table_name))
-                    .map(|table| table.columns.clone())
-                    .unwrap_or_default(),
-            )
-            .map_err(|_| anyhow!("DbIndex::GetPrimaryKeyColumns: unable to send response"))
-            .unwrap(),
+            DbIndex::GetTableColumns { tx } => tx
+                .send(
+                    db.0.read()
+                        .unwrap()
+                        .keyspaces
+                        .get(&metadata.keyspace_name)
+                        .and_then(|keyspace| keyspace.tables.get(&metadata.table_name))
+                        .map(|table| table.columns.clone())
+                        .unwrap_or_default(),
+                )
+                .map_err(|_| anyhow!("DbIndex::GetPrimaryKeyColumns: unable to send response"))
+                .unwrap(),
 
-        DbIndex::FullScanProgress { tx } => tx
-            .send({
-                let db = db.0.read().unwrap();
-                db.next_full_scan_progress.clone().unwrap_or_else(|| {
-                    if fullscan_finished.load(Ordering::Acquire) {
-                        Progress::Done
-                    } else {
-                        Progress::InProgress(Percentage::try_from(0.0).unwrap())
-                    }
+            DbIndex::FullScanProgress { tx } => tx
+                .send({
+                    let db = db.0.read().unwrap();
+                    db.next_full_scan_progress.clone().unwrap_or_else(|| {
+                        if fullscan_finished.load(Ordering::Acquire) {
+                            Progress::Done
+                        } else {
+                            Progress::InProgress(Percentage::try_from(0.0).unwrap())
+                        }
+                    })
                 })
-            })
-            .map_err(|_| anyhow!("DbIndex::GetTargetColumn: unable to send response"))
-            .unwrap(),
-    }
+                .map_err(|_| anyhow!("DbIndex::GetTargetColumn: unable to send response"))
+                .unwrap(),
+        }
+    });
 }


### PR DESCRIPTION
This change prepares vector-store to run benches for search while updating or inserting.

It fixes usearch simulator to be faster, fixes an issue with usearch ann - now search discards primary keys which don't exist anymore in a table cache.

It implements new method for httpserver actor to return axum::Router for testing request without http server.

It implements testclient which uses provided axum::Router for testing routing handlers.

It improves db_basic concurrency and fixes concurrency runner for benches.

It adds hotpath and subscriber-console for profiling runs.

Fixes: VECTOR-664