### PR TITLE
validator: add Alternator index data mutation and TTL tests

### DIFF
--- a/crates/validator/src/alternator/batch_write_item.rs
+++ b/crates/validator/src/alternator/batch_write_item.rs
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemError;
+use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemOutput;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use tracing::info;
+
+use crate::alternator;
+use crate::alternator::Item;
+use crate::alternator::TableContext;
+
+fn build_put_requests(items: &[Item]) -> Vec<aws_sdk_dynamodb::types::WriteRequest> {
+    items
+        .iter()
+        .map(|item| {
+            let mut builder = aws_sdk_dynamodb::types::PutRequest::builder();
+            for (attr_name, attr_val) in &item.0 {
+                builder = builder.item(attr_name, attr_val.clone());
+            }
+            aws_sdk_dynamodb::types::WriteRequest::builder()
+                .put_request(builder.build().expect("failed to build PutRequest"))
+                .build()
+        })
+        .collect()
+}
+
+async fn batch_write_items(
+    ctx: &TableContext,
+    puts: &[Item],
+    deletes: &[Item],
+) -> Result<BatchWriteItemOutput, SdkError<BatchWriteItemError>> {
+    let mut write_requests = build_put_requests(puts);
+
+    write_requests.extend(deletes.iter().map(|item| {
+        let mut builder = aws_sdk_dynamodb::types::DeleteRequest::builder();
+        let key_attrs: Vec<&str> = std::iter::once(ctx.shape.pk())
+            .chain(ctx.shape.sk())
+            .collect();
+        for attr_name in key_attrs {
+            if let Some(attr_val) = item.0.get(attr_name) {
+                builder = builder.key(attr_name, attr_val.clone());
+            }
+        }
+        aws_sdk_dynamodb::types::WriteRequest::builder()
+            .delete_request(builder.build().expect("failed to build DeleteRequest"))
+            .build()
+    }));
+
+    ctx.client
+        .batch_write_item()
+        .request_items(&ctx.table_name, write_requests)
+        .send()
+        .await
+}
+
+/// Exercises `BatchWriteItem` (puts, replaces, mixed put+delete, delete-only)
+/// and verifies the VS index is updated correctly.
+///
+/// Loops [`alternator::name_patterns`] to cover all key schema and
+/// naming combinations.
+#[framed]
+async fn batch_write_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let ctx = TableContext::create(&actors, shape).await;
+        let vec_attr = ctx.shape.vec().expect("TableContext has no vec_attr");
+
+        let a = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]);
+        let b = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let c = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]);
+
+        info!(
+            "Batch writing initial put requests into '{}'",
+            ctx.table_name
+        );
+        batch_write_items(&ctx, &[a.clone(), b.clone(), c.clone()], &[])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[a.clone(), b.clone(), c.clone()])
+            .await;
+
+        // Replace a with a_replaced=[-1,-1,-1] - same key, vector points in the
+        // opposite direction so it falls to last position in ANN results.
+        // b=[1,2,4] and c=[1,4,8] retain their order.
+        let a_replaced =
+            Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [-1.0, -1.0, -1.0]);
+        batch_write_items(&ctx, std::slice::from_ref(&a_replaced), &[])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b.clone(), c.clone(), a_replaced.clone()])
+            .await;
+
+        // Mixed put + delete - add d, remove a (using a_replaced which holds the
+        // current state of that key).
+        info!(
+            "Batch writing mixed put and delete requests into '{}'",
+            ctx.table_name
+        );
+        let d = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "d").vec(vec_attr, [1.0, 1.0, 1.0]);
+        batch_write_items(&ctx, std::slice::from_ref(&d), &[a_replaced])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[d.clone(), b.clone(), c.clone()])
+            .await;
+
+        info!("Batch writing delete requests into '{}'", ctx.table_name);
+        batch_write_items(&ctx, &[], &[b, c])
+            .await
+            .expect("BatchWriteItem should succeed");
+        ctx.wait_for_count(1).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&d))
+            .await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Tests that `BatchWriteItem` containing an item with an invalid vector type
+/// is rejected by Scylla and does not update the VS index. Covers string
+/// values, mixed-type lists, NULL elements, and wrong dimensions.
+#[framed]
+async fn batch_write_item_with_invalid_vector(actors: TestActors) {
+    info!("started");
+
+    let shape = &alternator::name_patterns()[0]; // plain names, HASH-only
+    let ctx = TableContext::create(&actors, shape).await;
+    let vec_attr = ctx.shape.vec().expect("TableContext has no vec_attr");
+
+    let pk = shape.pk();
+
+    let vec_with_string_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::S("3.0".into()),
+    ]);
+    let vec_with_null_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::Null(true),
+    ]);
+
+    info!(
+        "Scenario 1: batch put valid + no_vec into '{}'",
+        ctx.table_name
+    );
+    let valid = Item::key(pk, None, "pk", "valid").vec(vec_attr, [1.0, 1.0, 1.0]);
+    let no_vec = Item::key(pk, None, "pk", "no-vec");
+    batch_write_items(&ctx, &[valid.clone(), no_vec], &[])
+        .await
+        .expect("BatchWriteItem should succeed");
+    ctx.wait_for_count(1).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&valid))
+        .await;
+
+    info!(
+        "Scenario 2: batch put valid2 + wrong_type(String) into '{}'",
+        ctx.table_name
+    );
+    let valid2 = Item::key(pk, None, "pk", "valid2").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let wrong_type_string = Item::key(pk, None, "pk", "wrong-type-string")
+        .attr(vec_attr, AttributeValue::S("bad".into()));
+    alternator::assert_service_error(
+        batch_write_items(&ctx, &[valid2, wrong_type_string], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 3: batch put valid3 + wrong_type(mostly-float, one S) into '{}'",
+        ctx.table_name
+    );
+    let valid3 = Item::key(pk, None, "pk", "valid3").vec(vec_attr, [1.0, 4.0, 8.0]);
+    let wrong_type_mostly_float_one_s = Item::key(pk, None, "pk", "wrong-type-mostly-float-one-s")
+        .attr(vec_attr, vec_with_string_elem);
+    alternator::assert_service_error(
+        batch_write_items(&ctx, &[valid3, wrong_type_mostly_float_one_s], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 4: batch put valid4 + wrong_type(mostly-float, one NULL) into '{}'",
+        ctx.table_name
+    );
+    let valid4 = Item::key(pk, None, "pk", "valid4").vec(vec_attr, [-1.0, -1.0, -1.0]);
+    let wrong_type_mostly_float_one_null =
+        Item::key(pk, None, "pk", "wrong-type-mostly-float-one-null")
+            .attr(vec_attr, vec_with_null_elem);
+    alternator::assert_service_error(
+        batch_write_items(&ctx, &[valid4, wrong_type_mostly_float_one_null], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 5: batch put valid5 + wrong_type(too-short) into '{}'",
+        ctx.table_name
+    );
+    let valid5 = Item::key(pk, None, "pk", "valid5").vec(vec_attr, [1.0, 1.0, 2.0]);
+    let wrong_type_too_short = Item::key(pk, None, "pk", "wrong-type-too-short")
+        .attr(vec_attr, alternator::float_list([1.0_f32, 1.0]));
+    alternator::assert_service_error(
+        batch_write_items(&ctx, &[valid5, wrong_type_too_short], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    info!(
+        "Scenario 6: batch put valid6 + wrong_type(too-long) into '{}'",
+        ctx.table_name
+    );
+    let valid6 = Item::key(pk, None, "pk", "valid6").vec(vec_attr, [2.0, 1.0, 1.0]);
+    let wrong_type_too_long = Item::key(pk, None, "pk", "wrong-type-too-long")
+        .attr(vec_attr, alternator::float_list([1.0_f32, 1.0, 1.0, 1.0]));
+    alternator::assert_service_error(
+        batch_write_items(&ctx, &[valid6, wrong_type_too_long], &[]).await,
+        "ValidationException",
+    );
+    ctx.wait_for_count(1).await;
+
+    ctx.done().await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "batch_write_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            batch_write_item_updates_index,
+        )
+        .with_test(
+            "batch_write_item_with_invalid_vector",
+            common::DEFAULT_TEST_TIMEOUT,
+            batch_write_item_with_invalid_vector,
+        )
+}

--- a/crates/validator/src/alternator/delete_item.rs
+++ b/crates/validator/src/alternator/delete_item.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use e2etest::TestCase;
+use tracing::info;
+
+use crate::alternator;
+use crate::alternator::Item;
+use crate::alternator::TableContext;
+
+async fn delete_item(ctx: &TableContext, item: &Item) {
+    let mut req = ctx.client.delete_item().table_name(&ctx.table_name);
+    let key_attrs: Vec<&str> = std::iter::once(ctx.shape.pk())
+        .chain(ctx.shape.sk())
+        .collect();
+    for attr_name in key_attrs {
+        if let Some(attr_val) = item.0.get(attr_name) {
+            req = req.key(attr_name, attr_val.clone());
+        }
+    }
+    req.send().await.expect("DeleteItem should succeed");
+}
+
+/// Inserts items, deletes one via `DeleteItem`, and verifies the VS index
+/// reflects the deletion.
+///
+/// Loops [`alternator::name_patterns`] so that every combination
+/// of key schema (HASH-only / HASH+RANGE) and naming style (plain /
+/// special) is covered.
+#[framed]
+async fn delete_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let vec_attr = shape.vec().expect("NAME_PATTERNS entries always have vec");
+
+        let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]);
+        let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let c = Item::key(shape.pk(), shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]);
+
+        let ctx =
+            TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone(), c.clone()])
+                .await;
+
+        info!("Deleting item from '{}'", ctx.table_name);
+        delete_item(&ctx, &a).await;
+
+        ctx.wait_for_count(2).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b.clone(), c]).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "delete_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            delete_item_updates_index,
+        )
+}

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+mod batch_write_item;
 mod create_table;
 mod put_item;
 mod update_item;
@@ -94,6 +95,10 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
         ("alternator_update_table".into(), update_table::new().await),
         ("alternator_put_item".into(), put_item::new().await),
         ("alternator_update_item".into(), update_item::new().await),
+        (
+            "alternator_batch_write_item".into(),
+            batch_write_item::new().await,
+        ),
     ]
 }
 

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -5,6 +5,7 @@
 
 mod create_table;
 mod put_item;
+mod update_item;
 mod update_table;
 
 use crate::TestActors;
@@ -92,6 +93,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
         ("alternator_create_table".into(), create_table::new().await),
         ("alternator_update_table".into(), update_table::new().await),
         ("alternator_put_item".into(), put_item::new().await),
+        ("alternator_update_item".into(), update_item::new().await),
     ]
 }
 

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -4,6 +4,7 @@
  */
 
 mod create_table;
+mod put_item;
 mod update_table;
 
 use crate::TestActors;
@@ -90,6 +91,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
     vec![
         ("alternator_create_table".into(), create_table::new().await),
         ("alternator_update_table".into(), update_table::new().await),
+        ("alternator_put_item".into(), put_item::new().await),
     ]
 }
 
@@ -494,6 +496,22 @@ async fn delete_table(client: &Client, table_name: &str) {
         .expect("DeleteTable should succeed");
 }
 
+/// Asserts that an SDK result is a service error containing `expected_err`.
+fn assert_service_error<O, E>(result: Result<O, SdkError<E>>, expected_err: &str)
+where
+    O: std::fmt::Debug,
+    E: aws_smithy_types::error::metadata::ProvideErrorMetadata,
+{
+    use aws_sdk_dynamodb::error::ProvideErrorMetadata as _;
+    let err = result.expect_err("operation should have been rejected");
+    let code = err.code().unwrap_or("");
+    let message = err.message().unwrap_or("");
+    assert!(
+        code.contains(expected_err) || message.contains(expected_err),
+        "expected error containing {expected_err:?}, got code={code:?} message={message:?}"
+    );
+}
+
 /// Standard test init: starts ScyllaDB with the Alternator endpoint enabled on
 /// each node's own IP, alongside the Vector Store.
 #[framed]
@@ -734,6 +752,15 @@ impl TableContext {
             req = req.item(attr_name, attr_val.clone());
         }
         req.send().await.expect("PutItem should succeed");
+    }
+
+    /// Inserts an item, asserting that Scylla rejects it with `expected_err`.
+    async fn put_expecting_error(&self, item: &Item, expected_err: &str) {
+        let mut req = self.client.put_item().table_name(&self.table_name);
+        for (attr_name, attr_val) in &item.0 {
+            req = req.item(attr_name, attr_val.clone());
+        }
+        assert_service_error(req.send().await, expected_err);
     }
 
     /// Creates a table, inserts items, and adds a vector index via

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -7,6 +7,7 @@ mod batch_write_item;
 mod create_table;
 mod delete_item;
 mod put_item;
+mod ttl;
 mod update_item;
 mod update_table;
 
@@ -101,6 +102,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
             "alternator_batch_write_item".into(),
             batch_write_item::new().await,
         ),
+        ("alternator_ttl".into(), ttl::new().await),
     ]
 }
 

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -5,6 +5,7 @@
 
 mod batch_write_item;
 mod create_table;
+mod delete_item;
 mod put_item;
 mod update_item;
 mod update_table;
@@ -94,6 +95,7 @@ pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
         ("alternator_create_table".into(), create_table::new().await),
         ("alternator_update_table".into(), update_table::new().await),
         ("alternator_put_item".into(), put_item::new().await),
+        ("alternator_delete_item".into(), delete_item::new().await),
         ("alternator_update_item".into(), update_item::new().await),
         (
             "alternator_batch_write_item".into(),

--- a/crates/validator/src/alternator/put_item.rs
+++ b/crates/validator/src/alternator/put_item.rs
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use tracing::info;
+
+use crate::alternator;
+use crate::alternator::Item;
+use crate::alternator::TableContext;
+
+/// Inserts items via `PutItem` and verifies the VS index is updated.
+///
+/// Loops [`alternator::name_patterns`] so that every combination
+/// of key schema (HASH-only / HASH+RANGE) and naming style (plain /
+/// special) is covered.
+#[framed]
+async fn put_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let ctx = TableContext::create(&actors, shape).await;
+
+        let vec_attr = ctx.shape.vec().expect("TableContext has no vec_attr");
+
+        let a = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]);
+        let b = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let c = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]);
+
+        for item in [&a, &b, &c] {
+            ctx.put(item).await;
+        }
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[a, b.clone(), c.clone()])
+            .await;
+
+        // Replace item a with a vector pointing in the opposite direction -
+        // a_replaced=[-1,-1,-1] has cosine=-1.0 (antipodal to [1,1,1]) so it falls
+        // to last position.  b=[1,2,4] and c=[1,4,8] retain their order.
+        let a_replaced =
+            Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [-1.0, -1.0, -1.0]);
+        ctx.put(&a_replaced).await;
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b, c, a_replaced]).await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Inserts items with various invalid vector attributes and verifies VS does
+/// not index them.  Only the valid item should appear in the index.
+#[framed]
+async fn put_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
+    info!("started");
+
+    let shape = &alternator::name_patterns()[0]; // plain names, HASH-only
+    let pk = shape.pk();
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[0] always has vec");
+
+    let ctx = TableContext::create(&actors, shape).await;
+
+    let vec_with_string_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::S("3.0".into()),
+    ]);
+    let vec_with_null_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::Null(true),
+    ]);
+
+    let no_vec = Item::key(pk, None, "pk", "no-vec");
+    ctx.put(&no_vec).await;
+
+    let wrong_type_string = Item::key(pk, None, "pk", "wrong-type-string")
+        .attr(vec_attr, AttributeValue::S("not-a-vector".into()));
+    ctx.put_expecting_error(&wrong_type_string, "ValidationException")
+        .await;
+
+    let wrong_type_mostly_float_one_s = Item::key(pk, None, "pk", "wrong-type-mostly-float-one-s")
+        .attr(vec_attr, vec_with_string_elem);
+    ctx.put_expecting_error(&wrong_type_mostly_float_one_s, "ValidationException")
+        .await;
+
+    let wrong_type_mostly_float_one_null =
+        Item::key(pk, None, "pk", "wrong-type-mostly-float-one-null")
+            .attr(vec_attr, vec_with_null_elem);
+    ctx.put_expecting_error(&wrong_type_mostly_float_one_null, "ValidationException")
+        .await;
+
+    let wrong_type_too_short = Item::key(pk, None, "pk", "wrong-type-too-short")
+        .attr(vec_attr, alternator::float_list([1.0_f32, 1.0]));
+    ctx.put_expecting_error(&wrong_type_too_short, "ValidationException")
+        .await;
+
+    let wrong_type_too_long = Item::key(pk, None, "pk", "wrong-type-too-long")
+        .attr(vec_attr, alternator::float_list([1.0_f32, 1.0, 1.0, 1.0]));
+    ctx.put_expecting_error(&wrong_type_too_long, "ValidationException")
+        .await;
+
+    // valid is put last so that wait_for_ann acts as a sequencing barrier:
+    // when VS has indexed valid it must have already processed the no_vec CDC
+    // event before it (CDC events are ordered), proving that the item without
+    // a vector attribute was correctly ignored.
+    let valid = Item::key(pk, None, "pk", "valid").vec(vec_attr, [1.0, 1.0, 1.0]);
+    ctx.put(&valid).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[valid]).await;
+
+    let valid_no_vec = Item::key(pk, None, "pk", "valid");
+    ctx.put(&valid_no_vec).await;
+    ctx.wait_for_count(0).await;
+
+    let wrong_type2 =
+        Item::key(pk, None, "pk", "valid").attr(vec_attr, AttributeValue::S("bad".into()));
+    ctx.put_expecting_error(&wrong_type2, "ValidationException")
+        .await;
+    ctx.wait_for_count(0).await;
+
+    ctx.done().await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "put_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            put_item_updates_index,
+        )
+        .with_test(
+            "put_item_with_invalid_vector_is_not_indexed",
+            common::DEFAULT_TEST_TIMEOUT,
+            put_item_with_invalid_vector_is_not_indexed,
+        )
+}

--- a/crates/validator/src/alternator/ttl.rs
+++ b/crates/validator/src/alternator/ttl.rs
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+//! Alternator TTL integration tests.
+//!
+//! These tests verify that when DynamoDB TTL expires a row, the resulting CDC
+//! tombstone is consumed by Vector Store and the expired vector is removed
+//! from the index.
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::TimeToLiveSpecification;
+use e2etest::TestCase;
+use tracing::info;
+
+use super::Item;
+use super::TableContext;
+use super::TableShape;
+
+/// Enables DynamoDB TTL on `ttl_attribute` for the given table.
+async fn enable_ttl(client: &aws_sdk_dynamodb::Client, table_name: &str, ttl_attribute: &str) {
+    client
+        .update_time_to_live()
+        .table_name(table_name)
+        .time_to_live_specification(
+            TimeToLiveSpecification::builder()
+                .enabled(true)
+                .attribute_name(ttl_attribute)
+                .build()
+                .expect("failed to build TimeToLiveSpecification"),
+        )
+        .send()
+        .await
+        .expect("UpdateTimeToLive should succeed");
+}
+
+/// Returns a Unix epoch timestamp `seconds_from_now` seconds in the future.
+fn ttl_epoch(seconds_from_now: i64) -> i64 {
+    use std::time::SystemTime;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    now + seconds_from_now
+}
+
+/// Inserts 3 items (2 permanent + 1 expiring) via the initial-scan path,
+/// then enables TTL.  Waits for the TTL-expired row to be reaped and the
+/// index count to drop to 2.
+///
+/// Covers both HASH-only and HASH+RANGE key schemas.
+#[framed]
+async fn ttl_expiration_removes_vector(actors: TestActors) {
+    info!("started");
+
+    let shapes: &[TableShape] = &[
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-TTL".into(),
+            sk_name: None,
+            vec_name: Some("Vec-TTL".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+        TableShape {
+            table_prefix: None,
+            index_prefix: None,
+            pk_name: "Pk-TTLHR".into(),
+            sk_name: Some("Sk-TTLHR".into()),
+            vec_name: Some("Vec-TTLHR".into()),
+            pk_type: super::ScalarAttributeType::S,
+        },
+    ];
+
+    let ttl_attribute = "ttl_expiry";
+
+    for shape in shapes {
+        info!(?shape, "testing shape");
+
+        let perm1 =
+            Item::key(shape.pk(), shape.sk(), "pk", "1").vec(shape.vec().unwrap(), [1.0, 1.0, 1.0]);
+        let perm2 =
+            Item::key(shape.pk(), shape.sk(), "pk", "2").vec(shape.vec().unwrap(), [1.0, 2.0, 4.0]);
+        let expiring = Item::key(shape.pk(), shape.sk(), "pk", "expiring")
+            .vec(shape.vec().unwrap(), [1.0, 4.0, 8.0])
+            .attr(ttl_attribute, AttributeValue::N(ttl_epoch(2).to_string()));
+
+        let ctx = TableContext::create_with_data(
+            &actors,
+            shape,
+            &[perm1.clone(), perm2.clone(), expiring],
+        )
+        .await;
+
+        info!(
+            "Enabling TTL on attribute '{ttl_attribute}' for '{}'",
+            ctx.table_name
+        );
+        enable_ttl(&ctx.client, &ctx.table_name, ttl_attribute).await;
+
+        info!("Waiting for TTL expiration to propagate to VS index");
+        ctx.wait_for_count(2).await;
+
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[perm1.clone(), perm2.clone()])
+            .await;
+
+        info!("TTL expiration correctly removed expired item from index");
+        ctx.done().await;
+    }
+
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, super::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "ttl_expiration_removes_vector",
+            common::DEFAULT_TEST_TIMEOUT,
+            ttl_expiration_removes_vector,
+        )
+}

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::TestActors;
+use crate::common;
+use async_backtrace::framed;
+use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
+use aws_sdk_dynamodb::operation::update_item::UpdateItemOutput;
+use aws_sdk_dynamodb::types::AttributeValue;
+use e2etest::TestCase;
+use tracing::info;
+
+use crate::alternator;
+use crate::alternator::Item;
+use crate::alternator::TableContext;
+
+/// Issues an `UpdateItem` on the vector column of `item`.
+///
+/// The expression is supplied by the caller and may reference:
+/// - `#vec` - the vector attribute name (always bound to `ctx.shape.vec_name`)
+/// - `:val` - the new value (bound when `value` is `Some`)
+async fn update_item_expr(
+    ctx: &TableContext,
+    item: &Item,
+    update_expr: &str,
+    value: Option<AttributeValue>,
+) -> Result<UpdateItemOutput, SdkError<UpdateItemError>> {
+    let va = ctx.shape.vec().expect("TableContext has no vec_attr");
+    let mut req = ctx
+        .client
+        .update_item()
+        .table_name(&ctx.table_name)
+        .update_expression(update_expr)
+        .expression_attribute_names("#vec", va);
+    for attr_name in std::iter::once(ctx.shape.pk()).chain(ctx.shape.sk()) {
+        if let Some(attr_val) = item.0.get(attr_name) {
+            req = req.key(attr_name, attr_val.clone());
+        }
+    }
+    if let Some(val) = value {
+        req = req.expression_attribute_values(":val", val);
+    }
+    req.send().await
+}
+
+/// Updates a vector via `UpdateItem` and verifies the VS index reflects the
+/// change. Covers replacing an existing vector, adding a vector to a
+/// previously unindexed item, and conditional UpdateItem (LWT path).
+///
+/// Starting state: `a` and `b` indexed, `c` has no vector (count=2).
+#[framed]
+async fn update_item_updates_index(actors: TestActors) {
+    info!("started");
+
+    for shape in &alternator::name_patterns() {
+        info!("Testing shape: {shape:?}");
+
+        let vec_attr = shape.vec().expect("NAME_PATTERNS entries always have vec");
+
+        let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 2.0, 4.0]);
+        let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 4.0, 8.0]);
+        let c_no_vec = Item::key(shape.pk(), shape.sk(), "pk", "c");
+
+        let ctx = TableContext::create_with_invalid_data(
+            &actors,
+            shape,
+            &[a.clone(), b.clone()],
+            std::slice::from_ref(&c_no_vec),
+        )
+        .await;
+
+        info!("Step 1: updating 'b' vector in '{}'", ctx.table_name);
+        let b_vec = [1.0, 1.0, 1.0];
+        let b_updated = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, b_vec);
+        update_item_expr(
+            &ctx,
+            &b_updated,
+            "SET #vec = :val",
+            Some(alternator::float_list(b_vec)),
+        )
+        .await
+        .expect("UpdateItem should succeed");
+
+        ctx.wait_for_ann([1.0, 1.0, 1.0], &[b_updated.clone(), a.clone()])
+            .await;
+
+        info!("Step 2: adding vector to 'c' in '{}'", ctx.table_name);
+        let c_vec = [-1.0, -1.0, -1.0];
+        let c_with_vec = Item::key(shape.pk(), shape.sk(), "pk", "c").vec(vec_attr, c_vec);
+        update_item_expr(
+            &ctx,
+            &c_with_vec,
+            "SET #vec = :val",
+            Some(alternator::float_list(c_vec)),
+        )
+        .await
+        .expect("UpdateItem should succeed");
+
+        // c=[-1,-1,-1] is identical to query [-1,-1,-1] (similarity=1, first).
+        // a=[1,2,4] has cosine similarity ≈ -0.882 (second).
+        // b_updated=[1,1,1] is antipodal to [-1,-1,-1] (similarity=-1, last).
+        ctx.wait_for_count(3).await;
+        ctx.wait_for_ann([-1.0, -1.0, -1.0], &[c_with_vec, a, b_updated])
+            .await;
+
+        ctx.done().await;
+        info!("Shape {shape:?} passed");
+    }
+
+    info!("finished");
+}
+
+/// Tests that `UpdateItem` operations which result in an absent or invalid
+/// vector are handled correctly: REMOVE of the vector column de-indexes the
+/// item (the row remains in the table but without a vector - analogous to
+/// `put_item_with_invalid_vector_is_not_indexed` where a PutItem without a
+/// vector column is accepted but not indexed), and wrong-type updates are
+/// rejected by Scylla with `ValidationException`.
+#[framed]
+async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
+    info!("started");
+
+    let shape = &alternator::name_patterns()[0]; // plain names, HASH-only
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[0] always has vec");
+
+    let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 1.0, 1.0]);
+
+    let ctx = TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone()]).await;
+
+    let vec_with_string_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::S("3.0".into()),
+    ]);
+    let vec_with_null_elem = AttributeValue::L(vec![
+        AttributeValue::N("1.0".into()),
+        AttributeValue::N("2.0".into()),
+        AttributeValue::Null(true),
+    ]);
+
+    update_item_expr(&ctx, &b, "REMOVE #vec", None)
+        .await
+        .expect("UpdateItem should succeed");
+    ctx.wait_for_count(1).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&a))
+        .await;
+
+    alternator::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &a,
+            "SET #vec = :val",
+            Some(AttributeValue::S("not-a-vector".into())),
+        )
+        .await,
+        "ValidationException",
+    );
+
+    alternator::assert_service_error(
+        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_string_elem)).await,
+        "ValidationException",
+    );
+
+    alternator::assert_service_error(
+        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_null_elem)).await,
+        "ValidationException",
+    );
+
+    alternator::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &a,
+            "SET #vec = :val",
+            Some(alternator::float_list([1.0_f32, 1.0])),
+        )
+        .await,
+        "ValidationException",
+    );
+
+    alternator::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &a,
+            "SET #vec = :val",
+            Some(alternator::float_list([1.0_f32, 1.0, 1.0, 1.0])),
+        )
+        .await,
+        "ValidationException",
+    );
+
+    ctx.done().await;
+    info!("finished");
+}
+
+pub(super) async fn new() -> TestCase<TestActors> {
+    TestCase::empty()
+        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
+        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
+        .with_test(
+            "update_item_updates_index",
+            common::DEFAULT_TEST_TIMEOUT,
+            update_item_updates_index,
+        )
+        .with_test(
+            "update_item_with_invalid_vector_is_not_indexed",
+            common::DEFAULT_TEST_TIMEOUT,
+            update_item_with_invalid_vector_is_not_indexed,
+        )
+}


### PR DESCRIPTION
Add end-to-end tests covering PutItem, DeleteItem, UpdateItem, and BatchWriteItem operations against the Alternator endpoint, verifying that the Vector Store index is updated correctly via CDC. Also adds a TTL expiration test confirming that expired rows are de-indexed.
Covers HASH-only and HASH+RANGE key schemas, and invalid vector rejection.

Follow-up #459