### PR TITLE
validator: add Alternator index creation test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +404,325 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-dynamodb"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d2214c2ad3a175d3ece5a5af26916c29caa3e12e9e05b3cb8ed5e837b54b67"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699da1961a289b23842d88fe2984c6ff68735fdf9bdcbc69ceaeb2491c9bf434"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e3a4cb3b124833eafea9afd1a6cc5f8ddf3efefffc6651ef76a03cbc6b4981"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c4f19655ab0856375e169865c91264de965bd74c407c7f1e403184b1049409"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cba48474f1d6807384d06fec085b909f5807e16653c5af5c45dfe89539f0b70"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576b0d6991c9c32bc14fc340582ef148311f924d41815f641a308b5d11e8e7cd"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,8 +733,8 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -403,8 +764,8 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -435,8 +796,8 @@ dependencies = [
  "bytes",
  "either",
  "fs-err",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "hyper-util",
  "pin-project-lite",
@@ -454,7 +815,7 @@ source = "git+https://github.com/vinchona/axum-server-dual-protocol?rev=ca6db055
 dependencies = [
  "axum-server",
  "bytes",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "pin-project",
  "rustls",
@@ -477,7 +838,7 @@ dependencies = [
  "bytesize",
  "cookie",
  "expect-json",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -504,6 +865,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bcrypt"
@@ -600,6 +971,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytesize"
@@ -908,6 +1289,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1288,6 +1679,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1807,7 +2199,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.12.0",
  "slab",
  "tokio",
@@ -1964,6 +2356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hotpath"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2406,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2015,12 +2427,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2031,8 +2454,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2093,8 +2516,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2110,10 +2533,11 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2144,8 +2568,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -3031,6 +3455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3038,6 +3468,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "page_size"
@@ -3160,6 +3596,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3678,6 +4120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,8 +4142,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3790,7 +4238,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "mime",
  "rand 0.10.1",
  "thiserror 2.0.18",
@@ -3847,6 +4295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,6 +4347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4040,6 +4509,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4672,8 +5164,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -4732,8 +5224,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -4956,6 +5448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "usearch"
 version = "2.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5085,6 +5583,11 @@ name = "vector-search-validator"
 version = "0.0.0-dev"
 dependencies = [
  "async-backtrace",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-dynamodb",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bcrypt",
  "clap",
  "derive_more",
@@ -5095,6 +5598,7 @@ dependencies = [
  "e2etest-scylla-proxy-cluster",
  "e2etest-tls",
  "e2etest-vector-store-cluster",
+ "http 1.4.0",
  "httpapi",
  "httpclient",
  "itertools 0.14.0",
@@ -5182,6 +5686,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -5822,6 +6332,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ license = "LicenseRef-ScyllaDB-Source-Available-1.0"
 
 [workspace.dependencies]
 anyhow = "1.0.97"
+aws-config = "1.8.14"
+aws-credential-types = "1.2.12"
+aws-sdk-dynamodb = { version = "1.105.0", default-features = false, features = ["default-https-client", "rt-tokio"] }
+aws-smithy-runtime-api = "1.11.4"
+aws-smithy-types = "1.4.4"
 arrow-array = "56.0.0"
 async-backtrace = "0.2.7"
 async-channel = "2.5.0"
@@ -40,6 +45,7 @@ e2etest-tls = "0.1.0"
 e2etest-vector-store-cluster = "0.1.0"
 futures = "0.3.31"
 hotpath = { version = "0.15.0", features = ["tokio", "futures", "async-channel"] }
+http = "1.4.0"
 httpapi = { path = "crates/httpapi" }
 httpclient = { path = "crates/httpclient" }
 humantime = "2.2.0"

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -9,6 +9,11 @@ license.workspace = true
 
 [dependencies]
 async-backtrace.workspace = true
+aws-config.workspace = true
+aws-credential-types.workspace = true
+aws-sdk-dynamodb.workspace = true
+aws-smithy-runtime-api.workspace = true
+aws-smithy-types.workspace = true
 bcrypt.workspace = true
 clap.workspace = true
 derive_more.workspace = true
@@ -19,6 +24,7 @@ e2etest-scylla-cluster.workspace = true
 e2etest-scylla-proxy-cluster.workspace = true
 e2etest-tls.workspace = true
 e2etest-vector-store-cluster.workspace = true
+http.workspace = true
 httpapi.workspace = true
 httpclient.workspace = true
 itertools.workspace = true

--- a/crates/validator/src/alternator/create_table.rs
+++ b/crates/validator/src/alternator/create_table.rs
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::TestActors;
+use crate::alternator;
+use crate::common;
+use async_backtrace::framed;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::context::AfterDeserializationInterceptorContextRef;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::config_bag::ConfigBag;
+use e2etest::TestCase;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tracing::info;
+
+/// An SDK interceptor that captures the `VectorIndexes` extension field from
+/// the raw `DescribeTable` JSON response as a [`serde_json::Value`].  The
+/// caller retrieves it via [`into_captured`] after the SDK call completes and
+/// performs the assertions explicitly.
+///
+/// Attach this to a `client.describe_table().customize().interceptor(...)` call.
+/// It fires in [`read_after_deserialization`], at which point the response body
+/// has already been buffered by the SDK (via its internal `read_body()` call
+/// that precedes deserialization of non-streaming operations).
+///
+/// [`into_captured`]: VectorIndexesCaptureInterceptor::into_captured
+/// [`read_after_deserialization`]: Intercept::read_after_deserialization
+#[derive(Debug, Clone)]
+struct VectorIndexesCaptureInterceptor {
+    captured: Arc<Mutex<Option<serde_json::Value>>>,
+}
+
+impl VectorIndexesCaptureInterceptor {
+    fn new() -> Self {
+        Self {
+            captured: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Consume the interceptor and return the `VectorIndexes` JSON value
+    /// captured during the last `DescribeTable` call.  Returns `None` if
+    /// `read_after_deserialization` has not fired yet (i.e. the call has not
+    /// completed or failed before the response body was available).
+    fn into_captured(self) -> Option<serde_json::Value> {
+        // `unwrap`: poisoning here means a panic already occurred in the
+        // interceptor thread, which would surface as a test failure anyway.
+        Arc::try_unwrap(self.captured)
+            .expect("no other Arc clones should remain after the SDK call")
+            .into_inner()
+            .unwrap()
+    }
+}
+
+impl Intercept for VectorIndexesCaptureInterceptor {
+    fn name(&self) -> &'static str {
+        "VectorIndexesCaptureInterceptor"
+    }
+
+    fn read_after_deserialization(
+        &self,
+        context: &AfterDeserializationInterceptorContextRef<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let bytes = context
+            .response()
+            .body()
+            .bytes()
+            .ok_or("expected buffered response body for DescribeTable")?;
+
+        let json: serde_json::Value = serde_json::from_slice(bytes)?;
+
+        let table = json
+            .get("Table")
+            .ok_or("raw DescribeTable should contain 'Table' key")?;
+
+        // `VectorIndexes` is our extension field - capture it as-is so the
+        // test can assert on the full value.  Absence is stored as None and
+        // surfaced by the test assertion rather than aborting the SDK call.
+        *self.captured.lock().unwrap() = table.get("VectorIndexes").cloned();
+
+        Ok(())
+    }
+}
+
+/// Asserts that `actual` JSON contains all fields from `expected`, allowing
+/// additional attributes in objects. Arrays must match in length and each
+/// element is checked recursively. Scalar values must be exactly equal.
+fn assert_json_includes(actual: &serde_json::Value, expected: &serde_json::Value, ctx: &str) {
+    match (actual, expected) {
+        (serde_json::Value::Object(a), serde_json::Value::Object(e)) => {
+            for (k, v) in e {
+                let a_v = a
+                    .get(k)
+                    .unwrap_or_else(|| panic!("{ctx}: missing key {k:?}"));
+                assert_json_includes(a_v, v, &format!("{ctx}.{k}"));
+            }
+        }
+        (serde_json::Value::Array(a), serde_json::Value::Array(e)) => {
+            assert_eq!(a.len(), e.len(), "{ctx}: array length mismatch");
+            for (i, (a_v, e_v)) in a.iter().zip(e.iter()).enumerate() {
+                assert_json_includes(a_v, e_v, &format!("{ctx}[{i}]"));
+            }
+        }
+        _ => assert_eq!(actual, expected, "{ctx}: value mismatch"),
+    }
+}
+
+/// Creates, describes, and deletes Alternator tables for every entry in
+/// [`alternator::name_patterns`] (the 2x2 matrix of plain/special x HASH-only/HASH+RANGE).
+/// For each shape the test:
+/// 1. Calls `CreateTable` with a vector index.
+/// 2. Waits for Vector Store to discover the index.
+/// 3. Calls `DescribeTable` and verifies the `VectorIndexes` extension field.
+/// 4. Calls `DeleteTable` and waits for Vector Store to drop the index.
+#[framed]
+async fn create_describe_and_delete_table_with_vector_index(actors: TestActors) {
+    info!("started");
+
+    let (client, vs_clients) = alternator::make_clients(&actors).await;
+
+    let patterns = alternator::name_patterns();
+    for (i, shape) in patterns.iter().enumerate() {
+        info!("NAME_PATTERNS[{i}]: {shape:?}");
+
+        let vec_attr = shape.vec().expect("NAME_PATTERNS entries always have vec");
+        let (table_name, index) = alternator::resolve_table_names(shape);
+
+        info!(
+            "Creating Alternator table '{table_name}' with VectorIndex '{}'",
+            index.index
+        );
+        alternator::create_table(
+            &client,
+            &table_name,
+            shape.pk(),
+            shape.pk_type.clone(),
+            shape.sk(),
+            &[(index.index.as_ref(), vec_attr, 3)],
+        )
+        .await
+        .expect("CreateTable with VectorIndex should succeed");
+
+        info!(
+            "Waiting for Vector Store to discover index '{}/{}'",
+            index.keyspace, index.index
+        );
+        alternator::wait_for_index(&vs_clients, &index).await;
+
+        info!("Describing Alternator table '{table_name}' and asserting VectorIndexes");
+        let interceptor = VectorIndexesCaptureInterceptor::new();
+        client
+            .describe_table()
+            .table_name(&table_name)
+            .customize()
+            .interceptor(interceptor.clone())
+            .send()
+            .await
+            .expect("DescribeTable should succeed");
+
+        let ctx = format!("NAME_PATTERNS[{i}]");
+        let captured = interceptor
+            .into_captured()
+            .expect("VectorIndexesCaptureInterceptor should have fired");
+        assert_json_includes(
+            &captured,
+            &serde_json::json!([{
+                "IndexName": index.index.as_ref(),
+                "VectorAttribute": { "AttributeName": vec_attr, "Dimensions": 3 },
+                "IndexStatus": "ACTIVE",
+                "Projection": { "ProjectionType": "KEYS_ONLY" }
+            }]),
+            &ctx,
+        );
+
+        info!("Deleting Alternator table '{table_name}'");
+        alternator::delete_table(&client, &table_name).await;
+
+        info!(
+            "Waiting for Vector Store to drop index '{}/{}'",
+            index.keyspace, index.index
+        );
+        alternator::wait_for_no_index(&vs_clients, &index).await;
+
+        info!("NAME_PATTERNS[{i}] passed");
+    }
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "create_describe_and_delete_table_with_vector_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_describe_and_delete_table_with_vector_index,
+        )
+}

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -1,0 +1,499 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+mod create_table;
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_config::BehaviorVersion;
+use aws_credential_types::Credentials;
+use aws_sdk_dynamodb::Client;
+use aws_sdk_dynamodb::config::Region;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::create_table::CreateTableError;
+use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
+use aws_sdk_dynamodb::types::AttributeDefinition;
+use aws_sdk_dynamodb::types::BillingMode;
+use aws_sdk_dynamodb::types::KeySchemaElement;
+use aws_sdk_dynamodb::types::KeyType;
+use aws_sdk_dynamodb::types::ScalarAttributeType;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::config_bag::ConfigBag;
+use e2etest::TestCase;
+use http::HeaderValue;
+use http::header::CONTENT_LENGTH;
+use httpapi::IndexInfo;
+use httpapi::IndexName;
+use httpapi::KeyspaceName;
+use httpclient::HttpClient;
+use serde_json::Map;
+use serde_json::Value;
+use std::net::Ipv4Addr;
+use std::sync::atomic::AtomicUsize;
+use tracing::info;
+
+static TABLE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+static INDEX_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_table_name() -> String {
+    common::unique_name("Alt-Tbl", &TABLE_COUNTER)
+}
+
+fn unique_index_name() -> IndexName {
+    common::unique_name("Alt-Idx", &INDEX_COUNTER).into()
+}
+
+/// Maximum DynamoDB table name length accepted by ScyllaDB Alternator.
+///
+/// DynamoDB allows up to 255 characters, but ScyllaDB lowers this:
+/// Scylla stores each table in a directory named `<table>-<UUID>` (33 extra
+/// bytes), and Linux limits directory names to 255 bytes, capping CQL names
+/// at 222. Alternator then lowers it further to 192 to leave room for the
+/// `_scylla_cdc_log` suffix (15 chars) added when CDC/streams are enabled.
+/// See ScyllaDB `alternator/executor_util.hh`: `max_table_name_length = 192`.
+const MAX_ALTERNATOR_TABLE_NAME_LEN: usize = 192;
+
+/// Maximum DynamoDB vector index name length accepted by ScyllaDB Alternator.
+///
+/// Alternator validates index names with the same function and limit as table
+/// names. Documented in ScyllaDB `docs/alternator/vector-search.md`:
+/// "`IndexName`: 3–192 characters, matching the regex `[a-zA-Z0-9._-]+`".
+const MAX_ALTERNATOR_INDEX_NAME_LEN: usize = MAX_ALTERNATOR_TABLE_NAME_LEN;
+
+/// Maximum DynamoDB attribute name length in bytes.
+///
+/// Per AWS DynamoDB naming rules: attribute names must be between 1 and 255
+/// bytes long (UTF-8 encoded).
+/// See <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html>.
+const MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN: usize = 255;
+
+#[framed]
+pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
+    vec![("alternator_create_table".into(), create_table::new().await)]
+}
+
+const ALTERNATOR_PORT: u16 = 8000;
+
+/// In ScyllaDB Alternator, a DynamoDB table named `T` is stored under the CQL
+/// keyspace `alternator_T`. Vector Store discovers indexes by scanning
+/// `system_schema.indexes`, so the keyspace name is what VS uses to identify
+/// an Alternator-backed index.
+fn keyspace(table_name: &str) -> KeyspaceName {
+    format!("alternator_{table_name}").into()
+}
+
+/// A DynamoDB SDK interceptor that injects arbitrary key/value pairs into the
+/// JSON request body before SigV4 signing.
+///
+/// The standard `aws-sdk-dynamodb` crate serialises requests without knowledge
+/// of ScyllaDB Alternator extension fields such as `VectorIndexes`.  This
+/// interceptor fires in [`modify_before_signing`], reads the already-serialised
+/// JSON body, merges the provided fields, re-serialises, replaces the body, and
+/// updates the `Content-Length` header so the SigV4 signature and HTTP transport
+/// both operate on the correct byte count.
+///
+/// # Example
+/// ```ignore
+/// client
+///     .create_table()
+///     // ...
+///     .customize()
+///     .interceptor(JsonBodyInjectInterceptor::new([
+///         ("VectorIndexes", vector_indexes_json),
+///     ]))
+///     .send()
+///     .await?;
+/// ```
+///
+/// [`modify_before_signing`]: Intercept::modify_before_signing
+#[derive(Debug, Clone)]
+struct JsonBodyInjectInterceptor {
+    fields: Map<String, Value>,
+}
+
+impl JsonBodyInjectInterceptor {
+    /// Creates a new interceptor that will inject the given `fields` into every
+    /// outgoing request body.
+    fn new(fields: impl IntoIterator<Item = (impl Into<String>, Value)>) -> Self {
+        Self {
+            fields: fields.into_iter().map(|(k, v)| (k.into(), v)).collect(),
+        }
+    }
+}
+
+impl Intercept for JsonBodyInjectInterceptor {
+    fn name(&self) -> &'static str {
+        "JsonBodyInjectInterceptor"
+    }
+
+    fn modify_before_signing(
+        &self,
+        context: &mut BeforeTransmitInterceptorContextMut<'_>,
+        _runtime_components: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let new_bytes = {
+            let original = context
+                .request()
+                .body()
+                .bytes()
+                .ok_or("expected in-memory body for Alternator request")?
+                .to_vec();
+
+            let mut json: Value = serde_json::from_slice(&original)?;
+            let obj = json
+                .as_object_mut()
+                .ok_or("expected JSON object body for Alternator request")?;
+            for (key, value) in &self.fields {
+                obj.insert(key.clone(), value.clone());
+            }
+            serde_json::to_vec(&json)?
+        };
+
+        let new_len = new_bytes.len();
+
+        let request = context.request_mut();
+        *request.body_mut() = SdkBody::from(new_bytes);
+        request.headers_mut().insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&new_len.to_string()).expect("content-length value is valid"),
+        );
+
+        Ok(())
+    }
+}
+
+/// Builds a DynamoDB client pointing at the ScyllaDB Alternator endpoint on
+/// `db_ip`.
+///
+/// Dummy AWS credentials are used because authorization is disabled in tests
+/// via `--alternator-enforce-authorization=false`.
+async fn make_dynamodb_client(db_ip: Ipv4Addr) -> Client {
+    let creds = Credentials::new("any", "any", None, None, "test");
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .credentials_provider(creds)
+        .endpoint_url(format!("http://{db_ip}:{ALTERNATOR_PORT}"))
+        .region(Region::new("us-east-1"))
+        .load()
+        .await;
+    Client::new(&config)
+}
+
+/// Polls the Alternator HTTP endpoint on `db_ip` until it responds successfully.
+///
+/// The Alternator port may become available slightly after the CQL port (which
+/// is what `db.wait_for_ready()` checks), so `init` should call this once after
+/// the cluster has started before any tests run.
+async fn wait_for_alternator(db_ip: Ipv4Addr) {
+    let client = make_dynamodb_client(db_ip).await;
+    common::wait_for(
+        || {
+            let c = client.clone();
+            async move { c.list_tables().limit(1).send().await.is_ok() }
+        },
+        format!("Alternator endpoint at http://{db_ip}:{ALTERNATOR_PORT} to be ready"),
+        common::DEFAULT_TEST_TIMEOUT,
+    )
+    .await;
+}
+
+async fn make_clients(actors: &TestActors) -> (Client, Vec<HttpClient>) {
+    let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
+    let dynamodb_client = make_dynamodb_client(db_ip).await;
+    let vs_clients = common::get_default_vs_ips(actors)
+        .into_iter()
+        .map(|ip| HttpClient::new((ip, common::VS_PORT).into()))
+        .collect();
+    (dynamodb_client, vs_clients)
+}
+
+async fn wait_for_index(clients: &[HttpClient], index: &IndexInfo) {
+    for client in clients {
+        common::wait_for_index(client, index).await;
+    }
+}
+
+async fn wait_for_no_index(clients: &[HttpClient], index: &IndexInfo) {
+    for client in clients {
+        common::wait_for_no_index(client, index).await;
+    }
+}
+
+/// Creates an Alternator table with the given key schema and optional vector
+/// indexes. Pass `&[]` for `vector_indexes` to create a plain table.
+async fn create_table(
+    client: &Client,
+    table_name: &str,
+    partition_key_name: &str,
+    pk_type: ScalarAttributeType,
+    sort_key_name: Option<&str>,
+    vector_indexes: &[(&str, &str, usize)],
+) -> Result<CreateTableOutput, SdkError<CreateTableError>> {
+    let mut builder = client
+        .create_table()
+        .table_name(table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name(partition_key_name)
+                .attribute_type(pk_type)
+                .build()
+                .expect("failed to build AttributeDefinition"),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name(partition_key_name)
+                .key_type(KeyType::Hash)
+                .build()
+                .expect("failed to build KeySchemaElement"),
+        )
+        .billing_mode(BillingMode::PayPerRequest);
+
+    if let Some(sk) = sort_key_name {
+        builder = builder
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name(sk)
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .expect("failed to build AttributeDefinition"),
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name(sk)
+                    .key_type(KeyType::Range)
+                    .build()
+                    .expect("failed to build KeySchemaElement"),
+            );
+    }
+
+    if vector_indexes.is_empty() {
+        builder.send().await
+    } else {
+        let indexes_json = serde_json::json!(
+            vector_indexes
+                .iter()
+                .map(|(index_name, vec_attr, dims)| {
+                    serde_json::json!({
+                        "IndexName": index_name,
+                        "VectorAttribute": {
+                            "AttributeName": vec_attr,
+                            "Dimensions": dims
+                        }
+                    })
+                })
+                .collect::<Vec<_>>()
+        );
+        builder
+            .customize()
+            .interceptor(JsonBodyInjectInterceptor::new([(
+                "VectorIndexes",
+                indexes_json,
+            )]))
+            .send()
+            .await
+    }
+}
+
+async fn delete_table(client: &Client, table_name: &str) {
+    client
+        .delete_table()
+        .table_name(table_name)
+        .send()
+        .await
+        .expect("DeleteTable should succeed");
+}
+
+/// Standard test init: starts ScyllaDB with the Alternator endpoint enabled on
+/// each node's own IP, alongside the Vector Store.
+#[framed]
+pub async fn init(actors: TestActors) {
+    info!("started");
+
+    let mut scylla_configs = common::get_default_scylla_node_configs(&actors).await;
+
+    for config in &mut scylla_configs {
+        let node_ip = config.db_ip;
+        config.args.extend([
+            format!("--alternator-port={ALTERNATOR_PORT}"),
+            format!("--alternator-address={node_ip}"),
+            "--alternator-write-isolation=only_rmw_uses_lwt".to_string(),
+            "--alternator-enforce-authorization=false".to_string(),
+            // NOTE: --alternator-ttl-period-in-seconds is already set in
+            // DEFAULT_SCYLLA_ARGS (0.5s). ScyllaDB rejects duplicate flags.
+        ]);
+    }
+
+    // Capture db_ip before actors is moved into init_with_config.
+    let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
+    let vs_configs = common::get_default_vs_node_configs(&actors).await;
+    common::init_with_config(actors, scylla_configs, vs_configs).await;
+
+    wait_for_alternator(db_ip).await;
+    info!("finished");
+}
+
+/// Describes the key schema, attribute names, and name prefixes for a test
+/// table. Controls what [`TableContext::create`] builds. See
+/// [`name_patterns`] for the standard 2x2 test matrix.
+#[derive(Debug, Clone)]
+struct TableShape {
+    /// When `Some`, the table name base is padded and composed with a unique
+    /// suffix so that the total equals [`MAX_ALTERNATOR_TABLE_NAME_LEN`].
+    /// When `None`, a plain unique name is used.
+    pub table_prefix: Option<&'static str>,
+    /// Same as `table_prefix`, but for the index name.
+    pub index_prefix: Option<&'static str>,
+    pub pk_name: String,
+    pub sk_name: Option<String>,
+    pub vec_name: Option<String>,
+    /// Scalar type of the partition key attribute.  Use `ScalarAttributeType::S`
+    /// for the default string key; `N` or `B` for numeric / binary key tests.
+    pub pk_type: ScalarAttributeType,
+}
+
+impl TableShape {
+    pub fn pk(&self) -> &str {
+        &self.pk_name
+    }
+    pub fn sk(&self) -> Option<&str> {
+        self.sk_name.as_deref()
+    }
+    pub fn vec(&self) -> Option<&str> {
+        self.vec_name.as_deref()
+    }
+}
+
+//
+// Base strings contain the "interesting" characters we want to test:
+// ASCII special chars, mixed case, hyphens, dots, and multi-byte UTF-8
+// (Cyrillic 2-byte, CJK 3-byte, emoji 4-byte).  The `pad_to_len` helper
+// extends them to the exact maximum length with ASCII 'X' padding.
+
+/// Pads `base` with `pad` bytes to exactly `len` bytes.
+///
+/// # Panics
+/// Panics if `base` is already longer than `len`.
+fn pad_to_len(base: &str, len: usize, pad: char) -> String {
+    assert!(
+        base.len() <= len,
+        "base ({} bytes) exceeds target length ({len})",
+        base.len()
+    );
+    let mut s = String::with_capacity(len);
+    s.push_str(base);
+    for _ in 0..(len - base.len()) {
+        s.push(pad);
+    }
+    debug_assert_eq!(s.len(), len);
+    s
+}
+
+/// Base for special table-name prefixes - tests hyphens, dots, mixed case.
+const SPECIAL_TABLE_BASE: &str = "123-With.Hyphens_UPPER.MixedCase-";
+
+/// Base for special index-name prefixes - tests hyphens, dots, mixed case.
+const SPECIAL_INDEX_BASE: &str = "123-idx.With.Hyphens_UPPER-MixedCase-";
+
+/// Base for special attribute names - tests ASCII punctuation, Cyrillic
+/// (2-byte UTF-8), CJK (3-byte UTF-8), and emoji (4-byte UTF-8).
+const SPECIAL_ATTR_BASE_PK: &str = "1:pk'.\".\\@#$ кириллица 中文 αβ 🦀 ";
+const SPECIAL_ATTR_BASE_SK: &str = "1:sk'.\".\\@#$ кириллица 中文 αβ 🦀 ";
+const SPECIAL_ATTR_BASE_VEC: &str = "1:vec'.\".\\@#$ кириллица 中文 αβ 🦀 ";
+
+/// The 2x2 matrix of table shapes exercised by every `_with_names` test.
+///
+/// Each basic-operation test (`put_item`, `delete_item`, `update_item`,
+/// `batch_write_item`, etc.) loops over this slice so that every operation
+/// is verified against all four combinations:
+///
+/// | Entry | Names | Key schema |
+/// |-------|-------|------------|
+/// | 0 | plain | HASH-only |
+/// | 1 | plain | HASH+RANGE |
+/// | 2 | special (max-length + special chars) | HASH-only |
+/// | 3 | special (max-length + special chars) | HASH+RANGE |
+fn name_patterns() -> Vec<TableShape> {
+    vec![
+        // 0: plain, HASH-only
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "pk".into(),
+            sk_name: None,
+            vec_name: Some("vec".into()),
+            pk_type: ScalarAttributeType::S,
+        },
+        // 1: plain, HASH+RANGE
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "pk".into(),
+            sk_name: Some("sk".into()),
+            vec_name: Some("vec".into()),
+            pk_type: ScalarAttributeType::S,
+        },
+        // 2: special, HASH-only
+        TableShape {
+            table_prefix: Some(SPECIAL_TABLE_BASE),
+            index_prefix: Some(SPECIAL_INDEX_BASE),
+            pk_name: pad_to_len(SPECIAL_ATTR_BASE_PK, MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN, 'X'),
+            sk_name: None,
+            vec_name: Some(pad_to_len(
+                SPECIAL_ATTR_BASE_VEC,
+                MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN,
+                'X',
+            )),
+            pk_type: ScalarAttributeType::S,
+        },
+        // 3: special, HASH+RANGE
+        TableShape {
+            table_prefix: Some(SPECIAL_TABLE_BASE),
+            index_prefix: Some(SPECIAL_INDEX_BASE),
+            pk_name: pad_to_len(SPECIAL_ATTR_BASE_PK, MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN, 'X'),
+            sk_name: Some(pad_to_len(
+                SPECIAL_ATTR_BASE_SK,
+                MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN,
+                'X',
+            )),
+            vec_name: Some(pad_to_len(
+                SPECIAL_ATTR_BASE_VEC,
+                MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN,
+                'X',
+            )),
+            pk_type: ScalarAttributeType::S,
+        },
+    ]
+}
+
+/// Resolves the final table name, index name, and [`IndexInfo`] from a
+/// [`TableShape`].  When a prefix is `Some`, the unique name is appended
+/// with a `"_"` separator and the prefix is padded so the total hits the
+/// maximum length. When `None`, a plain unique name is used.
+///
+/// This is the single source of truth for name construction - used by both
+/// [`TableContext::create`] and tests that manage the table lifecycle directly.
+fn resolve_table_names(shape: &TableShape) -> (String, IndexInfo) {
+    let table_name = match shape.table_prefix {
+        None => unique_table_name(),
+        Some(base) => {
+            let raw = format!("{base}_{}", unique_table_name());
+            pad_to_len(&raw, MAX_ALTERNATOR_TABLE_NAME_LEN, 'X')
+        }
+    };
+    let index_name = match shape.index_prefix {
+        None => unique_index_name().to_string(),
+        Some(base) => {
+            let raw = format!("{base}_{}", unique_index_name());
+            pad_to_len(&raw, MAX_ALTERNATOR_INDEX_NAME_LEN, 'X')
+        }
+    };
+    let index = IndexInfo::new(keyspace(&table_name).as_ref(), &index_name);
+    (table_name, index)
+}

--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -491,6 +491,29 @@ pub async fn wait_for_index(client: &HttpClient, index: &IndexInfo) -> IndexStat
     .await
 }
 
+/// Polls the VS HTTP endpoint until the given index is no longer visible
+/// (i.e. `index_status` returns an error).  Used to confirm that a delete
+/// action (via `UpdateTable` or `DeleteTable`) has been processed and
+/// propagated to the Vector Store.
+pub async fn wait_for_no_index(client: &HttpClient, index: &IndexInfo) {
+    wait_for(
+        || async {
+            client
+                .index_status(&index.keyspace, &index.index)
+                .await
+                .is_err()
+        },
+        format!(
+            "index '{}/{}' to be gone at {}",
+            index.keyspace,
+            index.index,
+            client.url()
+        ),
+        Duration::from_secs(60),
+    )
+    .await;
+}
+
 #[framed]
 pub async fn get_query_results(query: impl Into<String>, session: &Session) -> QueryRowsResult {
     let mut stmt = Statement::new(query);
@@ -522,7 +545,7 @@ static KEYSPACE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static TABLE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static INDEX_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-fn unique_name(prefix: &str, counter: &AtomicUsize) -> String {
+pub(crate) fn unique_name(prefix: &str, counter: &AtomicUsize) -> String {
     format!(
         "{prefix}_{counter}",
         counter = counter.fetch_add(1, Ordering::Relaxed)

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod alternator;
 mod ann;
 mod auth;
 mod cdc;
@@ -245,4 +246,5 @@ pub async fn test_cases() -> impl Iterator<Item = (String, TestCase<TestActors>)
     ]
     .into_iter()
     .map(|(name, test_case)| (name.to_string(), test_case))
+    .chain(alternator::test_cases().await)
 }


### PR DESCRIPTION
Introduce the Alternator integration test suite with shared infrastructure (TableShape, Naming patterns, Injectors for customized AWS SDK calls) and test for basic table and index lifecycle operations: CreateTable, DescribeTable, DeleteTable.