### PR TITLE
docs: add docker-compose examples for ScyllaDB + Vector Store

### DIFF
--- a/docs/examples/docker/docker-compose-alternator.yml
+++ b/docs/examples/docker/docker-compose-alternator.yml
@@ -1,0 +1,46 @@
+# Minimal single-node ScyllaDB (Alternator/DynamoDB API) + Vector Store setup (RF=1).
+# Suitable for local development and testing with DynamoDB-compatible clients.
+# Not intended for production use — use replication_factor >= 3 in production.
+#
+# Alternator API is exposed on port 8000 (HTTP).
+# CQL is still available on port 9042 for administrative tasks.
+
+services:
+  scylla:
+    image: scylladb/scylla:2026.1.4
+    container_name: scylla-alternator
+    command: >
+      --smp 2
+      --memory 1G
+      --overprovisioned 1
+      --alternator-port 8000
+      --alternator-write-isolation always_use_lwt
+      --vector-store-primary-uri http://vector-store:6080
+    ports:
+      - "8000:8000"
+      - "9042:9042"
+    healthcheck:
+      test: ["CMD-SHELL", "cqlsh -e 'SELECT now() FROM system.local'"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+    networks:
+      - vector-net
+
+  vector-store:
+    image: scylladb/vector-store:1.6.0
+    container_name: vector-store
+    environment:
+      VECTOR_STORE_URI: "0.0.0.0:6080"
+      VECTOR_STORE_SCYLLADB_URI: "scylla-alternator:9042"
+    ports:
+      - "6080:6080"
+    depends_on:
+      scylla:
+        condition: service_healthy
+    networks:
+      - vector-net
+
+networks:
+  vector-net:
+    driver: bridge

--- a/docs/examples/docker/docker-compose.yml
+++ b/docs/examples/docker/docker-compose.yml
@@ -1,0 +1,40 @@
+# Minimal single-node ScyllaDB + Vector Store setup (RF=1).
+# Suitable for local development, testing, and quick-start examples.
+# Not intended for production use — use replication_factor >= 3 in production.
+
+services:
+  scylla:
+    image: scylladb/scylla:2026.1.4
+    container_name: scylla
+    command: >
+      --smp 2
+      --memory 1G
+      --overprovisioned 1
+      --vector-store-primary-uri http://vector-store:6080
+    ports:
+      - "9042:9042"
+    healthcheck:
+      test: ["CMD-SHELL", "cqlsh -e 'SELECT now() FROM system.local'"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+    networks:
+      - vector-net
+
+  vector-store:
+    image: scylladb/vector-store:1.6.0
+    container_name: vector-store
+    environment:
+      VECTOR_STORE_URI: "0.0.0.0:6080"
+      VECTOR_STORE_SCYLLADB_URI: "scylla:9042"
+    ports:
+      - "6080:6080"
+    depends_on:
+      scylla:
+        condition: service_healthy
+    networks:
+      - vector-net
+
+networks:
+  vector-net:
+    driver: bridge


### PR DESCRIPTION
## Summary

Add minimal single-node docker-compose setups for local development and testing.

### Files added

- `docs/examples/docker/docker-compose.yml` — Standard CQL setup with ScyllaDB 2026.1.4 and Vector Store 1.6.0 (RF=1)
- `docs/examples/docker/docker-compose-alternator.yml` — Same setup with Alternator (DynamoDB API) enabled on port 8000

### Validated

Both setups have been tested end-to-end:
- ScyllaDB + Vector Store starts successfully
- Vector index creation and ANN queries work
- Alternator API responds to DynamoDB-compatible requests on port 8000