### PR TITLE
validator: add Alternator UpdateTable integration tests

### DIFF
--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -738,14 +738,29 @@ impl TableContext {
 
     /// Creates a table, inserts items, and adds a vector index via
     /// `UpdateTable`. Waits for VS to serve the index with the correct count.
+    /// All `items` must carry a valid vector. Use
+    /// [`Self::create_with_invalid_data`] when the dataset includes items VS
+    /// should skip.
     async fn create_with_data(actors: &TestActors, shape: &TableShape, items: &[Item]) -> Self {
+        Self::create_with_invalid_data(actors, shape, items, &[]).await
+    }
+
+    /// Like [`Self::create_with_data`] but also pre-inserts `invalid_items`
+    /// (wrong type, missing vector, wrong dimensions) that VS should skip.
+    /// Only `items` count toward the expected index count.
+    async fn create_with_invalid_data(
+        actors: &TestActors,
+        shape: &TableShape,
+        items: &[Item],
+        invalid_items: &[Item],
+    ) -> Self {
         let no_vec_shape = TableShape {
             vec_name: None,
             ..shape.clone()
         };
         let ctx = Self::create(actors, &no_vec_shape).await;
 
-        for item in items {
+        for item in items.iter().chain(invalid_items.iter()) {
             ctx.put(item).await;
         }
 
@@ -786,7 +801,7 @@ impl TableContext {
     }
 
     /// Waits until ANN returns exactly the expected items in the expected order.
-    async fn wait_for_ann(&self, qvec: [f32; 3], expected: &[Item]) {
+    async fn wait_for_ann(&self, qvec: [f32; Item::VEC_DIMS], expected: &[Item]) {
         wait_for_ann(
             &self.vs_clients,
             &self.index,

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -4,6 +4,7 @@
  */
 
 mod create_table;
+mod update_table;
 
 use crate::TestActors;
 use crate::common;
@@ -15,6 +16,7 @@ use aws_sdk_dynamodb::config::Region;
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
+use aws_sdk_dynamodb::operation::delete_table::DeleteTableError;
 use aws_sdk_dynamodb::types::AttributeDefinition;
 use aws_sdk_dynamodb::types::BillingMode;
 use aws_sdk_dynamodb::types::KeySchemaElement;
@@ -38,6 +40,7 @@ use serde_json::Value;
 use std::net::Ipv4Addr;
 use std::sync::atomic::AtomicUsize;
 use tracing::info;
+use tracing::warn;
 
 static TABLE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 static INDEX_COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -76,7 +79,10 @@ const MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN: usize = 255;
 
 #[framed]
 pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
-    vec![("alternator_create_table".into(), create_table::new().await)]
+    vec![
+        ("alternator_create_table".into(), create_table::new().await),
+        ("alternator_update_table".into(), update_table::new().await),
+    ]
 }
 
 const ALTERNATOR_PORT: u16 = 8000;
@@ -301,6 +307,24 @@ async fn create_table(
     }
 }
 
+async fn update_table_vector_indexes(
+    client: &Client,
+    table_name: &str,
+    vector_index_updates: Value,
+) {
+    client
+        .update_table()
+        .table_name(table_name)
+        .customize()
+        .interceptor(JsonBodyInjectInterceptor::new([(
+            "VectorIndexUpdates",
+            vector_index_updates,
+        )]))
+        .send()
+        .await
+        .expect("UpdateTable with VectorIndexUpdates should succeed");
+}
+
 async fn delete_table(client: &Client, table_name: &str) {
     client
         .delete_table()
@@ -496,4 +520,73 @@ fn resolve_table_names(shape: &TableShape) -> (String, IndexInfo) {
     };
     let index = IndexInfo::new(keyspace(&table_name).as_ref(), &index_name);
     (table_name, index)
+}
+
+// ---------------------------------------------------------------------------
+
+/// Test fixture that encapsulates the create-table -> wait -> operate -> cleanup
+/// cycle. `done()` is idempotent (swallows `ResourceNotFoundException`).
+struct TableContext {
+    pub client: Client,
+    pub vs_clients: Vec<HttpClient>,
+    pub table_name: String,
+    pub index: IndexInfo,
+}
+
+impl TableContext {
+    /// Creates a new Alternator table and (optionally) a vector index.
+    async fn create(actors: &TestActors, shape: &TableShape) -> Self {
+        let (client, vs_clients) = make_clients(actors).await;
+
+        let (table_name, index) = resolve_table_names(shape);
+
+        let indexes: Vec<(&str, &str, usize)> = match shape.vec() {
+            Some(va) => vec![(index.index.as_ref(), va, 3)],
+            None => vec![],
+        };
+        create_table(
+            &client,
+            &table_name,
+            shape.pk(),
+            shape.pk_type.clone(),
+            shape.sk(),
+            &indexes,
+        )
+        .await
+        .expect("CreateTable should succeed");
+        if shape.vec().is_some() {
+            wait_for_index(&vs_clients, &index).await;
+        }
+
+        Self {
+            client,
+            vs_clients,
+            table_name,
+            index,
+        }
+    }
+
+    /// Idempotent.
+    async fn done(&self) {
+        match self
+            .client
+            .delete_table()
+            .table_name(&self.table_name)
+            .send()
+            .await
+        {
+            Ok(_) => {}
+            Err(err) => {
+                if !err
+                    .as_service_error()
+                    .is_some_and(|e| matches!(e, DeleteTableError::ResourceNotFoundException(_)))
+                {
+                    warn!(
+                        "DeleteTable for '{}' failed unexpectedly: {err}",
+                        self.table_name
+                    );
+                }
+            }
+        }
+    }
 }

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -18,6 +18,7 @@ use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
 use aws_sdk_dynamodb::operation::delete_table::DeleteTableError;
 use aws_sdk_dynamodb::types::AttributeDefinition;
+use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::types::BillingMode;
 use aws_sdk_dynamodb::types::KeySchemaElement;
 use aws_sdk_dynamodb::types::KeyType;
@@ -31,14 +32,21 @@ use aws_smithy_types::config_bag::ConfigBag;
 use e2etest::TestCase;
 use http::HeaderValue;
 use http::header::CONTENT_LENGTH;
+use httpapi::ColumnName;
 use httpapi::IndexInfo;
 use httpapi::IndexName;
 use httpapi::KeyspaceName;
+use httpapi::Limit;
+use httpapi::Vector;
 use httpclient::HttpClient;
 use serde_json::Map;
 use serde_json::Value;
+use std::collections::HashMap;
+use std::fmt::Write;
 use std::net::Ipv4Addr;
+use std::num::NonZeroUsize;
 use std::sync::atomic::AtomicUsize;
+use std::time::Duration;
 use tracing::info;
 use tracing::warn;
 
@@ -220,6 +228,51 @@ async fn make_clients(actors: &TestActors) -> (Client, Vec<HttpClient>) {
     (dynamodb_client, vs_clients)
 }
 
+fn float_list(values: impl IntoIterator<Item = f32>) -> AttributeValue {
+    AttributeValue::L(
+        values
+            .into_iter()
+            .map(|value| AttributeValue::N(value.to_string()))
+            .collect(),
+    )
+}
+
+/// Builder for a single DynamoDB test item.
+#[derive(Debug, Clone)]
+struct Item(pub HashMap<String, AttributeValue>);
+
+impl Item {
+    const VEC_DIMS: usize = 3;
+
+    fn new(pk_attr: &str, pk_val: AttributeValue) -> Self {
+        let mut map = HashMap::new();
+        map.insert(pk_attr.to_string(), pk_val);
+        Self(map)
+    }
+
+    /// Constructs key attributes depending on whether sort key exists.
+    /// HASH-only -> `pk="{prefix}-{suffix}"`,
+    /// HASH+RANGE -> `pk=prefix, sk=suffix`.
+    fn key(pk_attr: &str, sk_attr: Option<&str>, pk_prefix: &str, suffix: &str) -> Self {
+        if let Some(sk) = sk_attr {
+            Self::new(pk_attr, AttributeValue::S(pk_prefix.to_string()))
+                .sk(sk, AttributeValue::S(suffix.to_string()))
+        } else {
+            Self::new(pk_attr, AttributeValue::S(format!("{pk_prefix}-{suffix}")))
+        }
+    }
+
+    fn sk(mut self, sk_attr: &str, sk_val: AttributeValue) -> Self {
+        self.0.insert(sk_attr.to_string(), sk_val);
+        self
+    }
+
+    fn vec(mut self, vec_attr: &str, v: [f32; Self::VEC_DIMS]) -> Self {
+        self.0.insert(vec_attr.to_string(), float_list(v));
+        self
+    }
+}
+
 async fn wait_for_index(clients: &[HttpClient], index: &IndexInfo) {
     for client in clients {
         common::wait_for_index(client, index).await;
@@ -229,6 +282,108 @@ async fn wait_for_index(clients: &[HttpClient], index: &IndexInfo) {
 async fn wait_for_no_index(clients: &[HttpClient], index: &IndexInfo) {
     for client in clients {
         common::wait_for_no_index(client, index).await;
+    }
+}
+
+/// Polls ANN until the returned keys match `expected` position-by-position.
+async fn wait_for_ann(
+    clients: &[HttpClient],
+    index: &IndexInfo,
+    pk_name: &str,
+    sk_name: Option<&str>,
+    query_vector: [f32; Item::VEC_DIMS],
+    expected: &[Item],
+) {
+    let pk_column: ColumnName = pk_name.into();
+    let sk_column: Option<ColumnName> = sk_name.map(|s| s.into());
+    let expect_count = expected.len();
+
+    let expected_keys: Vec<(String, Option<String>)> = expected
+        .iter()
+        .map(|item| {
+            let pk = av_to_key_string(item.0.get(pk_name).expect("expected Item has no pk attr"));
+            let sk = sk_name
+                .map(|sk| av_to_key_string(item.0.get(sk).expect("expected Item has no sk attr")));
+            (pk, sk)
+        })
+        .collect();
+
+    for client in clients {
+        common::wait_for(
+            || async {
+                let (primary_keys, _distances, _scores) = client
+                    .ann(
+                        &index.keyspace,
+                        &index.index,
+                        Vector::from(query_vector.to_vec()),
+                        None,
+                        Limit::from(
+                            NonZeroUsize::new(expect_count)
+                                .expect("expected ANN result set is non-empty"),
+                        ),
+                    )
+                    .await;
+
+                let Some(pk_values) = primary_keys.get(&pk_column) else {
+                    return false;
+                };
+                if pk_values.len() != expect_count {
+                    return false;
+                }
+
+                let sk_values: Option<&Vec<Value>> = match sk_column.as_ref() {
+                    None => None,
+                    Some(col) => primary_keys.get(col),
+                };
+                if sk_column.is_some() && sk_values.is_none() {
+                    return false;
+                }
+
+                for (i, (exp_pk, exp_sk)) in expected_keys.iter().enumerate() {
+                    let got_pk = json_value_to_key_string(&pk_values[i]);
+                    if got_pk != *exp_pk {
+                        return false;
+                    }
+                    if let (Some(sk_vals), Some(exp_sk_str)) = (sk_values, exp_sk) {
+                        let got_sk = json_value_to_key_string(&sk_vals[i]);
+                        if got_sk != *exp_sk_str {
+                            return false;
+                        }
+                    }
+                }
+
+                true
+            },
+            format!(
+                "index '{}/{}' to return expected ANN keys at {}",
+                index.keyspace,
+                index.index,
+                client.url()
+            ),
+            Duration::from_secs(60),
+        )
+        .await;
+    }
+}
+
+fn av_to_key_string(av: &AttributeValue) -> String {
+    match av {
+        AttributeValue::S(s) => s.clone(),
+        AttributeValue::N(n) => n.clone(),
+        AttributeValue::B(b) => b.as_ref().iter().fold(String::new(), |mut s, byte| {
+            let _ = write!(s, "{byte:02x}");
+            s
+        }),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Strips `0x` prefix from blob hex values.
+fn json_value_to_key_string(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.strip_prefix("0x").unwrap_or(s).to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        other => panic!("unexpected ANN key JSON value: {other:?}"),
     }
 }
 
@@ -531,6 +686,7 @@ struct TableContext {
     pub vs_clients: Vec<HttpClient>,
     pub table_name: String,
     pub index: IndexInfo,
+    pub shape: TableShape,
 }
 
 impl TableContext {
@@ -563,7 +719,78 @@ impl TableContext {
             vs_clients,
             table_name,
             index,
+            shape: shape.clone(),
         }
+    }
+
+    async fn put(&self, item: &Item) {
+        let mut req = self.client.put_item().table_name(&self.table_name);
+        for (attr_name, attr_val) in &item.0 {
+            req = req.item(attr_name, attr_val.clone());
+        }
+        req.send().await.expect("PutItem should succeed");
+    }
+
+    /// Creates a table, inserts items, and adds a vector index via
+    /// `UpdateTable`. Waits for VS to serve the index with the correct count.
+    async fn create_with_data(actors: &TestActors, shape: &TableShape, items: &[Item]) -> Self {
+        let no_vec_shape = TableShape {
+            vec_name: None,
+            ..shape.clone()
+        };
+        let ctx = Self::create(actors, &no_vec_shape).await;
+
+        for item in items {
+            ctx.put(item).await;
+        }
+
+        let vec_attr = match &shape.vec_name {
+            None => return ctx,
+            Some(va) => va,
+        };
+
+        // Add the vector index via UpdateTable (initial-scan path).
+        update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            serde_json::json!([{
+                "Create": {
+                    "IndexName": ctx.index.index.as_ref(),
+                    "VectorAttribute": {
+                        "AttributeName": vec_attr,
+                        "Dimensions": Item::VEC_DIMS
+                    }
+                }
+            }]),
+        )
+        .await;
+
+        ctx.wait_for_count(items.len()).await;
+
+        Self {
+            shape: TableShape {
+                vec_name: Some(vec_attr.clone()),
+                ..ctx.shape
+            },
+            ..ctx
+        }
+    }
+
+    async fn wait_for_count(&self, n: usize) {
+        common::wait_for_index_count(&self.vs_clients, &self.index, n).await;
+    }
+
+    /// Waits until ANN returns exactly the expected items in the expected order.
+    async fn wait_for_ann(&self, qvec: [f32; 3], expected: &[Item]) {
+        wait_for_ann(
+            &self.vs_clients,
+            &self.index,
+            self.shape.pk(),
+            self.shape.sk(),
+            qvec,
+            expected,
+        )
+        .await
     }
 
     /// Idempotent.

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -271,6 +271,11 @@ impl Item {
         self.0.insert(vec_attr.to_string(), float_list(v));
         self
     }
+
+    fn attr(mut self, name: &str, val: AttributeValue) -> Self {
+        self.0.insert(name.to_string(), val);
+        self
+    }
 }
 
 async fn wait_for_index(clients: &[HttpClient], index: &IndexInfo) {

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use e2etest::TestCase;
+use serde_json::Value;
+use tracing::info;
+
+use crate::alternator;
+use crate::alternator::TableContext;
+use crate::alternator::TableShape;
+
+fn vector_index_create_update(index_name: &str, vec_attr: &str) -> Value {
+    serde_json::json!([
+        {
+            "Create": {
+                "IndexName": index_name,
+                "VectorAttribute": {
+                    "AttributeName": vec_attr,
+                    "Dimensions": 3
+                }
+            }
+        }
+    ])
+}
+
+#[framed]
+async fn create_vector_index_via_update_table(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        let no_vec_shape = TableShape {
+            vec_name: None,
+            ..shape.clone()
+        };
+        let vec_attr = shape.vec().unwrap_or("vec");
+        info!("Testing shape: {shape:?}");
+
+        let ctx = TableContext::create(&actors, &no_vec_shape).await;
+
+        info!("Confirming no index exists yet for '{}'", ctx.table_name);
+        alternator::wait_for_no_index(&ctx.vs_clients, &ctx.index).await;
+
+        info!(
+            "Issuing UpdateTable for '{}' to add vector index '{}'",
+            ctx.table_name, ctx.index.index
+        );
+        alternator::update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            vector_index_create_update(ctx.index.index.as_ref(), vec_attr),
+        )
+        .await;
+
+        info!(
+            "Waiting for Vector Store to serve index '{}/{}'",
+            ctx.index.keyspace, ctx.index.index
+        );
+        alternator::wait_for_index(&ctx.vs_clients, &ctx.index).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "create_vector_index_via_update_table",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_vector_index_via_update_table,
+        )
+}

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use tracing::info;
 
 use crate::alternator;
+use crate::alternator::Item;
 use crate::alternator::TableContext;
 use crate::alternator::TableShape;
 
@@ -21,7 +22,7 @@ fn vector_index_create_update(index_name: &str, vec_attr: &str) -> Value {
                 "IndexName": index_name,
                 "VectorAttribute": {
                     "AttributeName": vec_attr,
-                    "Dimensions": 3
+                    "Dimensions": Item::VEC_DIMS
                 }
             }
         }
@@ -69,6 +70,57 @@ async fn create_vector_index_via_update_table(actors: TestActors) {
     info!("finished");
 }
 
+/// Like above but with pre-existing data in the table before adding the index.
+#[framed]
+async fn create_vector_index_via_update_table_with_preexisting_data(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        let vec_attr = shape.vec().unwrap_or("vec");
+        info!("Testing shape: {shape:?}");
+
+        let no_vec_shape = TableShape {
+            vec_name: None,
+            ..shape.clone()
+        };
+
+        let items = [
+            Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]),
+        ];
+
+        let ctx = TableContext::create_with_data(&actors, &no_vec_shape, &items).await;
+
+        info!("Confirming no index exists yet for '{}'", ctx.table_name);
+        alternator::wait_for_no_index(&ctx.vs_clients, &ctx.index).await;
+
+        info!(
+            "Issuing UpdateTable for '{}' to add vector index '{}'",
+            ctx.table_name, ctx.index.index
+        );
+        alternator::update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            vector_index_create_update(ctx.index.index.as_ref(), vec_attr),
+        )
+        .await;
+
+        info!(
+            "Waiting for Vector Store to serve index '{}/{}'",
+            ctx.index.keyspace, ctx.index.index
+        );
+        common::wait_for_index_count(&ctx.vs_clients, &ctx.index, items.len()).await;
+
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &items).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
 pub(super) async fn new() -> TestCase<TestActors> {
     TestCase::empty()
         .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
@@ -77,5 +129,10 @@ pub(super) async fn new() -> TestCase<TestActors> {
             "create_vector_index_via_update_table",
             common::DEFAULT_TEST_TIMEOUT,
             create_vector_index_via_update_table,
+        )
+        .with_test(
+            "create_vector_index_via_update_table_with_preexisting_data",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_vector_index_via_update_table_with_preexisting_data,
         )
 }

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -6,6 +6,7 @@
 use crate::TestActors;
 use crate::common;
 use async_backtrace::framed;
+use aws_sdk_dynamodb::types::AttributeValue;
 use e2etest::TestCase;
 use serde_json::Value;
 use tracing::info;
@@ -121,6 +122,56 @@ async fn create_vector_index_via_update_table_with_preexisting_data(actors: Test
     info!("finished");
 }
 
+/// Deletes a vector index via UpdateTable and verifies writes succeed after.
+#[framed]
+async fn delete_vector_index_via_update_table(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let vec_attr = shape.vec().unwrap();
+        let items = [
+            Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]),
+        ];
+        let ctx = TableContext::create_with_data(&actors, shape, &items).await;
+
+        info!(
+            "Issuing UpdateTable for '{}' to delete vector index '{}'",
+            ctx.table_name, ctx.index.index
+        );
+        alternator::update_table_vector_indexes(
+            &ctx.client,
+            &ctx.table_name,
+            serde_json::json!([{
+                "Delete": {
+                    "IndexName": ctx.index.index.as_ref()
+                }
+            }]),
+        )
+        .await;
+
+        info!(
+            "Waiting for Vector Store to drop index '{}/{}'",
+            ctx.index.keyspace, ctx.index.index
+        );
+        alternator::wait_for_no_index(&ctx.vs_clients, &ctx.index).await;
+
+        info!("Confirming arbitrary writes are accepted after index deletion");
+        ctx.put(
+            &Item::key(shape.pk(), shape.sk(), "pk", "c")
+                .attr(vec_attr, AttributeValue::S("not-a-vector".into())),
+        )
+        .await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
 pub(super) async fn new() -> TestCase<TestActors> {
     TestCase::empty()
         .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
@@ -134,5 +185,10 @@ pub(super) async fn new() -> TestCase<TestActors> {
             "create_vector_index_via_update_table_with_preexisting_data",
             common::DEFAULT_TEST_TIMEOUT,
             create_vector_index_via_update_table_with_preexisting_data,
+        )
+        .with_test(
+            "delete_vector_index_via_update_table",
+            common::DEFAULT_TEST_TIMEOUT,
+            delete_vector_index_via_update_table,
         )
 }

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -122,6 +122,67 @@ async fn create_vector_index_via_update_table_with_preexisting_data(actors: Test
     info!("finished");
 }
 
+/// Verifies that the initial-scan path skips non-indexable rows.
+#[framed]
+async fn create_vector_index_via_update_table_with_invalid_data(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        let vec_attr = shape.vec().unwrap_or("vec");
+        info!("Testing shape: {shape:?}");
+
+        let vec_with_string_elem = AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::S("3.0".into()),
+        ]);
+        let vec_with_null_elem = AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::Null(true),
+        ]);
+        let valid_items = [
+            Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]),
+            Item::key(shape.pk(), shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]),
+        ];
+        let invalid_items = [
+            Item::key(shape.pk(), shape.sk(), "pk", "no-vec"),
+            Item::key(shape.pk(), shape.sk(), "pk", "wrong-type-string")
+                .attr(vec_attr, AttributeValue::S("not-a-vector".into())),
+            Item::key(
+                shape.pk(),
+                shape.sk(),
+                "pk",
+                "wrong-type-mostly-float-one-s",
+            )
+            .attr(vec_attr, vec_with_string_elem),
+            Item::key(
+                shape.pk(),
+                shape.sk(),
+                "pk",
+                "wrong-type-mostly-float-one-null",
+            )
+            .attr(vec_attr, vec_with_null_elem),
+            Item::key(shape.pk(), shape.sk(), "pk", "wrong-type-too-short")
+                .attr(vec_attr, alternator::float_list([1.0_f32, 1.0])),
+            Item::key(shape.pk(), shape.sk(), "pk", "wrong-type-too-long")
+                .attr(vec_attr, alternator::float_list([1.0_f32, 1.0, 1.0, 1.0])),
+        ];
+
+        let ctx =
+            TableContext::create_with_invalid_data(&actors, shape, &valid_items, &invalid_items)
+                .await;
+
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &valid_items).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
 /// Deletes a vector index via UpdateTable and verifies writes succeed after.
 #[framed]
 async fn delete_vector_index_via_update_table(actors: TestActors) {
@@ -185,6 +246,11 @@ pub(super) async fn new() -> TestCase<TestActors> {
             "create_vector_index_via_update_table_with_preexisting_data",
             common::DEFAULT_TEST_TIMEOUT,
             create_vector_index_via_update_table_with_preexisting_data,
+        )
+        .with_test(
+            "create_vector_index_via_update_table_with_invalid_data",
+            common::DEFAULT_TEST_TIMEOUT,
+            create_vector_index_via_update_table_with_invalid_data,
         )
         .with_test(
             "delete_vector_index_via_update_table",

--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -491,10 +491,7 @@ pub async fn wait_for_index(client: &HttpClient, index: &IndexInfo) -> IndexStat
     .await
 }
 
-/// Polls the VS HTTP endpoint until the given index is no longer visible
-/// (i.e. `index_status` returns an error).  Used to confirm that a delete
-/// action (via `UpdateTable` or `DeleteTable`) has been processed and
-/// propagated to the Vector Store.
+#[framed]
 pub async fn wait_for_no_index(client: &HttpClient, index: &IndexInfo) {
     wait_for(
         || async {
@@ -512,6 +509,35 @@ pub async fn wait_for_no_index(client: &HttpClient, index: &IndexInfo) {
         Duration::from_secs(60),
     )
     .await;
+}
+
+#[framed]
+pub async fn wait_for_index_count(
+    clients: &[HttpClient],
+    index: &IndexInfo,
+    expected_count: usize,
+) {
+    for client in clients {
+        wait_for(
+            || async {
+                client
+                    .index_status(&index.keyspace, &index.index)
+                    .await
+                    .is_ok_and(|resp| {
+                        resp.status == httpapi::IndexStatus::Serving && resp.count == expected_count
+                    })
+            },
+            format!(
+                "index '{}/{}' to report count {} at {}",
+                index.keyspace,
+                index.index,
+                expected_count,
+                client.url()
+            ),
+            Duration::from_secs(60),
+        )
+        .await;
+    }
 }
 
 #[framed]


### PR DESCRIPTION
End-to-end tests for the UpdateTable vector index lifecycle: creating an index on an empty table, on a table with preexisting data (initial-scan path), deleting an index, and verifying that non-indexable rows (wrong type, missing vector, wrong dimensions) are skipped during initial scan.
Introduces shared test infrastructure in alternator::mod — TableContext for table lifecycle management with automatic cleanup, Item builder for DynamoDB items, and ANN result verification helpers — reused across all four tests and subsequent test modules.