### PR TITLE
engine: make index-status sync interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ service supports also `.env` files.
 | `VECTOR_STORE_CDC_FINE_SAFETY_INTERVAL`    | Fine-grained CDC reader's safety interval for low-latency updates (ie. `100ms`)                                                                                                      | `100ms`                  |
 | `VECTOR_STORE_CDC_FINE_SLEEP_INTERVAL`     | Fine-grained CDC reader's sleep interval for low-latency updates (ie. `500ms`)                                                                                                       | `500ms`                  |
 | `VECTOR_STORE_MONITOR_INDEXES_INTERVAL`    | How often to poll Scylla for schema changes (new/removed vector indexes). The value is in human readable format (ie. `100ms`)                                                        | `1s`                     |
+| `VECTOR_STORE_INDEX_STATUS_UPDATE_INTERVAL` | How often to sync index status (e.g., BOOTSTRAPPING->SERVING) into the engine's cached state. The value is in human readable format (ie. `100ms`) | `1s`            |
 | `VECTOR_STORE_USEARCH_SIMULATOR`           | Enable simulator for USearch. Provides human readable delays for simulated operations (`search:add-remove:reserve`).                                                                 |                          |
 | `VECTOR_STORE_ALTER_INDEX_SIMULATOR`       | Enable simulator for missing `ALTER INDEX`. When enable indexes aren't deleted and their version is not checked.                                                                     | `false`                  |
 

--- a/crates/vector-store/src/config_manager.rs
+++ b/crates/vector-store/src/config_manager.rs
@@ -491,6 +491,12 @@ pub async fn load_config(env: impl Fn(&str) -> anyhow::Result<String>) -> anyhow
         .transpose()?
         .map(|v| v.into());
 
+    config.engine_status_update_interval = env("VECTOR_STORE_INDEX_STATUS_UPDATE_INTERVAL")
+        .ok()
+        .map(|v| v.parse::<humantime::Duration>())
+        .transpose()?
+        .map(|v| v.into());
+
     config.cql_uri_translation_map = env("VECTOR_STORE_CQL_URI_TRANSLATION_MAP")
         .ok()
         .map(|v| serde_json::from_str(&v))

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -121,14 +121,17 @@ pub(crate) async fn new(
         config_rx.clone(),
     )
     .await?;
+    let check_interval = config_rx
+        .borrow()
+        .engine_status_update_interval
+        .unwrap_or(Duration::from_secs(1));
     let memory_actor = memory::new(config_rx);
 
     tokio::spawn(
         async move {
             debug!("starting");
 
-            const CHECK_INTERVAL: Duration = Duration::from_secs(1);
-            let mut interval = time::interval(CHECK_INTERVAL);
+            let mut interval = time::interval(check_interval);
             loop {
                 tokio::select! {
                     msg = rx.recv() => {

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -173,6 +173,7 @@ pub struct Config {
     pub cdc_fine_safety_interval: Option<Duration>,
     pub cdc_fine_sleep_interval: Option<Duration>,
     pub monitor_indexes_interval: Option<Duration>,
+    pub engine_status_update_interval: Option<Duration>,
     pub disable_colors: bool,
     pub tls_cert_path: Option<std::path::PathBuf>,
     pub tls_key_path: Option<std::path::PathBuf>,
@@ -207,6 +208,7 @@ impl Default for Config {
             cdc_fine_safety_interval: None,
             cdc_fine_sleep_interval: None,
             monitor_indexes_interval: None,
+            engine_status_update_interval: None,
         }
     }
 }


### PR DESCRIPTION
The engine's main loop syncs each index's status from node_state into the engine's internal cache every second (hardcoded CHECK_INTERVAL). This cache is what the get_index_status HTTP endpoint reads, which is what Scylla calls to determine whether a vector index is ready.

Because this interval was hardcoded to 1s, a newly-built index would continue to be reported as CREATING for up to a second after the prefill scan finished and node_state marked it as Serving. This caused tests that wait for IndexStatus==ACTIVE to take at least ~1 second even when the actual indexing completed in milliseconds.

Expose the interval as VECTOR_STORE_INDEX_STATUS_UPDATE_INTERVAL (default: 1s, matching the previous hardcoded value) so test environments can set it to a lower value (e.g. 100ms) to reduce test latency.

For example, before this patch Alternator's vector test suite (in the Scylla core repository) took 57 seconds; With this patch, it is down to 28 seconds.