### PR TITLE
vector-store: fullscan stops when index is dropped

### DIFF
--- a/crates/validator/src/full_scan.rs
+++ b/crates/validator/src/full_scan.rs
@@ -8,11 +8,18 @@ use crate::common::*;
 use async_backtrace::framed;
 use e2etest::TestCase;
 use e2etest_scylla_proxy_cluster::ScyllaProxyClusterExt;
+use httpapi::IndexInfo;
+use httpapi::IndexStatus;
+use httpclient::HttpClient;
 use scylla_proxy::Condition;
 use scylla_proxy::Reaction;
+use scylla_proxy::RequestFrame;
+use scylla_proxy::RequestOpcode;
 use scylla_proxy::RequestReaction;
 use scylla_proxy::RequestRule;
+use std::collections::HashMap;
 use std::time::Duration;
+use tokio::sync::mpsc;
 use tracing::info;
 
 #[framed]
@@ -25,6 +32,11 @@ pub(crate) async fn new() -> TestCase<TestActors> {
             "full_scan_is_completed_when_responding_to_messages_concurrently",
             timeout,
             full_scan_is_completed_when_responding_to_messages_concurrently,
+        )
+        .with_test(
+            "full_scan_stops_when_index_is_dropped",
+            timeout,
+            full_scan_stops_when_index_is_dropped,
         )
 }
 
@@ -126,4 +138,169 @@ async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors:
         .expect("failed to drop a keyspace");
 
     info!("finished");
+}
+
+#[framed]
+async fn full_scan_stops_when_index_is_dropped(actors: TestActors) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
+    let client = clients.first().unwrap();
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "id INT PRIMARY KEY, embedding VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+
+    info!("Inserting data to the table");
+    const DATASET_SIZE: i32 = 1000;
+    let embedding: Vec<f32> = vec![0.0, 0.0, 0.0];
+    for i in 0..DATASET_SIZE {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (id, embedding) VALUES (?, ?)"),
+                (i, embedding.clone()),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    info!("Slowing down communication to keep fullscan in progress");
+    const FRAME_DELAY: Duration = Duration::from_millis(50);
+    let (tx_feedback_before_drop, mut rx_feedback_before_drop) = mpsc::unbounded_channel();
+    actors
+        .db_proxy
+        .change_request_rules(Some(vec![RequestRule(
+            Condition::True,
+            RequestReaction::delay(FRAME_DELAY)
+                .with_feedback_when_performed(tx_feedback_before_drop),
+        )]))
+        .await;
+
+    info!("Creating index");
+    let index = create_index(CreateIndexQuery::new(
+        &session,
+        &clients,
+        &table,
+        "embedding",
+    ))
+    .await;
+
+    info!("Waiting for fullscan to reach BOOTSTRAPPING state");
+    wait_for_bootstrapping(client, &index).await;
+
+    let fullscan_statement_id = tokio::time::timeout(Duration::from_secs(10), async {
+        let mut accumulated_counts: HashMap<Vec<u8>, usize> = HashMap::new();
+        while let Some((frame, _)) = rx_feedback_before_drop.recv().await {
+            if frame.opcode != RequestOpcode::Execute {
+                continue;
+            }
+            if let Some(id) = execute_statement_id(&frame) {
+                *accumulated_counts.entry(id).or_insert(0) += 1;
+            }
+            if let Some((statement_id, _)) = accumulated_counts
+                .iter()
+                .max_by_key(|(_, count)| *count)
+                .filter(|(_, count)| **count >= 5)
+            {
+                return statement_id.clone();
+            }
+        }
+        panic!("feedback channel closed before observing enough fullscan frames");
+    })
+    .await
+    .expect("expected to observe at least one fullscan EXECUTE before drop");
+
+    info!("Dropping index while fullscan is still running");
+    session
+        .query_unpaged(format!("DROP INDEX {}", index.index), ())
+        .await
+        .expect("failed to drop an index");
+
+    info!("Waiting for index to be removed from vector-store");
+    wait_for(
+        || async { client.indexes().await.is_empty() },
+        "index must be removed",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+
+    info!("Verifying no DB execute traffic continues after index drop");
+    let (tx_feedback, mut rx_feedback) = mpsc::unbounded_channel();
+    actors
+        .db_proxy
+        .change_request_rules(Some(vec![RequestRule(
+            Condition::RequestOpcode(RequestOpcode::Execute),
+            RequestReaction::noop().with_feedback_when_performed(tx_feedback),
+        )]))
+        .await;
+
+    // We cannot deterministically prove that fullscan has stopped — we can only
+    // observe that no matching execute frames arrive within a bounded window.
+    // A 500ms settle period absorbs any in-flight queries from the transition,
+    // and the remaining 1.5s is long enough to detect ongoing fullscan traffic
+    // (which sends queries at high frequency when active).
+    let mut fullscan_execute_after_drop = 0usize;
+    let settle_until = tokio::time::Instant::now() + Duration::from_millis(500);
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    while let Ok(Some((frame, _))) = tokio::time::timeout_at(deadline, rx_feedback.recv()).await {
+        let Some(statement_id) = execute_statement_id(&frame) else {
+            continue;
+        };
+        if statement_id == fullscan_statement_id && tokio::time::Instant::now() > settle_until {
+            fullscan_execute_after_drop += 1;
+        }
+    }
+
+    assert_eq!(
+        fullscan_execute_after_drop, 0,
+        "fullscan still sends DB execute requests after index drop: {fullscan_execute_after_drop}",
+    );
+
+    info!("Recovering normal communication");
+    actors.db_proxy.turn_off_rules().await;
+
+    info!("Dropping keyspace");
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+fn execute_statement_id(frame: &RequestFrame) -> Option<Vec<u8>> {
+    let body = frame.body.as_ref();
+    if body.len() < 2 {
+        return None;
+    }
+
+    let id_len = u16::from_be_bytes([body[0], body[1]]) as usize;
+    let end = 2 + id_len;
+    if body.len() < end {
+        return None;
+    }
+
+    Some(body[2..end].to_vec())
+}
+
+async fn wait_for_bootstrapping(client: &HttpClient, index: &IndexInfo) {
+    wait_for_value(
+        || async {
+            match client.index_status(&index.keyspace, &index.index).await {
+                Ok(status) if status.status == IndexStatus::Bootstrapping => Some(status),
+                _ => None,
+            }
+        },
+        format!(
+            "index '{}' must reach BOOTSTRAPPING at {}",
+            index.index,
+            client.url()
+        ),
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
 }

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -236,8 +236,16 @@ pub(crate) async fn new(
                         break;
                     }
 
-                    Some(msg) = rx_index.recv() => {
-                        tokio::spawn(process(Arc::clone(&statements), msg, completed_scan_length.clone()));
+                    msg = rx_index.recv() => {
+                        match msg {
+                            Some(msg) => {
+                                tokio::spawn(process(Arc::clone(&statements), msg, completed_scan_length.clone()));
+                            }
+                            None => {
+                                // Index was dropped, stop fullscan.
+                                break;
+                            }
+                        }
                     }
 
                     else => {


### PR DESCRIPTION
Handle None from rx_index.recv() in the db_index fullscan loop by breaking immediately instead of waiting indefinitely for initial_scan. This ensures fullscan terminates when the index is dropped, fixing VECTOR-663.

Also add validator test full_scan_stops_when_index_is_dropped to verify fullscan halts when index is removed by checking for absence of post-drop scan statement executions.

Fixes: VECTOR-663