### PR TITLE
validator: add Alternator FLOAT32VECTOR type end-to-end tests

### DIFF
--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -24,6 +24,7 @@ use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
 use aws_sdk_dynamodb::operation::delete_table::DeleteTableError;
+use aws_sdk_dynamodb::primitives::Blob;
 use aws_sdk_dynamodb::types::AttributeDefinition;
 use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::types::BillingMode;
@@ -34,6 +35,7 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::base64;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::config_bag::ConfigBag;
 use e2etest::TestCase;
@@ -201,6 +203,91 @@ impl Intercept for JsonBodyInjectInterceptor {
     }
 }
 
+/// Magic prefix for FLOAT32VECTOR-encoded binary attribute values.
+/// Same prefix as used by the Java Alternator client (`alternator-client-java`).
+/// When the interceptor detects this prefix in a Base64-encoded `B` attribute,
+/// it replaces the entire attribute with `{"FLOAT32VECTOR": [...]}`.
+const F32VEC_MAGIC: &[u8] = &[0xF2, 0xF3, 0x2F, 0xEC, 0x4A, 0x7B, 0x19, 0xD3];
+
+/// Base64 encoding of the magic prefix, used for fast pre-scanning of the body.
+/// Corresponds to `base64::encode(F32VEC_MAGIC)` truncated to a unique prefix.
+const F32VEC_BASE64_PREFIX: &str = "8vMv7Ep7";
+
+/// Encodes a float vector as a `B` [`AttributeValue`] with a magic prefix.
+/// The [`Float32VectorInterceptor`] will transcode it to `{"FLOAT32VECTOR": [...]}`.
+fn float32_vector(v: impl IntoIterator<Item = f32>) -> AttributeValue {
+    let v: Vec<f32> = v.into_iter().collect();
+    let mut bytes = Vec::with_capacity(F32VEC_MAGIC.len() + v.len() * 4);
+    bytes.extend_from_slice(F32VEC_MAGIC);
+    for f in &v {
+        bytes.extend_from_slice(&f.to_le_bytes());
+    }
+    AttributeValue::B(Blob::new(bytes))
+}
+
+fn decode_float32_vector(bytes: &[u8]) -> Vec<f32> {
+    bytes[F32VEC_MAGIC.len()..]
+        .chunks(4)
+        .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+        .collect()
+}
+
+/// Rewrites any `B`-attribute with the magic prefix into the `FLOAT32VECTOR` wire
+/// format that Alternator expects. This is a no-op for requests without such attributes.
+#[derive(Debug, Clone)]
+struct Float32VectorInterceptor;
+
+impl Intercept for Float32VectorInterceptor {
+    fn name(&self) -> &'static str {
+        "Float32VectorInterceptor"
+    }
+
+    fn modify_before_signing(
+        &self,
+        context: &mut BeforeTransmitInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let body_bytes = context
+            .request()
+            .body()
+            .bytes()
+            .ok_or("expected in-memory body for Alternator request")?;
+
+        // Fast pre-scan: skip transcoding if no magic-prefixed B attributes present.
+        let body_str = std::str::from_utf8(body_bytes)?;
+        if !body_str.contains(F32VEC_BASE64_PREFIX) {
+            return Ok(());
+        }
+
+        let mut json: Value = serde_json::from_str(body_str)?;
+
+        // Walk all `Item` values in the JSON body.
+        if let Some(item) = json.get_mut("Item").and_then(|v| v.as_object_mut()) {
+            for (_attr_name, attr_val) in item.iter_mut() {
+                if let Some(b64) = attr_val.get("B").and_then(|v| v.as_str())
+                    && let Ok(bytes) = base64::decode(b64)
+                    && bytes.starts_with(F32VEC_MAGIC)
+                {
+                    let floats = decode_float32_vector(&bytes);
+                    *attr_val = serde_json::json!({ "FLOAT32VECTOR": floats });
+                }
+            }
+        }
+
+        let new_bytes = serde_json::to_vec(&json)?;
+        let new_len = new_bytes.len();
+        let request = context.request_mut();
+        *request.body_mut() = SdkBody::from(new_bytes);
+        request.headers_mut().insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&new_len.to_string()).expect("content-length value is valid"),
+        );
+
+        Ok(())
+    }
+}
+
 /// Builds a DynamoDB client pointing at the ScyllaDB Alternator endpoint on
 /// `db_ip`.
 ///
@@ -214,7 +301,11 @@ async fn make_dynamodb_client(db_ip: Ipv4Addr) -> Client {
         .region(Region::new("us-east-1"))
         .load()
         .await;
-    Client::new(&config)
+    Client::from_conf(
+        aws_sdk_dynamodb::config::Builder::from(&config)
+            .interceptor(Float32VectorInterceptor)
+            .build(),
+    )
 }
 
 /// Polls the Alternator HTTP endpoint on `db_ip` until it responds successfully.
@@ -294,6 +385,11 @@ impl Item {
 
     fn vec(mut self, vec_attr: &str, v: [f32; Self::VEC_DIMS]) -> Self {
         self.0.insert(vec_attr.to_string(), float_list(v));
+        self
+    }
+
+    fn vec_optimized(mut self, vec_attr: &str, v: [f32; Self::VEC_DIMS]) -> Self {
+        self.0.insert(vec_attr.to_string(), float32_vector(v));
         self
     }
 

--- a/crates/validator/src/alternator/query.rs
+++ b/crates/validator/src/alternator/query.rs
@@ -30,6 +30,11 @@ pub(super) trait QueryBuilderExt {
         self,
         vector: impl IntoIterator<Item = f32>,
     ) -> CustomizableOperation<QueryOutput, QueryError, QueryFluentBuilder>;
+
+    fn vector_search_optimized(
+        self,
+        vector: impl IntoIterator<Item = f32>,
+    ) -> CustomizableOperation<QueryOutput, QueryError, QueryFluentBuilder>;
 }
 
 impl QueryBuilderExt for QueryFluentBuilder {
@@ -43,6 +48,19 @@ impl QueryBuilderExt for QueryFluentBuilder {
                     .into_iter()
                     .map(|v| serde_json::json!({ "N": v.to_string() }))
                     .collect::<Vec<_>>()
+            }
+        });
+        self.customize()
+            .interceptor(JsonBodyInjectInterceptor::new([("VectorSearch", json)]))
+    }
+
+    fn vector_search_optimized(
+        self,
+        vector: impl IntoIterator<Item = f32>,
+    ) -> CustomizableOperation<QueryOutput, QueryError, QueryFluentBuilder> {
+        let json = serde_json::json!({
+            "QueryVector": {
+                "FLOAT32VECTOR": vector.into_iter().collect::<Vec<_>>()
             }
         });
         self.customize()

--- a/crates/validator/src/alternator/types.rs
+++ b/crates/validator/src/alternator/types.rs
@@ -10,7 +10,7 @@ use aws_sdk_dynamodb::primitives::Blob;
 use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::types::ScalarAttributeType;
 use e2etest::TestCase;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use tracing::info;
 
 use crate::alternator;
@@ -19,54 +19,69 @@ use crate::alternator::TableContext;
 use crate::alternator::TableShape;
 use crate::alternator::query::QueryBuilderExt;
 
-/// Shared logic for all key-type tests: creates a table with 2 initial items,
-/// adds a 3rd via PutItem, then queries with a keys-only projection and asserts
-/// that only the pk attribute is returned.
+/// Shared logic for all key-type tests: creates a table with initial items,
+/// adds extra items via PutItem, then queries with both L-type and FLOAT32VECTOR
+/// encodings and asserts that all expected pk values are returned with correct
+/// projection.
 async fn query_with_key_type(
     actors: &TestActors,
     shape: &TableShape,
     initial: &[Item],
-    extra: Item,
+    extra: &[Item],
 ) {
-    let vec_attr = shape.vec().unwrap();
     let ctx = TableContext::create_with_data(actors, shape, initial).await;
 
-    ctx.put(&extra).await;
-    ctx.wait_for_count(3).await;
+    for item in extra {
+        ctx.put(item).await;
+    }
+    ctx.wait_for_count(initial.len() + extra.len()).await;
 
-    let items = ctx
-        .client
-        .query()
-        .table_name(&ctx.table_name)
-        .index_name(ctx.index.index.as_ref())
-        .limit(3)
-        .projection_expression("#pk")
-        .expression_attribute_names("#pk", shape.pk())
+    let expected_pks: Vec<&AttributeValue> = initial
+        .iter()
+        .chain(extra.iter())
+        .map(|item| item.0.get(shape.pk()).expect("item has no pk"))
+        .collect();
+
+    let base_query = || {
+        ctx.client
+            .query()
+            .table_name(&ctx.table_name)
+            .index_name(ctx.index.index.as_ref())
+            .limit((initial.len() + extra.len()) as i32)
+            .projection_expression("#pk")
+            .expression_attribute_names("#pk", shape.pk())
+    };
+
+    let assert_results = |items: &[HashMap<String, AttributeValue>], label: &str| {
+        let mut expected: Vec<HashMap<String, AttributeValue>> = expected_pks
+            .iter()
+            .map(|pk| HashMap::from([(shape.pk().to_string(), (*pk).clone())]))
+            .collect();
+
+        let mut got = items.to_vec();
+        got.sort_by_key(|m| format!("{:?}", m.get(shape.pk())));
+        expected.sort_by_key(|m| format!("{:?}", m.get(shape.pk())));
+
+        assert_eq!(got, expected, "{label} query returned unexpected results");
+    };
+
+    let items = base_query()
         .vector_search([1.0, 1.0, 1.0])
         .send()
         .await
-        .expect("Query with VectorSearch should succeed")
+        .expect("Query with `L-type vector` should succeed")
         .items()
         .to_vec();
+    assert_results(&items, "L-type");
 
-    assert!(
-        !items.is_empty(),
-        "keys-only query should return at least one item"
-    );
-    let expected_keys: HashSet<&str> = [shape.pk()].into();
-    for item in &items {
-        let got_keys: HashSet<&str> = item.keys().map(String::as_str).collect();
-        assert_eq!(
-            got_keys,
-            expected_keys,
-            "projected item should contain only pk '{}'",
-            shape.pk()
-        );
-        assert!(
-            !item.contains_key(vec_attr),
-            "projected item should NOT contain vector '{vec_attr}'"
-        );
-    }
+    let items = base_query()
+        .vector_search_optimized([1.0, 1.0, 1.0])
+        .send()
+        .await
+        .expect("Query with `FLOAT32VECTOR` should succeed")
+        .items()
+        .to_vec();
+    assert_results(&items, "FLOAT32VECTOR");
 
     ctx.done().await;
 }
@@ -87,8 +102,8 @@ async fn query_with_string_key(actors: TestActors) {
         Item::new(shape.pk(), AttributeValue::S("str-a".into())).vec(v, [1.0, 1.0, 1.0]),
         Item::new(shape.pk(), AttributeValue::S("str-b".into())).vec(v, [1.0, 2.0, 4.0]),
     ];
-    let extra = Item::new(shape.pk(), AttributeValue::S("str-c".into())).vec(v, [1.0, 4.0, 8.0]);
-    query_with_key_type(&actors, &shape, &initial, extra).await;
+    let extra = [Item::new(shape.pk(), AttributeValue::S("str-c".into())).vec(v, [1.0, 4.0, 8.0])];
+    query_with_key_type(&actors, &shape, &initial, &extra).await;
     info!("finished");
 }
 
@@ -108,8 +123,8 @@ async fn query_with_number_key(actors: TestActors) {
         Item::new(shape.pk(), AttributeValue::N("1".into())).vec(v, [1.0, 1.0, 1.0]),
         Item::new(shape.pk(), AttributeValue::N("2".into())).vec(v, [1.0, 2.0, 4.0]),
     ];
-    let extra = Item::new(shape.pk(), AttributeValue::N("3".into())).vec(v, [1.0, 4.0, 8.0]);
-    query_with_key_type(&actors, &shape, &initial, extra).await;
+    let extra = [Item::new(shape.pk(), AttributeValue::N("3".into())).vec(v, [1.0, 4.0, 8.0])];
+    query_with_key_type(&actors, &shape, &initial, &extra).await;
     info!("finished");
 }
 
@@ -129,9 +144,40 @@ async fn query_with_binary_key(actors: TestActors) {
         Item::new(shape.pk(), AttributeValue::B(Blob::new(vec![0x01u8]))).vec(v, [1.0, 1.0, 1.0]),
         Item::new(shape.pk(), AttributeValue::B(Blob::new(vec![0x02u8]))).vec(v, [1.0, 2.0, 4.0]),
     ];
-    let extra =
-        Item::new(shape.pk(), AttributeValue::B(Blob::new(vec![0x03u8]))).vec(v, [1.0, 4.0, 8.0]);
-    query_with_key_type(&actors, &shape, &initial, extra).await;
+    let extra = [
+        Item::new(shape.pk(), AttributeValue::B(Blob::new(vec![0x03u8]))).vec(v, [1.0, 4.0, 8.0]),
+    ];
+    query_with_key_type(&actors, &shape, &initial, &extra).await;
+    info!("finished");
+}
+
+/// Verifies queries work with both FLOAT32VECTOR-encoded items and query vectors.
+#[framed]
+async fn query_with_optimized_vector_type(actors: TestActors) {
+    info!("started");
+
+    let shape = TableShape {
+        table_prefix: None,
+        index_prefix: None,
+        pk_name: "Pk-VecType".into(),
+        sk_name: None,
+        vec_name: Some("Vec-VecType".into()),
+        pk_type: ScalarAttributeType::S,
+    };
+
+    let v = shape.vec().unwrap();
+    let initial = [
+        Item::new(shape.pk(), AttributeValue::S("pk-l-scan".into())).vec(v, [1.0, 1.0, 1.0]),
+        Item::new(shape.pk(), AttributeValue::S("pk-v-scan".into()))
+            .vec_optimized(v, [1.0, 1.0, 1.0]),
+    ];
+    let extra = [
+        Item::new(shape.pk(), AttributeValue::S("pk-l-live".into())).vec(v, [1.0, 1.0, 1.0]),
+        Item::new(shape.pk(), AttributeValue::S("pk-v-live".into()))
+            .vec_optimized(v, [1.0, 1.0, 1.0]),
+    ];
+    query_with_key_type(&actors, &shape, &initial, &extra).await;
+
     info!("finished");
 }
 
@@ -153,5 +199,10 @@ pub(super) async fn new() -> TestCase<TestActors> {
             "query_with_binary_key",
             common::DEFAULT_TEST_TIMEOUT,
             query_with_binary_key,
+        )
+        .with_test(
+            "query_with_optimized_vector_type",
+            common::DEFAULT_TEST_TIMEOUT,
+            query_with_optimized_vector_type,
         )
 }


### PR DESCRIPTION
Add end-to-end coverage for the Alternator optimized vector type using requests with the new encoding injected into the JSON body.

Verify that queries work for items stored with the optimized vector representation and remain compatible with the existing L-based vector representation in the same index.

Fixes: VECTOR-666