### PR TITLE
validator: update e2etest framework

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -147,7 +147,7 @@ jobs:
     - name: Set testcases output
       id: testcases
       run: |
-        echo "testcases=[$(./vector-search-validator-amd64 list | cut -d : -f 1 | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)]" >> "$GITHUB_OUTPUT"
+        echo "testcases=[$(./vector-search-validator-amd64 list | sed -E 's/(.*)::.*/\1/' | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)]" >> "$GITHUB_OUTPUT"
 
   daily-validator-tests:
     needs: ["daily-get-scylla-nightly-digest", "daily-get-testcases"]

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -103,7 +103,7 @@ jobs:
     - name: Set testcases output
       id: testcases
       run: |
-        echo "testcases=[$(./vector-search-validator list | cut -d : -f 1 | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)]" >> "$GITHUB_OUTPUT"
+        echo "testcases=[$(./vector-search-validator list | sed -E 's/(.*)::.*/\1/' | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)]" >> "$GITHUB_OUTPUT"
 
   validator-tests:
     needs: ["validator-scylla-nightly-digest", "validator-build"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,7 +1667,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case",
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1740,13 +1749,14 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2etest"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d8953946c126952b7f490151686121d00327b3aa552e4ba3f7dde03da0ac31"
+checksum = "5c07d6e20f5593d38a99c606d037cd6e5c48ae207c807be3ba0bd41c772da0b2"
 dependencies = [
  "async-backtrace",
- "clap",
+ "e2etest-macros",
  "futures",
+ "itertools 0.14.0",
  "tokio",
  "tracing",
 ]
@@ -1777,13 +1787,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "e2etest-scylla-cluster"
+name = "e2etest-macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a145fd9bc023ed3596c4991329ccd46b29e6efde2ae267f8817fcd345e6ff60"
+checksum = "319137d449236a9c0b537f2d2266d31ce919bc3d367364178a05a1c69c01ff63"
+dependencies = [
+ "convert_case 0.11.0",
+ "itertools 0.14.0",
+ "linkme",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "e2etest-scylla-cluster"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197c0c59ecd2d9a45609e32e1265df2657204a09cdf784d70062128fcec5ada7"
 dependencies = [
  "async-backtrace",
- "e2etest",
  "sysinfo",
  "tap",
  "tempfile",
@@ -1820,13 +1843,12 @@ dependencies = [
 
 [[package]]
 name = "e2etest-vector-store-cluster"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5060f9d070e4d422115f7981ef07606f815008f78bc257acbd9aa3d7c74b422"
+checksum = "bb3607172385cb4f2f193ecd769a492b5818da496a1ce3781ec732f9a403ac44"
 dependencies = [
  "anyhow",
  "async-backtrace",
- "e2etest",
  "reqwest",
  "serde",
  "tempfile",
@@ -3019,6 +3041,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5602,11 +5644,15 @@ dependencies = [
  "httpapi",
  "httpclient",
  "itertools 0.14.0",
+ "linkme",
+ "rcgen",
+ "reqwest",
  "rustls",
  "scylla",
  "scylla-proxy",
  "serde_json",
  "tap",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
 dotenvy = "0.15.7"
-e2etest = "0.1.0"
+e2etest = "0.2.0"
 e2etest-dns = "0.1.0"
 e2etest-firewall = "0.1.0"
-e2etest-scylla-cluster = "0.1.0"
+e2etest-scylla-cluster = "0.1.1"
 e2etest-scylla-proxy-cluster = "0.1.0"
 e2etest-tls = "0.1.0"
-e2etest-vector-store-cluster = "0.1.0"
+e2etest-vector-store-cluster = "0.1.1"
 futures = "0.3.31"
 hotpath = { version = "0.15.0", features = ["tokio", "futures", "async-channel"] }
 http = "1.4.0"
@@ -50,6 +50,7 @@ httpapi = { path = "crates/httpapi" }
 httpclient = { path = "crates/httpclient" }
 humantime = "2.2.0"
 itertools = "0.14.0"
+linkme = "0.3.36"
 macros = { path = "crates/macros" }
 mimalloc = "0.1.48"
 mockall = "0.13.1"

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -28,6 +28,7 @@ http.workspace = true
 httpapi.workspace = true
 httpclient.workspace = true
 itertools.workspace = true
+linkme.workspace = true
 rustls.workspace = true
 rcgen.workspace = true
 scylla.workspace = true
@@ -40,3 +41,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
 reqwest.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["linkme"]

--- a/crates/validator/src/alternator/batch_write_item.rs
+++ b/crates/validator/src/alternator/batch_write_item.rs
@@ -4,18 +4,16 @@
  */
 
 use crate::TestActors;
+use crate::alternator;
+use crate::alternator::Item;
+use crate::alternator::TableContext;
 use crate::common;
-use async_backtrace::framed;
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemError;
 use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemOutput;
 use aws_sdk_dynamodb::types::AttributeValue;
-use e2etest::TestCase;
+use std::sync::Arc;
 use tracing::info;
-
-use crate::alternator;
-use crate::alternator::Item;
-use crate::alternator::TableContext;
 
 fn build_put_requests(items: &[Item]) -> Vec<aws_sdk_dynamodb::types::WriteRequest> {
     items
@@ -66,8 +64,8 @@ async fn batch_write_items(
 ///
 /// Loops [`alternator::name_patterns`] to cover all key schema and
 /// naming combinations.
-#[framed]
-async fn batch_write_item_updates_index(actors: TestActors) {
+#[e2etest::test(group = batch_write_item)]
+async fn batch_write_item_updates_index(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -134,8 +132,8 @@ async fn batch_write_item_updates_index(actors: TestActors) {
 /// Tests that `BatchWriteItem` containing an item with an invalid vector type
 /// is rejected by Scylla and does not update the VS index. Covers string
 /// values, mixed-type lists, NULL elements, and wrong dimensions.
-#[framed]
-async fn batch_write_item_with_invalid_vector(actors: TestActors) {
+#[e2etest::test(group = batch_write_item)]
+async fn batch_write_item_with_invalid_vector(actors: Arc<TestActors>) {
     info!("started");
 
     let shape = &alternator::name_patterns()[0]; // plain names, HASH-only
@@ -238,18 +236,25 @@ async fn batch_write_item_with_invalid_vector(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "batch_write_item_updates_index",
-            common::DEFAULT_TEST_TIMEOUT,
-            batch_write_item_updates_index,
-        )
-        .with_test(
-            "batch_write_item_with_invalid_vector",
-            common::DEFAULT_TEST_TIMEOUT,
-            batch_write_item_with_invalid_vector,
-        )
+e2etest::group!(
+    name = batch_write_item,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/create_table.rs
+++ b/crates/validator/src/alternator/create_table.rs
@@ -6,13 +6,11 @@
 use crate::TestActors;
 use crate::alternator;
 use crate::common;
-use async_backtrace::framed;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::interceptors::context::AfterDeserializationInterceptorContextRef;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
-use e2etest::TestCase;
 use httpapi::IndexInfo;
 use httpapi::IndexName;
 use std::sync::Arc;
@@ -119,8 +117,8 @@ fn assert_json_includes(actual: &serde_json::Value, expected: &serde_json::Value
 /// 2. Waits for Vector Store to discover the index.
 /// 3. Calls `DescribeTable` and verifies the `VectorIndexes` extension field.
 /// 4. Calls `DeleteTable` and waits for Vector Store to drop the index.
-#[framed]
-async fn create_describe_and_delete_table_with_vector_index(actors: TestActors) {
+#[e2etest::test(group = create_table)]
+async fn create_describe_and_delete_table_with_vector_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, vs_clients) = alternator::make_clients(&actors).await;
@@ -194,8 +192,8 @@ async fn create_describe_and_delete_table_with_vector_index(actors: TestActors) 
     info!("finished");
 }
 
-#[framed]
-async fn create_table_with_two_case_distinct_vector_indexes(actors: TestActors) {
+#[e2etest::test(group = create_table)]
+async fn create_table_with_two_case_distinct_vector_indexes(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, vs_clients) = alternator::make_clients(&actors).await;
@@ -251,8 +249,8 @@ async fn create_table_with_two_case_distinct_vector_indexes(actors: TestActors) 
 
 /// Index names are scoped to a CQL keyspace (`alternator_<table>`), so the
 /// same index name on case-distinct tables should be independent.
-#[framed]
-async fn create_table_with_same_index_name_on_case_distinct_tables(actors: TestActors) {
+#[e2etest::test(group = create_table)]
+async fn create_table_with_same_index_name_on_case_distinct_tables(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, vs_clients) = alternator::make_clients(&actors).await;
@@ -315,8 +313,8 @@ async fn create_table_with_same_index_name_on_case_distinct_tables(actors: TestA
 }
 
 /// Alternator currently forbids two vector indexes on the same column.
-#[framed]
-async fn create_table_with_two_indexes_on_same_vector_column(actors: TestActors) {
+#[e2etest::test(group = create_table)]
+async fn create_table_with_two_indexes_on_same_vector_column(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, _vs_clients) = alternator::make_clients(&actors).await;
@@ -361,8 +359,8 @@ async fn create_table_with_two_indexes_on_same_vector_column(actors: TestActors)
 }
 
 /// Positive case (192-char name) is covered by `alternator::name_patterns`.
-#[framed]
-async fn create_table_with_over_max_length_index_name(actors: TestActors) {
+#[e2etest::test(group = create_table)]
+async fn create_table_with_over_max_length_index_name(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, _vs_clients) = alternator::make_clients(&actors).await;
@@ -401,8 +399,8 @@ async fn create_table_with_over_max_length_index_name(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn create_table_with_boundary_dimensions(actors: TestActors) {
+#[e2etest::test(group = create_table)]
+async fn create_table_with_boundary_dimensions(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, vs_clients) = alternator::make_clients(&actors).await;
@@ -466,38 +464,25 @@ async fn create_table_with_boundary_dimensions(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "create_describe_and_delete_table_with_vector_index",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_describe_and_delete_table_with_vector_index,
-        )
-        .with_test(
-            "create_table_with_two_case_distinct_vector_indexes",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_table_with_two_case_distinct_vector_indexes,
-        )
-        .with_test(
-            "create_table_with_same_index_name_on_case_distinct_tables",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_table_with_same_index_name_on_case_distinct_tables,
-        )
-        .with_test(
-            "create_table_with_two_indexes_on_same_vector_column",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_table_with_two_indexes_on_same_vector_column,
-        )
-        .with_test(
-            "create_table_with_boundary_dimensions",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_table_with_boundary_dimensions,
-        )
-        .with_test(
-            "create_table_with_over_max_length_index_name",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_table_with_over_max_length_index_name,
-        )
+e2etest::group!(
+    name = create_table,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/delete_item.rs
+++ b/crates/validator/src/alternator/delete_item.rs
@@ -4,16 +4,14 @@
  */
 
 use crate::TestActors;
-use crate::common;
-use async_backtrace::framed;
-use e2etest::TestCase;
-use tracing::info;
-
 use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::TableContext;
+use crate::common;
+use std::sync::Arc;
+use tracing::info;
 
-async fn delete_item(ctx: &TableContext, item: &Item) {
+async fn ctx_delete_item(ctx: &TableContext, item: &Item) {
     let mut req = ctx.client.delete_item().table_name(&ctx.table_name);
     let key_attrs: Vec<&str> = std::iter::once(ctx.shape.pk())
         .chain(ctx.shape.sk())
@@ -32,8 +30,8 @@ async fn delete_item(ctx: &TableContext, item: &Item) {
 /// Loops [`alternator::name_patterns`] so that every combination
 /// of key schema (HASH-only / HASH+RANGE) and naming style (plain /
 /// special) is covered.
-#[framed]
-async fn delete_item_updates_index(actors: TestActors) {
+#[e2etest::test(group = delete_item)]
+async fn delete_item_updates_index(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -50,7 +48,7 @@ async fn delete_item_updates_index(actors: TestActors) {
                 .await;
 
         info!("Deleting item from '{}'", ctx.table_name);
-        delete_item(&ctx, &a).await;
+        ctx_delete_item(&ctx, &a).await;
 
         ctx.wait_for_count(2).await;
         ctx.wait_for_ann([1.0, 1.0, 1.0], &[b.clone(), c]).await;
@@ -62,13 +60,25 @@ async fn delete_item_updates_index(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "delete_item_updates_index",
-            common::DEFAULT_TEST_TIMEOUT,
-            delete_item_updates_index,
-        )
+e2etest::group!(
+    name = delete_item,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -38,7 +38,6 @@ use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::base64;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::config_bag::ConfigBag;
-use e2etest::TestCase;
 use http::HeaderValue;
 use http::header::CONTENT_LENGTH;
 use httpapi::ColumnName;
@@ -94,23 +93,7 @@ const MAX_ALTERNATOR_INDEX_NAME_LEN: usize = MAX_ALTERNATOR_TABLE_NAME_LEN;
 /// See <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html>.
 const MAX_ALTERNATOR_ATTRIBUTE_NAME_LEN: usize = 255;
 
-#[framed]
-pub(crate) async fn test_cases() -> Vec<(String, TestCase<TestActors>)> {
-    vec![
-        ("alternator_create_table".into(), create_table::new().await),
-        ("alternator_update_table".into(), update_table::new().await),
-        ("alternator_put_item".into(), put_item::new().await),
-        ("alternator_delete_item".into(), delete_item::new().await),
-        ("alternator_update_item".into(), update_item::new().await),
-        (
-            "alternator_batch_write_item".into(),
-            batch_write_item::new().await,
-        ),
-        ("alternator_ttl".into(), ttl::new().await),
-        ("alternator_query".into(), query::new().await),
-        ("alternator_types".into(), types::new().await),
-    ]
-}
+e2etest::group!(name = alternator, fixtures = (), parent = crate::validator);
 
 const ALTERNATOR_PORT: u16 = 8000;
 
@@ -634,10 +617,10 @@ where
 /// Standard test init: starts ScyllaDB with the Alternator endpoint enabled on
 /// each node's own IP, alongside the Vector Store.
 #[framed]
-pub async fn init(actors: TestActors) {
+pub async fn init(actors: &TestActors) {
     info!("started");
 
-    let mut scylla_configs = common::get_default_scylla_node_configs(&actors).await;
+    let mut scylla_configs = common::get_default_scylla_node_configs(actors).await;
 
     for config in &mut scylla_configs {
         let node_ip = config.db_ip;
@@ -653,7 +636,7 @@ pub async fn init(actors: TestActors) {
 
     // Capture db_ip before actors is moved into init_with_config.
     let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
-    let vs_configs = common::get_default_vs_node_configs(&actors).await;
+    let vs_configs = common::get_default_vs_node_configs(actors).await;
     common::init_with_config(actors, scylla_configs, vs_configs).await;
 
     wait_for_alternator(db_ip).await;

--- a/crates/validator/src/alternator/put_item.rs
+++ b/crates/validator/src/alternator/put_item.rs
@@ -4,23 +4,21 @@
  */
 
 use crate::TestActors;
-use crate::common;
-use async_backtrace::framed;
-use aws_sdk_dynamodb::types::AttributeValue;
-use e2etest::TestCase;
-use tracing::info;
-
 use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::TableContext;
+use crate::common;
+use aws_sdk_dynamodb::types::AttributeValue;
+use std::sync::Arc;
+use tracing::info;
 
 /// Inserts items via `PutItem` and verifies the VS index is updated.
 ///
 /// Loops [`alternator::name_patterns`] so that every combination
 /// of key schema (HASH-only / HASH+RANGE) and naming style (plain /
 /// special) is covered.
-#[framed]
-async fn put_item_updates_index(actors: TestActors) {
+#[e2etest::test(group = put_item)]
+async fn put_item_updates_index(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -58,8 +56,8 @@ async fn put_item_updates_index(actors: TestActors) {
 
 /// Inserts items with various invalid vector attributes and verifies VS does
 /// not index them.  Only the valid item should appear in the index.
-#[framed]
-async fn put_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
+#[e2etest::test(group = put_item)]
+async fn put_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>) {
     info!("started");
 
     let shape = &alternator::name_patterns()[0]; // plain names, HASH-only
@@ -130,18 +128,25 @@ async fn put_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "put_item_updates_index",
-            common::DEFAULT_TEST_TIMEOUT,
-            put_item_updates_index,
-        )
-        .with_test(
-            "put_item_with_invalid_vector_is_not_indexed",
-            common::DEFAULT_TEST_TIMEOUT,
-            put_item_with_invalid_vector_is_not_indexed,
-        )
+e2etest::group!(
+    name = put_item,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/query.rs
+++ b/crates/validator/src/alternator/query.rs
@@ -4,25 +4,23 @@
  */
 
 use crate::TestActors;
-use crate::common;
-use async_backtrace::framed;
-use aws_sdk_dynamodb::client::customize::CustomizableOperation;
-use aws_sdk_dynamodb::operation::query::QueryError;
-use aws_sdk_dynamodb::operation::query::QueryOutput;
-use aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder;
-use aws_sdk_dynamodb::types::AttributeValue;
-use aws_sdk_dynamodb::types::Select;
-use e2etest::TestCase;
-use httpapi::IndexName;
-use std::collections::HashMap;
-use tracing::info;
-
 use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::JsonBodyInjectInterceptor;
 use crate::alternator::TableContext;
 use crate::alternator::TableShape;
+use crate::common;
+use aws_sdk_dynamodb::client::customize::CustomizableOperation;
+use aws_sdk_dynamodb::operation::query::QueryError;
+use aws_sdk_dynamodb::operation::query::QueryOutput;
+use aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder;
+use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::types::ScalarAttributeType;
+use aws_sdk_dynamodb::types::Select;
+use httpapi::IndexName;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::info;
 
 /// Extension trait that adds Alternator `VectorSearch` to [`QueryFluentBuilder`].
 pub(super) trait QueryBuilderExt {
@@ -69,8 +67,8 @@ impl QueryBuilderExt for QueryFluentBuilder {
 }
 
 /// Verifies basic VectorSearch query: results returned, limit respected, nearest item first.
-#[framed]
-async fn query_with_vector_search(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_vector_search(actors: Arc<TestActors>) {
     info!("started");
 
     let shapes = [
@@ -155,8 +153,8 @@ async fn query_with_vector_search(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn query_uses_selected_vector_index(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_uses_selected_vector_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, vs_clients) = alternator::make_clients(&actors).await;
@@ -281,8 +279,8 @@ async fn query_uses_selected_vector_index(actors: TestActors) {
 }
 
 /// Verifies ANN results are ordered by ascending cosine distance.
-#[framed]
-async fn query_with_vector_search_multiple_results_ordering(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_vector_search_multiple_results_ordering(actors: Arc<TestActors>) {
     info!("started");
 
     let dataset = [
@@ -346,8 +344,8 @@ async fn query_with_vector_search_multiple_results_ordering(actors: TestActors) 
 }
 
 /// Verifies ProjectionExpression returns only requested key attributes across name_patterns.
-#[framed]
-async fn query_with_projection_special_names(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_projection_special_names(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -415,8 +413,8 @@ async fn query_with_projection_special_names(actors: TestActors) {
 }
 
 /// Verifies Select::AllAttributes returns all item attributes.
-#[framed]
-async fn query_with_select_all_attributes(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_select_all_attributes(actors: Arc<TestActors>) {
     info!("started");
 
     let shape = TableShape {
@@ -474,8 +472,8 @@ async fn query_with_select_all_attributes(actors: TestActors) {
 }
 
 /// Verifies Select::Count returns count > 0 with empty items list.
-#[framed]
-async fn query_with_select_count(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_select_count(actors: Arc<TestActors>) {
     info!("started");
 
     let dataset = [
@@ -527,8 +525,8 @@ async fn query_with_select_count(actors: TestActors) {
 }
 
 /// Verifies Limit larger than dataset returns all items without error.
-#[framed]
-async fn query_with_limit_larger_than_dataset(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_limit_larger_than_dataset(actors: Arc<TestActors>) {
     info!("started");
 
     let dataset = [
@@ -588,8 +586,8 @@ async fn query_with_limit_larger_than_dataset(actors: TestActors) {
 }
 
 /// Verifies VectorSearch works with 1536-dimensional vectors.
-#[framed]
-async fn query_with_large_dimensions(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_large_dimensions(actors: Arc<TestActors>) {
     info!("started");
 
     let (client, vs_clients) = alternator::make_clients(&actors).await;
@@ -667,8 +665,8 @@ async fn query_with_large_dimensions(actors: TestActors) {
 }
 
 /// Verifies FilterExpression excludes non-matching items while preserving ANN ordering.
-#[framed]
-async fn query_with_filter_expression(actors: TestActors) {
+#[e2etest::test(group = query)]
+async fn query_with_filter_expression(actors: Arc<TestActors>) {
     info!("started");
 
     let pk_name = "Pk-Flt";
@@ -751,53 +749,25 @@ async fn query_with_filter_expression(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "query_with_vector_search",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_vector_search,
-        )
-        .with_test(
-            "query_uses_selected_vector_index",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_uses_selected_vector_index,
-        )
-        .with_test(
-            "query_with_vector_search_multiple_results_ordering",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_vector_search_multiple_results_ordering,
-        )
-        .with_test(
-            "query_with_projection_special_names",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_projection_special_names,
-        )
-        .with_test(
-            "query_with_select_all_attributes",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_select_all_attributes,
-        )
-        .with_test(
-            "query_with_select_count",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_select_count,
-        )
-        .with_test(
-            "query_with_limit_larger_than_dataset",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_limit_larger_than_dataset,
-        )
-        .with_test(
-            "query_with_large_dimensions",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_large_dimensions,
-        )
-        .with_test(
-            "query_with_filter_expression",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_filter_expression,
-        )
+e2etest::group!(
+    name = query,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/ttl.rs
+++ b/crates/validator/src/alternator/ttl.rs
@@ -10,20 +10,18 @@
 //! from the index.
 
 use crate::TestActors;
-use crate::common;
-use async_backtrace::framed;
-use aws_sdk_dynamodb::types::AttributeValue;
-use aws_sdk_dynamodb::types::Select;
-use aws_sdk_dynamodb::types::TimeToLiveSpecification;
-use e2etest::TestCase;
-use tracing::info;
-
 use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::TableContext;
 use crate::alternator::TableShape;
 use crate::alternator::query::QueryBuilderExt;
+use crate::common;
+use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::types::ScalarAttributeType;
+use aws_sdk_dynamodb::types::Select;
+use aws_sdk_dynamodb::types::TimeToLiveSpecification;
+use std::sync::Arc;
+use tracing::info;
 
 /// Enables DynamoDB TTL on `ttl_attribute` for the given table.
 async fn enable_ttl(client: &aws_sdk_dynamodb::Client, table_name: &str, ttl_attribute: &str) {
@@ -57,8 +55,8 @@ fn ttl_epoch(seconds_from_now: i64) -> i64 {
 /// index count to drop to 2.
 ///
 /// Covers both HASH-only and HASH+RANGE key schemas.
-#[framed]
-async fn ttl_expiration_removes_vector(actors: TestActors) {
+#[e2etest::test(group = ttl)]
+async fn ttl_expiration_removes_vector(actors: Arc<TestActors>) {
     info!("started");
 
     let shapes: &[TableShape] = &[
@@ -121,8 +119,8 @@ async fn ttl_expiration_removes_vector(actors: TestActors) {
 
 /// Like [`ttl_expiration_removes_vector`] but uses `Select::AllProjectedAttributes`
 /// - an index-only read that skips the base table.
-#[framed]
-async fn ttl_expiration_verified_via_query_with_all_projected(actors: TestActors) {
+#[e2etest::test(group = ttl)]
+async fn ttl_expiration_verified_via_query_with_all_projected(actors: Arc<TestActors>) {
     info!("started");
 
     let shape = TableShape {
@@ -191,18 +189,25 @@ async fn ttl_expiration_verified_via_query_with_all_projected(actors: TestActors
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "ttl_expiration_removes_vector",
-            common::DEFAULT_TEST_TIMEOUT,
-            ttl_expiration_removes_vector,
-        )
-        .with_test(
-            "ttl_expiration_verified_via_query_with_all_projected",
-            common::DEFAULT_TEST_TIMEOUT,
-            ttl_expiration_verified_via_query_with_all_projected,
-        )
+e2etest::group!(
+    name = ttl,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/types.rs
+++ b/crates/validator/src/alternator/types.rs
@@ -4,20 +4,18 @@
  */
 
 use crate::TestActors;
-use crate::common;
-use async_backtrace::framed;
-use aws_sdk_dynamodb::primitives::Blob;
-use aws_sdk_dynamodb::types::AttributeValue;
-use aws_sdk_dynamodb::types::ScalarAttributeType;
-use e2etest::TestCase;
-use std::collections::HashMap;
-use tracing::info;
-
 use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::TableContext;
 use crate::alternator::TableShape;
 use crate::alternator::query::QueryBuilderExt;
+use crate::common;
+use aws_sdk_dynamodb::primitives::Blob;
+use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::ScalarAttributeType;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::info;
 
 /// Shared logic for all key-type tests: creates a table with initial items,
 /// adds extra items via PutItem, then queries with both L-type and FLOAT32VECTOR
@@ -86,8 +84,8 @@ async fn query_with_key_type(
     ctx.done().await;
 }
 
-#[framed]
-async fn query_with_string_key(actors: TestActors) {
+#[e2etest::test(group = types)]
+async fn query_with_string_key(actors: Arc<TestActors>) {
     info!("started");
     let shape = TableShape {
         table_prefix: None,
@@ -107,8 +105,8 @@ async fn query_with_string_key(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn query_with_number_key(actors: TestActors) {
+#[e2etest::test(group = types)]
+async fn query_with_number_key(actors: Arc<TestActors>) {
     info!("started");
     let shape = TableShape {
         table_prefix: None,
@@ -128,8 +126,8 @@ async fn query_with_number_key(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn query_with_binary_key(actors: TestActors) {
+#[e2etest::test(group = types)]
+async fn query_with_binary_key(actors: Arc<TestActors>) {
     info!("started");
     let shape = TableShape {
         table_prefix: None,
@@ -152,8 +150,8 @@ async fn query_with_binary_key(actors: TestActors) {
 }
 
 /// Verifies queries work with both FLOAT32VECTOR-encoded items and query vectors.
-#[framed]
-async fn query_with_optimized_vector_type(actors: TestActors) {
+#[e2etest::test(group = types)]
+async fn query_with_optimized_vector_type(actors: Arc<TestActors>) {
     info!("started");
 
     let shape = TableShape {
@@ -181,28 +179,25 @@ async fn query_with_optimized_vector_type(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "query_with_string_key",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_string_key,
-        )
-        .with_test(
-            "query_with_number_key",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_number_key,
-        )
-        .with_test(
-            "query_with_binary_key",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_binary_key,
-        )
-        .with_test(
-            "query_with_optimized_vector_type",
-            common::DEFAULT_TEST_TIMEOUT,
-            query_with_optimized_vector_type,
-        )
+e2etest::group!(
+    name = types,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -4,18 +4,16 @@
  */
 
 use crate::TestActors;
+use crate::alternator;
+use crate::alternator::Item;
+use crate::alternator::TableContext;
 use crate::common;
-use async_backtrace::framed;
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
 use aws_sdk_dynamodb::operation::update_item::UpdateItemOutput;
 use aws_sdk_dynamodb::types::AttributeValue;
-use e2etest::TestCase;
+use std::sync::Arc;
 use tracing::info;
-
-use crate::alternator;
-use crate::alternator::Item;
-use crate::alternator::TableContext;
 
 /// Issues an `UpdateItem` on the vector column of `item`.
 ///
@@ -51,8 +49,8 @@ async fn update_item_expr(
 /// previously unindexed item, and conditional UpdateItem (LWT path).
 ///
 /// Starting state: `a` and `b` indexed, `c` has no vector (count=2).
-#[framed]
-async fn update_item_updates_index(actors: TestActors) {
+#[e2etest::test(group = update_item)]
+async fn update_item_updates_index(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -119,8 +117,8 @@ async fn update_item_updates_index(actors: TestActors) {
 /// `put_item_with_invalid_vector_is_not_indexed` where a PutItem without a
 /// vector column is accepted but not indexed), and wrong-type updates are
 /// rejected by Scylla with `ValidationException`.
-#[framed]
-async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
+#[e2etest::test(group = update_item)]
+async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>) {
     info!("started");
 
     let shape = &alternator::name_patterns()[0]; // plain names, HASH-only
@@ -196,18 +194,25 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "update_item_updates_index",
-            common::DEFAULT_TEST_TIMEOUT,
-            update_item_updates_index,
-        )
-        .with_test(
-            "update_item_with_invalid_vector_is_not_indexed",
-            common::DEFAULT_TEST_TIMEOUT,
-            update_item_with_invalid_vector_is_not_indexed,
-        )
+e2etest::group!(
+    name = update_item,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -4,17 +4,15 @@
  */
 
 use crate::TestActors;
-use crate::common;
-use async_backtrace::framed;
-use aws_sdk_dynamodb::types::AttributeValue;
-use e2etest::TestCase;
-use serde_json::Value;
-use tracing::info;
-
 use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::TableContext;
 use crate::alternator::TableShape;
+use crate::common;
+use aws_sdk_dynamodb::types::AttributeValue;
+use serde_json::Value;
+use std::sync::Arc;
+use tracing::info;
 
 fn vector_index_create_update(index_name: &str, vec_attr: &str) -> Value {
     serde_json::json!([
@@ -30,8 +28,8 @@ fn vector_index_create_update(index_name: &str, vec_attr: &str) -> Value {
     ])
 }
 
-#[framed]
-async fn create_vector_index_via_update_table(actors: TestActors) {
+#[e2etest::test(group = update_table)]
+async fn create_vector_index_via_update_table(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -72,8 +70,8 @@ async fn create_vector_index_via_update_table(actors: TestActors) {
 }
 
 /// Like above but with pre-existing data in the table before adding the index.
-#[framed]
-async fn create_vector_index_via_update_table_with_preexisting_data(actors: TestActors) {
+#[e2etest::test(group = update_table)]
+async fn create_vector_index_via_update_table_with_preexisting_data(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -123,8 +121,8 @@ async fn create_vector_index_via_update_table_with_preexisting_data(actors: Test
 }
 
 /// Verifies that the initial-scan path skips non-indexable rows.
-#[framed]
-async fn create_vector_index_via_update_table_with_invalid_data(actors: TestActors) {
+#[e2etest::test(group = update_table)]
+async fn create_vector_index_via_update_table_with_invalid_data(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -184,8 +182,8 @@ async fn create_vector_index_via_update_table_with_invalid_data(actors: TestActo
 }
 
 /// Deletes a vector index via UpdateTable and verifies writes succeed after.
-#[framed]
-async fn delete_vector_index_via_update_table(actors: TestActors) {
+#[e2etest::test(group = update_table)]
+async fn delete_vector_index_via_update_table(actors: Arc<TestActors>) {
     info!("started");
 
     for shape in &alternator::name_patterns() {
@@ -233,28 +231,25 @@ async fn delete_vector_index_via_update_table(actors: TestActors) {
     info!("finished");
 }
 
-pub(super) async fn new() -> TestCase<TestActors> {
-    TestCase::empty()
-        .with_init(common::DEFAULT_TEST_TIMEOUT, alternator::init)
-        .with_cleanup(common::DEFAULT_TEST_TIMEOUT, common::cleanup)
-        .with_test(
-            "create_vector_index_via_update_table",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_vector_index_via_update_table,
-        )
-        .with_test(
-            "create_vector_index_via_update_table_with_preexisting_data",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_vector_index_via_update_table_with_preexisting_data,
-        )
-        .with_test(
-            "create_vector_index_via_update_table_with_invalid_data",
-            common::DEFAULT_TEST_TIMEOUT,
-            create_vector_index_via_update_table_with_invalid_data,
-        )
-        .with_test(
-            "delete_vector_index_via_update_table",
-            common::DEFAULT_TEST_TIMEOUT,
-            delete_vector_index_via_update_table,
-        )
+e2etest::group!(
+    name = update_table,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        alternator::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }

--- a/crates/validator/src/ann.rs
+++ b/crates/validator/src/ann.rs
@@ -5,54 +5,34 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "ann_query_returns_expected_results",
-            timeout,
-            ann_query_returns_expected_results,
-        )
-        .with_test(
-            "ann_query_returns_expected_results_multicolumn_pk",
-            timeout,
-            ann_query_returns_expected_results_multicolumn_pk,
-        )
-        .with_test(
-            "ann_query_respects_limit",
-            timeout,
-            ann_query_respects_limit,
-        )
-        .with_test(
-            "ann_query_respects_limit_over_1000_vectors",
-            timeout,
-            ann_query_respects_limit_over_1000_vectors,
-        )
-        .with_test(
-            "ann_query_returns_rows_identified_by_composite_primary_key",
-            timeout,
-            ann_query_returns_rows_identified_by_composite_primary_key,
-        )
-        .with_test(
-            "ann_query_returns_rows_using_cdc",
-            timeout,
-            ann_query_returns_rows_using_cdc,
-        )
+e2etest::group!(name = ann, fixtures = (Fixture), parent = crate::validator);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn ann_query_returns_expected_results(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = ann)]
+async fn ann_query_returns_expected_results(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -122,8 +102,8 @@ async fn ann_query_returns_expected_results(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn ann_query_returns_expected_results_multicolumn_pk(actors: TestActors) {
+#[e2etest::test(group = ann)]
+async fn ann_query_returns_expected_results_multicolumn_pk(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -187,8 +167,8 @@ async fn ann_query_returns_expected_results_multicolumn_pk(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn ann_query_respects_limit(actors: TestActors) {
+#[e2etest::test(group = ann)]
+async fn ann_query_respects_limit(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -255,8 +235,8 @@ async fn ann_query_respects_limit(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn ann_query_respects_limit_over_1000_vectors(actors: TestActors) {
+#[e2etest::test(group = ann)]
+async fn ann_query_respects_limit_over_1000_vectors(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -325,8 +305,8 @@ async fn ann_query_respects_limit_over_1000_vectors(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn ann_query_returns_rows_identified_by_composite_primary_key(actors: TestActors) {
+#[e2etest::test(group = ann)]
+async fn ann_query_returns_rows_identified_by_composite_primary_key(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -404,8 +384,8 @@ async fn ann_query_returns_rows_identified_by_composite_primary_key(actors: Test
 /// 6. Wait until vector-stores update indexes using CDC.
 /// 7. Perform an ANN query and verify the results.
 /// 8. Drop the keyspace.
-#[framed]
-async fn ann_query_returns_rows_using_cdc(actors: TestActors) {
+#[e2etest::test(group = ann)]
+async fn ann_query_returns_rows_using_cdc(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;

--- a/crates/validator/src/auth.rs
+++ b/crates/validator/src/auth.rs
@@ -4,14 +4,12 @@
  */
 
 use crate::TestActors;
-use crate::common;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use e2etest_scylla_cluster::ScyllaClusterExt;
 use e2etest_vector_store_cluster::VectorStoreClusterExt;
 use httpapi::IndexStatus;
 use httpapi::NodeStatus;
+use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -40,26 +38,26 @@ fn scylla_auth_config() -> Vec<u8> {
     .into_bytes()
 }
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_test(
-            "vs_doesnt_work_without_permission",
-            timeout,
-            vs_doesnt_work_without_permission,
-        )
-        .with_test(
-            "vs_works_when_permission_granted",
-            timeout,
-            vs_works_when_permission_granted,
-        )
-        .with_test("cdc_works_with_auth", timeout, cdc_works_with_auth)
-        .with_cleanup(timeout, common::cleanup)
+e2etest::group!(name = auth, fixtures = (Fixture), parent = crate::validator);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn vs_doesnt_work_without_permission(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = auth)]
+async fn vs_doesnt_work_without_permission(actors: Arc<TestActors>) {
     info!("started");
 
     let mut scylla_configs = get_default_scylla_node_configs(&actors).await;
@@ -111,13 +109,13 @@ async fn vs_doesnt_work_without_permission(actors: TestActors) {
     }
 
     info!("Cleaning up");
-    cleanup(actors).await;
+    cleanup(&actors).await;
 
     info!("finished");
 }
 
-#[framed]
-async fn vs_works_when_permission_granted(actors: TestActors) {
+#[e2etest::test(group = auth)]
+async fn vs_works_when_permission_granted(actors: Arc<TestActors>) {
     info!("started");
 
     let mut scylla_configs = get_default_scylla_node_configs(&actors).await;
@@ -180,13 +178,13 @@ async fn vs_works_when_permission_granted(actors: TestActors) {
     }
 
     info!("Cleaning up");
-    cleanup(actors).await;
+    cleanup(&actors).await;
 
     info!("finished");
 }
 
-#[framed]
-async fn cdc_works_with_auth(actors: TestActors) {
+#[e2etest::test(group = auth)]
+async fn cdc_works_with_auth(actors: Arc<TestActors>) {
     info!("started");
 
     let mut scylla_configs = get_default_scylla_node_configs(&actors).await;
@@ -281,7 +279,7 @@ async fn cdc_works_with_auth(actors: TestActors) {
         .expect("failed to drop keyspace");
 
     info!("Cleaning up");
-    cleanup(actors).await;
+    cleanup(&actors).await;
 
     info!("finished");
 }

--- a/crates/validator/src/cdc.rs
+++ b/crates/validator/src/cdc.rs
@@ -5,8 +5,7 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -17,44 +16,27 @@ const CDC_MAX_LATENCY: Duration = Duration::from_secs(60);
 const CDC_ACTOR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const TTL_EXPIRATION_TIMEOUT: Duration = Duration::from_secs(10);
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "cdc_insert_visible_immediately",
-            timeout,
-            cdc_insert_visible_immediately,
-        )
-        .with_test(
-            "cdc_update_visible_immediately",
-            timeout,
-            cdc_update_visible_immediately,
-        )
-        .with_test(
-            "cdc_delete_visible_immediately",
-            timeout,
-            cdc_delete_visible_immediately,
-        )
-        .with_test("cdc_lwt_insert_visible", timeout, cdc_lwt_insert_visible)
-        .with_test("cdc_lwt_update_visible", timeout, cdc_lwt_update_visible)
-        .with_test("cdc_lwt_delete_visible", timeout, cdc_lwt_delete_visible)
-        .with_test(
-            "recreating_index_terminates_old_cdc_actors",
-            timeout,
-            recreating_index_terminates_old_cdc_actors,
-        )
-        .with_test(
-            "cql_per_row_ttl_expires_from_index",
-            timeout,
-            cql_per_row_ttl_expires_from_index,
-        )
+e2etest::group!(name = cdc, fixtures = (Fixture), parent = crate::validator);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn cdc_insert_visible_immediately(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = cdc)]
+async fn cdc_insert_visible_immediately(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs(&actors).await;
@@ -102,8 +84,8 @@ async fn cdc_insert_visible_immediately(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn cdc_update_visible_immediately(actors: TestActors) {
+#[e2etest::test(group = cdc)]
+async fn cdc_update_visible_immediately(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs(&actors).await;
@@ -196,8 +178,9 @@ fn now_epoch_secs() -> i64 {
         .expect("system time before UNIX epoch")
         .as_secs() as i64
 }
-#[framed]
-async fn cdc_delete_visible_immediately(actors: TestActors) {
+
+#[e2etest::test(group = cdc)]
+async fn cdc_delete_visible_immediately(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs(&actors).await;
@@ -245,8 +228,8 @@ async fn cdc_delete_visible_immediately(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn cdc_lwt_insert_visible(actors: TestActors) {
+#[e2etest::test(group = cdc)]
+async fn cdc_lwt_insert_visible(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs(&actors).await;
@@ -293,8 +276,8 @@ async fn cdc_lwt_insert_visible(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn cdc_lwt_update_visible(actors: TestActors) {
+#[e2etest::test(group = cdc)]
+async fn cdc_lwt_update_visible(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs(&actors).await;
@@ -385,8 +368,8 @@ async fn cdc_lwt_update_visible(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn cdc_lwt_delete_visible(actors: TestActors) {
+#[e2etest::test(group = cdc)]
+async fn cdc_lwt_delete_visible(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs(&actors).await;
@@ -440,8 +423,8 @@ async fn cdc_lwt_delete_visible(actors: TestActors) {
 /// DROP + CREATE of the same index), old CDC actors must terminate. If
 /// they are orphaned, the same index ends up with multiple CDC readers
 /// running concurrently, which is the symptom observed in the field.
-#[framed]
-async fn recreating_index_terminates_old_cdc_actors(actors: TestActors) {
+#[e2etest::test(group = cdc)]
+async fn recreating_index_terminates_old_cdc_actors(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs(&actors).await;
@@ -542,8 +525,8 @@ async fn recreating_index_terminates_old_cdc_actors(actors: TestActors) {
 /// 2. Create an index and verify all rows are queryable via ANN.
 /// 3. Wait for the expiration service to delete expired rows (via CDC).
 /// 4. Verify the index count drops and ANN queries return only non-TTL rows.
-#[framed]
-async fn cql_per_row_ttl_expires_from_index(actors: TestActors) {
+#[e2etest::test(group = cdc)]
+async fn cql_per_row_ttl_expires_from_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;

--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -205,25 +205,25 @@ pub fn get_proxy_translation_map(
 }
 
 #[framed]
-pub async fn init(actors: TestActors) {
+pub async fn init(actors: &TestActors) {
     info!("started");
 
-    let scylla_configs = get_default_scylla_node_configs(&actors).await;
-    let vs_configs = get_default_vs_node_configs(&actors).await;
+    let scylla_configs = get_default_scylla_node_configs(actors).await;
+    let vs_configs = get_default_vs_node_configs(actors).await;
     init_with_config(actors, scylla_configs, vs_configs).await;
 
     info!("finished");
 }
 
 #[framed]
-pub async fn init_with_proxy(actors: TestActors) {
+pub async fn init_with_proxy(actors: &TestActors) {
     info!("started");
 
-    init_dns(&actors).await;
+    init_dns(actors).await;
 
     // Proxy operates at CQL frame level and cannot handle TLS, so ScyllaDB
     // must be started without TLS when using the proxy.
-    let scylla_configs: Vec<ScyllaNodeConfig> = get_default_scylla_node_configs(&actors)
+    let scylla_configs: Vec<ScyllaNodeConfig> = get_default_scylla_node_configs(actors)
         .await
         .into_iter()
         .map(|mut c| {
@@ -232,8 +232,8 @@ pub async fn init_with_proxy(actors: TestActors) {
             c
         })
         .collect();
-    let scylla_proxy_configs = get_default_scylla_proxy_node_configs(&actors).await;
-    let mut vs_configs = get_proxy_vs_node_configs(&actors);
+    let scylla_proxy_configs = get_default_scylla_proxy_node_configs(actors).await;
+    let mut vs_configs = get_proxy_vs_node_configs(actors);
 
     actors.db.start(scylla_configs).await;
     assert!(actors.db.wait_for_ready().await);
@@ -254,14 +254,14 @@ pub async fn init_with_proxy(actors: TestActors) {
 }
 
 #[framed]
-pub async fn init_with_proxy_single_vs(actors: TestActors) {
+pub async fn init_with_proxy_single_vs(actors: &TestActors) {
     info!("started");
 
-    init_dns(&actors).await;
+    init_dns(actors).await;
 
     // Proxy operates at CQL frame level and cannot handle TLS, so ScyllaDB
     // must be started without TLS when using the proxy.
-    let mut scylla_configs: Vec<ScyllaNodeConfig> = get_default_scylla_node_configs(&actors)
+    let mut scylla_configs: Vec<ScyllaNodeConfig> = get_default_scylla_node_configs(actors)
         .await
         .into_iter()
         .map(|mut c| {
@@ -282,8 +282,8 @@ pub async fn init_with_proxy_single_vs(actors: TestActors) {
         config.primary_vs_uris = vec![first_vs_url.clone()];
         config.secondary_vs_uris = vec![];
     });
-    let scylla_proxy_configs = get_default_scylla_proxy_node_configs(&actors).await;
-    let mut vs_configs: Vec<_> = get_proxy_vs_node_configs(&actors)
+    let scylla_proxy_configs = get_default_scylla_proxy_node_configs(actors).await;
+    let mut vs_configs: Vec<_> = get_proxy_vs_node_configs(actors)
         .into_iter()
         .take(1)
         .collect();
@@ -316,11 +316,11 @@ pub async fn init_dns(actors: &TestActors) {
 
 #[framed]
 pub async fn init_with_config(
-    actors: TestActors,
+    actors: &TestActors,
     scylla_configs: Vec<ScyllaNodeConfig>,
     vs_configs: Vec<VectorStoreNodeConfig>,
 ) {
-    init_dns(&actors).await;
+    init_dns(actors).await;
 
     actors.db.start(scylla_configs).await;
     assert!(actors.db.wait_for_ready().await);
@@ -329,7 +329,7 @@ pub async fn init_with_config(
 }
 
 #[framed]
-pub async fn cleanup(actors: TestActors) {
+pub async fn cleanup(actors: &TestActors) {
     info!("started");
     for name in VS_NAMES.iter() {
         actors.dns.remove(name.to_string()).await;

--- a/crates/validator/src/connection_timeout.rs
+++ b/crates/validator/src/connection_timeout.rs
@@ -5,27 +5,36 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use e2etest_firewall::FirewallExt;
 use e2etest_vector_store_cluster::VectorStoreClusterExt;
+use std::sync::Arc;
 use std::time::Duration;
 use tap::Pipe;
 use tracing::info;
 
 const CONNECTION_TIMEOUT: &str = "5s";
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init_with_proxy_single_vs)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "connection_timeout_triggers_session_failure",
-            timeout,
-            connection_timeout_triggers_session_failure,
-        )
+e2etest::group!(
+    name = connection_timeout,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init_with_proxy_single_vs(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
 }
 
 /// Test that the CQL connection timeout causes session creation to fail
@@ -40,8 +49,8 @@ pub(crate) async fn new() -> TestCase<TestActors> {
 /// - Verify that session-create-failure counter increments (timeout fires).
 /// - Restore connectivity by allowing traffic through the proxy.
 /// - Verify that vector-store eventually connects and becomes ready.
-#[framed]
-async fn connection_timeout_triggers_session_failure(actors: TestActors) {
+#[e2etest::test(group = connection_timeout)]
+async fn connection_timeout_triggers_session_failure(actors: Arc<TestActors>) {
     info!("started");
 
     info!("Stop vector-store");

--- a/crates/validator/src/crud.rs
+++ b/crates/validator/src/crud.rs
@@ -5,41 +5,31 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use httpapi::IndexStatus;
+use std::sync::Arc;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "simple_create_drop_index",
-            timeout,
-            simple_create_drop_index,
-        )
-        .with_test(
-            "simple_create_drop_multiple_indexes",
-            timeout,
-            simple_create_drop_multiple_indexes,
-        )
-        .with_test(
-            "drop_table_removes_index",
-            timeout,
-            drop_table_removes_index,
-        )
-        .with_test(
-            "null_vector_is_not_indexed",
-            timeout,
-            null_vector_is_not_indexed,
-        )
+e2etest::group!(name = crud, fixtures = (Fixture), parent = crate::validator);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn simple_create_drop_index(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = crud)]
+async fn simple_create_drop_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -84,8 +74,8 @@ async fn simple_create_drop_index(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn simple_create_drop_multiple_indexes(actors: TestActors) {
+#[e2etest::test(group = crud)]
+async fn simple_create_drop_multiple_indexes(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -211,8 +201,8 @@ async fn simple_create_drop_multiple_indexes(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn drop_table_removes_index(actors: TestActors) {
+#[e2etest::test(group = crud)]
+async fn drop_table_removes_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -273,8 +263,8 @@ async fn drop_table_removes_index(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn null_vector_is_not_indexed(actors: TestActors) {
+#[e2etest::test(group = crud)]
+async fn null_vector_is_not_indexed(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;

--- a/crates/validator/src/db_timeout.rs
+++ b/crates/validator/src/db_timeout.rs
@@ -5,13 +5,12 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use e2etest_scylla_proxy_cluster::ScyllaProxyClusterExt;
 use scylla_proxy::Condition;
 use scylla_proxy::Reaction;
 use scylla_proxy::RequestReaction;
 use scylla_proxy::RequestRule;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::mpsc;
@@ -19,17 +18,27 @@ use tokio::sync::watch;
 use tokio::time;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init_with_proxy)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "client_timeout_doesnt_stop_cdc",
-            timeout,
-            client_timeout_doesnt_stop_cdc,
-        )
+e2etest::group!(
+    name = db_timeout,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init_with_proxy(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
 }
 
 /// Test that CDC is working after rust driver session's client timeout.
@@ -45,8 +54,8 @@ pub(crate) async fn new() -> TestCase<TestActors> {
 /// - Bring back simulator to normal operation.
 /// - Wait until vector-stores update indexes using CDC.
 /// - Drop the keyspace.
-#[framed]
-async fn client_timeout_doesnt_stop_cdc(actors: TestActors) {
+#[e2etest::test(group = db_timeout)]
+async fn client_timeout_doesnt_stop_cdc(actors: Arc<TestActors>) {
     info!("started");
     let (session, clients) = prepare_connection_no_tls(&actors).await;
     let keyspace = create_keyspace(&session).await;

--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -5,109 +5,41 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use httpapi::KeyspaceName;
 use scylla::client::session::Session;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "ann_filter_by_partition_key_eq",
-            timeout,
-            ann_filter_by_partition_key_eq,
-        )
-        .with_test(
-            "ann_filter_by_partition_key_in",
-            timeout,
-            ann_filter_by_partition_key_in,
-        )
-        .with_test(
-            "ann_filter_by_clustering_key_lt",
-            timeout,
-            ann_filter_by_clustering_key_lt,
-        )
-        .with_test(
-            "ann_filter_by_clustering_key_gt",
-            timeout,
-            ann_filter_by_clustering_key_gt,
-        )
-        .with_test(
-            "ann_filter_by_clustering_key_range",
-            timeout,
-            ann_filter_by_clustering_key_range,
-        )
-        .with_test("ann_filter_by_pk_and_ck", timeout, ann_filter_by_pk_and_ck)
-        .with_test(
-            "ann_filter_returns_no_results_when_nothing_matches",
-            timeout,
-            ann_filter_returns_no_results_when_nothing_matches,
-        )
-        .with_test(
-            "ann_filter_by_vector_column_fails",
-            timeout,
-            ann_filter_by_vector_column_fails,
-        )
-        .with_test(
-            "ann_filter_by_non_indexed_column_fails",
-            timeout,
-            ann_filter_by_non_indexed_column_fails,
-        )
-        .with_test(
-            "ann_filter_by_clustering_key_only_requires_allow_filtering",
-            timeout,
-            ann_filter_by_clustering_key_only_requires_allow_filtering,
-        )
-        .with_test(
-            "ann_filter_by_non_pk_column_rejected_without_allow_filtering",
-            timeout,
-            ann_filter_by_non_pk_column_rejected_without_allow_filtering,
-        )
-        .with_test(
-            "ann_filter_by_non_pk_column_rejected_with_allow_filtering",
-            timeout,
-            ann_filter_by_non_pk_column_rejected_with_allow_filtering,
-        )
-        .with_test(
-            "local_index_filter_by_partition_key_eq",
-            timeout,
-            local_index_filter_by_partition_key_eq,
-        )
-        .with_test(
-            "local_index_filter_by_clustering_key_range",
-            timeout,
-            local_index_filter_by_clustering_key_range,
-        )
-        .with_test(
-            "local_index_filter_returns_no_results_when_nothing_matches",
-            timeout,
-            local_index_filter_returns_no_results_when_nothing_matches,
-        )
-        .with_test(
-            "global_ann_with_timestamp_eq_filter",
-            timeout,
-            global_ann_with_timestamp_eq_filter,
-        )
-        .with_test(
-            "local_ann_with_timestamp_gte_filter",
-            timeout,
-            local_ann_with_timestamp_gte_filter,
-        )
+e2etest::group!(
+    name = filtering,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
 }
 
 /// Test ANN search filtered by partition key equality.
 ///
 /// Table has composite primary key (pk, ck). Insert rows across multiple
 /// partitions. Query with `WHERE pk = 1` to get only rows from partition 1.
-#[framed]
-async fn ann_filter_by_partition_key_eq(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_partition_key_eq(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -178,8 +110,8 @@ async fn ann_filter_by_partition_key_eq(actors: TestActors) {
 /// Test ANN search filtered by partition key using IN clause.
 ///
 /// Query with `WHERE pk IN (0, 2)` to get rows from partitions 0 and 2 only.
-#[framed]
-async fn ann_filter_by_partition_key_in(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_partition_key_in(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -247,8 +179,8 @@ async fn ann_filter_by_partition_key_in(actors: TestActors) {
 ///
 /// Restrict to a single partition with `WHERE pk = 0 AND ck < 3`.
 /// Only rows with ck in {0, 1, 2} should be returned.
-#[framed]
-async fn ann_filter_by_clustering_key_lt(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_clustering_key_lt(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -314,8 +246,8 @@ async fn ann_filter_by_clustering_key_lt(actors: TestActors) {
 ///
 /// Restrict to a single partition with `WHERE pk = 0 AND ck > 7`.
 /// Only rows with ck in {8, 9} should be returned.
-#[framed]
-async fn ann_filter_by_clustering_key_gt(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_clustering_key_gt(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -381,8 +313,8 @@ async fn ann_filter_by_clustering_key_gt(actors: TestActors) {
 ///
 /// Restrict to a single partition with `WHERE pk = 0 AND ck >= 3 AND ck <= 5`.
 /// Only rows with ck in {3, 4, 5} should be returned.
-#[framed]
-async fn ann_filter_by_clustering_key_range(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_clustering_key_range(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -449,8 +381,8 @@ async fn ann_filter_by_clustering_key_range(actors: TestActors) {
 /// Create a table with composite primary key (pk, ck1, ck2).
 /// Use `WHERE pk = 1 AND ck1 = 0` to restrict on both partition and
 /// first clustering column.
-#[framed]
-async fn ann_filter_by_pk_and_ck(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_pk_and_ck(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -523,8 +455,8 @@ async fn ann_filter_by_pk_and_ck(actors: TestActors) {
 
 /// Test that a CQL ANN query filtering on a partition key with no matching
 /// rows returns empty results.
-#[framed]
-async fn ann_filter_returns_no_results_when_nothing_matches(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_returns_no_results_when_nothing_matches(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -592,8 +524,8 @@ async fn ann_filter_returns_no_results_when_nothing_matches(actors: TestActors) 
 /// Test that filtering by the vector column in a WHERE clause fails.
 ///
 /// `WHERE v = [...]` does not apply a filter and should be rejected.
-#[framed]
-async fn ann_filter_by_vector_column_fails(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_vector_column_fails(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -644,8 +576,8 @@ async fn ann_filter_by_vector_column_fails(actors: TestActors) {
 /// Test that filtering by a non-primary-key column in a WHERE clause fails.
 ///
 /// `WHERE f = 1` on a non-indexed column should be rejected.
-#[framed]
-async fn ann_filter_by_non_indexed_column_fails(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_non_indexed_column_fails(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -696,8 +628,8 @@ async fn ann_filter_by_non_indexed_column_fails(actors: TestActors) {
 /// Create a local index partitioned by pk. Insert rows across multiple
 /// partitions. Query with `WHERE pk = 1` and verify only rows from
 /// partition 1 are returned.
-#[framed]
-async fn local_index_filter_by_partition_key_eq(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn local_index_filter_by_partition_key_eq(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -772,8 +704,8 @@ async fn local_index_filter_by_partition_key_eq(actors: TestActors) {
 /// Create a local index partitioned by pk. Restrict to a single partition
 /// with `WHERE pk = 0 AND ck >= 3 AND ck <= 5` and verify only the matching
 /// clustering keys are returned.
-#[framed]
-async fn local_index_filter_by_clustering_key_range(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn local_index_filter_by_clustering_key_range(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -840,8 +772,8 @@ async fn local_index_filter_by_clustering_key_range(actors: TestActors) {
 
 /// Test that a CQL ANN query on a local index filtering on a non-existent
 /// partition key returns empty results.
-#[framed]
-async fn local_index_filter_returns_no_results_when_nothing_matches(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn local_index_filter_returns_no_results_when_nothing_matches(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -909,8 +841,8 @@ async fn local_index_filter_returns_no_results_when_nothing_matches(actors: Test
 
 /// Reproducer for VECTOR-593: ANN query with global index and a timestamp
 /// equality filter using a space-separated CQL timestamp must not fail.
-#[framed]
-async fn global_ann_with_timestamp_eq_filter(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn global_ann_with_timestamp_eq_filter(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -973,8 +905,8 @@ async fn global_ann_with_timestamp_eq_filter(actors: TestActors) {
 
 /// Reproducer for VECTOR-593: ANN query with local index and a timestamp
 /// inequality filter using a date-only CQL timestamp must not fail.
-#[framed]
-async fn local_ann_with_timestamp_gte_filter(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn local_ann_with_timestamp_gte_filter(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -1044,8 +976,8 @@ async fn local_ann_with_timestamp_gte_filter(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn ann_filter_by_clustering_key_only_requires_allow_filtering(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_clustering_key_only_requires_allow_filtering(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -1090,8 +1022,8 @@ async fn ann_filter_by_clustering_key_only_requires_allow_filtering(actors: Test
     info!("finished");
 }
 
-#[framed]
-async fn ann_filter_by_non_pk_column_rejected_without_allow_filtering(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_non_pk_column_rejected_without_allow_filtering(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, keyspace, table) = prepare_non_pk_column_filter_test(&actors).await;
@@ -1113,8 +1045,8 @@ async fn ann_filter_by_non_pk_column_rejected_without_allow_filtering(actors: Te
     info!("finished");
 }
 
-#[framed]
-async fn ann_filter_by_non_pk_column_rejected_with_allow_filtering(actors: TestActors) {
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_non_pk_column_rejected_with_allow_filtering(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, keyspace, table) = prepare_non_pk_column_filter_test(&actors).await;

--- a/crates/validator/src/full_scan.rs
+++ b/crates/validator/src/full_scan.rs
@@ -5,8 +5,6 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use e2etest_scylla_proxy_cluster::ScyllaProxyClusterExt;
 use httpapi::IndexInfo;
 use httpapi::IndexStatus;
@@ -18,30 +16,36 @@ use scylla_proxy::RequestOpcode;
 use scylla_proxy::RequestReaction;
 use scylla_proxy::RequestRule;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init_with_proxy_single_vs)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "full_scan_is_completed_when_responding_to_messages_concurrently",
-            timeout,
-            full_scan_is_completed_when_responding_to_messages_concurrently,
-        )
-        .with_test(
-            "full_scan_stops_when_index_is_dropped",
-            timeout,
-            full_scan_stops_when_index_is_dropped,
-        )
+e2etest::group!(
+    name = full_scan,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init_with_proxy_single_vs(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = full_scan)]
+async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
@@ -140,8 +144,8 @@ async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors:
     info!("finished");
 }
 
-#[framed]
-async fn full_scan_stops_when_index_is_dropped(actors: TestActors) {
+#[e2etest::test(group = full_scan)]
+async fn full_scan_stops_when_index_is_dropped(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;

--- a/crates/validator/src/high_availability.rs
+++ b/crates/validator/src/high_availability.rs
@@ -7,27 +7,38 @@ use std::collections::HashMap;
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use e2etest_scylla_cluster::ScyllaClusterExt;
 use e2etest_scylla_cluster::ScyllaNodeConfig;
 use e2etest_tls::TlsExt;
 use e2etest_vector_store_cluster::VectorStoreNodeConfig;
 use scylla::statement::Statement;
+use std::sync::Arc;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty().with_cleanup(timeout, cleanup).with_test(
-        "secondary_uri_works_correctly",
-        timeout,
-        test_secondary_uri_works_correctly,
-    )
+e2etest::group!(
+    name = high_availability,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn test_secondary_uri_works_correctly(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = high_availability)]
+async fn test_secondary_uri_works_correctly(actors: Arc<TestActors>) {
     info!("started");
 
     let vs_urls = get_default_vs_urls(&actors).await;
@@ -81,7 +92,7 @@ async fn test_secondary_uri_works_correctly(actors: TestActors) {
         user: None,
         password: None,
     }];
-    init_with_config(actors.clone(), scylla_configs, vs_configs).await;
+    init_with_config(&actors, scylla_configs, vs_configs).await;
 
     let vs_ips = vec![actors.services_subnet.ip(VS_OCTET_1)];
     let (session, clients) = prepare_connection_with_custom_vs_ips(&actors, vs_ips).await;

--- a/crates/validator/src/index_create.rs
+++ b/crates/validator/src/index_create.rs
@@ -6,10 +6,8 @@
 use crate::TestActors;
 use crate::common;
 use crate::common::CreateIndexQuery;
-use crate::common::DEFAULT_TEST_TIMEOUT;
 use crate::common::TableName;
 use async_backtrace::framed;
-use e2etest::TestCase;
 use httpapi::IndexInfo;
 use httpapi::KeyspaceName;
 use httpclient::HttpClient;
@@ -17,32 +15,27 @@ use scylla::client::session::Session;
 use std::sync::Arc;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, common::init)
-        .with_cleanup(timeout, common::cleanup)
-        .with_test(
-            "global_index_without_filtering_columns",
-            timeout,
-            global_index_without_filtering_columns,
-        )
-        .with_test(
-            "global_index_with_filtering_columns",
-            timeout,
-            global_index_with_filtering_columns,
-        )
-        .with_test(
-            "local_index_without_filtering_columns",
-            timeout,
-            local_index_without_filtering_columns,
-        )
-        .with_test(
-            "local_index_with_filtering_columns",
-            timeout,
-            local_index_with_filtering_columns,
-        )
+e2etest::group!(
+    name = index_create,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        common::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }
 
 #[framed]
@@ -96,8 +89,8 @@ async fn wait_for_index(clients: &[HttpClient], index: &IndexInfo) {
     }
 }
 
-#[framed]
-async fn global_index_without_filtering_columns(actors: TestActors) {
+#[e2etest::test(group = index_create)]
+async fn global_index_without_filtering_columns(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients, keyspace, table) = init_keyspace_table(&actors).await;
@@ -121,8 +114,8 @@ async fn global_index_without_filtering_columns(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn global_index_with_filtering_columns(actors: TestActors) {
+#[e2etest::test(group = index_create)]
+async fn global_index_with_filtering_columns(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients, keyspace, table) = init_keyspace_table(&actors).await;
@@ -150,8 +143,8 @@ async fn global_index_with_filtering_columns(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn local_index_without_filtering_columns(actors: TestActors) {
+#[e2etest::test(group = index_create)]
+async fn local_index_without_filtering_columns(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients, keyspace, table) = init_keyspace_table(&actors).await;
@@ -178,8 +171,8 @@ async fn local_index_without_filtering_columns(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn local_index_with_filtering_columns(actors: TestActors) {
+#[e2etest::test(group = index_create)]
+async fn local_index_with_filtering_columns(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients, keyspace, table) = init_keyspace_table(&actors).await;

--- a/crates/validator/src/index_status.rs
+++ b/crates/validator/src/index_status.rs
@@ -5,33 +5,37 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use httpapi::IndexName;
 use httpapi::IndexStatus;
 use httpapi::KeyspaceName;
+use std::sync::Arc;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "status_returned_correctly",
-            timeout,
-            status_returned_correctly,
-        )
-        .with_test(
-            "status_returns_404_for_non_existent_index",
-            timeout,
-            status_returns_404_for_non_existent_index,
-        )
+e2etest::group!(
+    name = index_status,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn status_returned_correctly(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = index_status)]
+async fn status_returned_correctly(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -75,8 +79,8 @@ async fn status_returned_correctly(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn status_returns_404_for_non_existent_index(actors: TestActors) {
+#[e2etest::test(group = index_status)]
+async fn status_returns_404_for_non_existent_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (_session, clients) = prepare_connection(&actors).await;

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -23,8 +23,9 @@ mod serde;
 mod similarity_functions;
 mod tls_reload;
 
-use async_backtrace::framed;
-use e2etest::TestCase;
+use clap::Parser;
+use clap::Subcommand;
+use e2etest::Config;
 use e2etest_dns::Dns;
 use e2etest_dns::DnsExt;
 use e2etest_firewall::Firewall;
@@ -38,7 +39,10 @@ use std::env;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc;
+use tokio::time;
+use tracing::error;
 use tracing::info;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -46,8 +50,24 @@ use tracing_subscriber::filter;
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
 
-#[derive(clap::Args)]
+#[derive(Parser)]
+#[clap(version)]
 struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Print the list of available tests and exit.
+    List,
+
+    /// Run the E2E tests.
+    Run(RunArgs),
+}
+
+#[derive(clap::Args)]
+struct RunArgs {
     /// IP address for the DNS server to bind to. Must be a loopback address.
     #[arg(short, long, default_value = "127.0.1.1", value_name = "IP")]
     dns_ip: Ipv4Addr,
@@ -83,9 +103,19 @@ struct Args {
     /// Path to the Vector Store executable.
     #[arg(value_name = "PATH")]
     vector_store: PathBuf,
+
+    /// Filters to select specific tests to run.
+    /// The syntax is as follows:
+    ///     `<partially_matching_test_group_name>::<partially_matching_test_case_name>`
+    /// Wrap either side in double quotes to require an exact match, for example:
+    ///     `"crud"::`
+    ///     `::"simple_create"`
+    /// Without specifying `::`, the filter will try to match both the group and test names.
+    #[arg(value_name = "FILTER")]
+    filters: Vec<String>,
 }
 
-fn init(args: &Args) {
+fn init(args: RunArgs) -> Config {
     let ansi = !args.disable_colors;
     let rust_log = if args.verbose {
         "info"
@@ -121,12 +151,12 @@ fn init(args: &Args) {
                 .with_writer(std::io::stdout),
         )
         .init();
-}
 
-#[framed]
-/// Returns a vector of all known test cases to be run. Each test case is registered with a name
-async fn register() -> Vec<(String, TestCase<TestActors>)> {
-    test_cases().await.collect()
+    args.filters
+        .iter()
+        .fold(Config::default(), |acc, filter| acc.with_filter(filter))
+        .with_permanent_fixture(args)
+        .with_default_timeout(common::DEFAULT_TEST_TIMEOUT)
 }
 
 fn validate_different_subnet(dns_ip: Ipv4Addr, base_ip: Ipv4Addr) {
@@ -138,52 +168,50 @@ fn validate_different_subnet(dns_ip: Ipv4Addr, base_ip: Ipv4Addr) {
     );
 }
 
-async fn fixture(args: &Args) -> TestActors {
-    validate_different_subnet(args.dns_ip, args.base_ip);
+e2etest::group!(name = validator, fixtures = (TestActors));
 
-    let services_subnet = Arc::new(ServicesSubnet::new(args.base_ip));
-    let tls = e2etest_tls::new(&common::get_default_db_ips_for_subnet(&services_subnet)).await;
-    let dns = e2etest_dns::new(args.dns_ip).await;
-    let firewall = e2etest_firewall::new().await;
-    let db = e2etest_scylla_cluster::new(
-        args.scylla.clone(),
-        args.scylla_default_conf.clone(),
-        args.tmpdir.clone(),
-        args.verbose,
-    )
-    .await;
-    let vs = e2etest_vector_store_cluster::new(
-        args.vector_store.clone(),
-        args.verbose,
-        args.disable_colors,
-        args.tmpdir.clone(),
-    )
-    .await;
-    let db_proxy = e2etest_scylla_proxy_cluster::new().await;
+pub async fn run() {
+    let args = Args::parse();
+    let root = validator();
+    let stats = match args.command {
+        Command::List => {
+            root.test_names().into_iter().for_each(|name| {
+                println!("{name}");
+            });
+            return;
+        }
+        Command::Run(args) => e2etest::run(init(args), root).await,
+    };
 
-    info!(
-        "{} version: {}",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION")
-    );
-    let version = db.version().await;
-    info!("scylla version: {}", version);
-    info!("dns version: {}", dns.version().await);
-    info!("vector-store version: {}", vs.version().await);
+    info!("Waiting for all tasks to finish...");
+    if time::timeout(common::DEFAULT_TEST_TIMEOUT, async {
+        while Handle::current().metrics().num_alive_tasks() > 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .is_err()
+    {
+        error!("Timed out waiting for tasks to finish");
+    } else {
+        info!("All tasks finished");
+    }
 
-    TestActors {
-        services_subnet,
-        tls,
-        dns,
-        firewall,
-        db,
-        vs,
-        db_proxy,
+    if !stats.is_success() {
+        error!(
+            "{error_list}",
+            error_list = format_failed_names(&stats.failed_names())
+        );
     }
 }
 
-pub fn run() -> Result<(), &'static str> {
-    e2etest::run(env::args_os(), init, register, fixture)
+pub(crate) fn format_failed_names(failed_names: &[String]) -> String {
+    let failed_names = failed_names
+        .iter()
+        .map(|name| format!("- {name}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("List of failures:\n{failed_names}")
 }
 
 /// Represents a subnet for services, derived from a base IP address.
@@ -222,31 +250,51 @@ struct TestActors {
     pub(crate) db_proxy: mpsc::Sender<ScyllaProxyCluster>,
 }
 
-#[framed]
-pub async fn test_cases() -> impl Iterator<Item = (String, TestCase<TestActors>)> {
-    vec![
-        ("ann", ann::new().await),
-        ("auth", auth::new().await),
-        ("cdc", cdc::new().await),
-        ("connection_timeout", connection_timeout::new().await),
-        ("crud", crud::new().await),
-        ("db_timeout", db_timeout::new().await),
-        ("filtering", filtering::new().await),
-        ("full_scan", full_scan::new().await),
-        ("high_availability", high_availability::new().await),
-        ("index_status", index_status::new().await),
-        ("index_create", index_create::new().await),
-        ("reconnect", reconnect::new().await),
-        ("routing", routing::new().await),
-        ("serde", serde::new().await),
-        ("similarity_function", similarity_functions::new().await),
-        ("tls_reload", tls_reload::new().await),
-        (
-            "quantization_and_rescoring",
-            quantization_and_rescoring::new().await,
-        ),
-    ]
-    .into_iter()
-    .map(|(name, test_case)| (name.to_string(), test_case))
-    .chain(alternator::test_cases().await)
+impl e2etest::Fixture for TestActors {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        let args = setup.get::<RunArgs>().await.unwrap();
+
+        validate_different_subnet(args.dns_ip, args.base_ip);
+
+        let services_subnet = Arc::new(ServicesSubnet::new(args.base_ip));
+        let tls = e2etest_tls::new(&common::get_default_db_ips_for_subnet(&services_subnet)).await;
+        let dns = e2etest_dns::new(args.dns_ip).await;
+        let firewall = e2etest_firewall::new().await;
+        let db = e2etest_scylla_cluster::new(
+            args.scylla.clone(),
+            args.scylla_default_conf.clone(),
+            args.tmpdir.clone(),
+            args.verbose,
+        )
+        .await;
+        let vs = e2etest_vector_store_cluster::new(
+            args.vector_store.clone(),
+            args.verbose,
+            args.disable_colors,
+            args.tmpdir.clone(),
+        )
+        .await;
+        let db_proxy = e2etest_scylla_proxy_cluster::new().await;
+
+        info!(
+            "{} version: {}",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION")
+        );
+        let version = db.version().await;
+        info!("scylla version: {}", version);
+        info!("dns version: {}", dns.version().await);
+        info!("vector-store version: {}", vs.version().await);
+
+        Self {
+            services_subnet,
+            tls,
+            dns,
+            firewall,
+            db,
+            vs,
+            db_proxy,
+        }
+    }
+    async fn teardown(self) {}
 }

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-fn main() -> Result<(), &'static str> {
-    vector_search_validator::run()
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    vector_search_validator::run().await
 }

--- a/crates/validator/src/quantization_and_rescoring.rs
+++ b/crates/validator/src/quantization_and_rescoring.rs
@@ -8,11 +8,11 @@ use crate::common;
 use crate::common::TableName;
 use crate::common::*;
 use async_backtrace::framed;
-use e2etest::TestCase;
 use httpapi::IndexInfo;
 use httpclient::HttpClient;
 use scylla::client::session::Session;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::info;
 
 /// Generate test vectors for quantization precision testing
@@ -65,42 +65,37 @@ async fn insert_vectors(session: &Session, table: &TableName, embeddings: &HashM
     }
 }
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "non_quantized_index_returns_correctly_ranked_vectors",
-            timeout,
-            non_quantized_index_returns_correctly_ranked_vectors,
-        )
-        .with_test(
-            "quantized_index_returns_incorrectly_ranked_vectors_due_to_precision_loss",
-            timeout,
-            quantized_index_returns_incorrectly_ranked_vectors_due_to_precision_loss,
-        )
-        .with_test(
-            "rescoring_ranks_results_correctly_for_quantized_index",
-            timeout,
-            rescoring_ranks_results_correctly_for_quantized_index,
-        )
-        .with_test(
-            "searching_and_rescoring_works_for_binary_quantization",
-            timeout,
-            searching_and_rescoring_works_for_binary_quantization,
-        )
+e2etest::group!(
+    name = quantization_and_rescoring,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = quantization_and_rescoring)]
 // This test confirms that with full f32 precision, the vector search can distinguish
 // between very similar vectors and rank them correctly. The test vectors are generated
 // with small, incremental differences. A correct implementation should order them by their
 // primary key (pk), which corresponds to their increasing distance from the query vector.
 // The success of this test depends on the underlying floating-point precision (f32) being
 // sufficient to handle the small differences in the test data.
-async fn non_quantized_index_returns_correctly_ranked_vectors(actors: TestActors) {
+async fn non_quantized_index_returns_correctly_ranked_vectors(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -158,7 +153,7 @@ async fn non_quantized_index_returns_correctly_ranked_vectors(actors: TestActors
     info!("finished");
 }
 
-#[framed]
+#[e2etest::test(group = quantization_and_rescoring)]
 // This test verifies that i8 quantization leads to a loss of precision.
 // Test vectors are generated such that their distance from the query vector increases
 // with their primary key (pk). The differences are small and are lost when vectors
@@ -171,7 +166,7 @@ async fn non_quantized_index_returns_correctly_ranked_vectors(actors: TestActors
 // We assert that the results are NOT sorted by pk, which would be the correct order
 // if full precision were maintained. This demonstrates the effect of precision loss.
 async fn quantized_index_returns_incorrectly_ranked_vectors_due_to_precision_loss(
-    actors: TestActors,
+    actors: Arc<TestActors>,
 ) {
     info!("started");
 
@@ -230,7 +225,7 @@ async fn quantized_index_returns_incorrectly_ranked_vectors_due_to_precision_los
     info!("finished");
 }
 
-#[framed]
+#[e2etest::test(group = quantization_and_rescoring)]
 // This test demonstrates that rescoring can correct the ranking inaccuracies introduced by quantization.
 //
 // The initial search is performed on the quantized (i8) index. As shown in the previous test,
@@ -239,7 +234,7 @@ async fn quantized_index_returns_incorrectly_ranked_vectors_due_to_precision_los
 // By enabling rescoring, the system recalculates the exact distances using the original, full-precision
 // vectors for a set of top candidates. This corrects the ranking. The test asserts that the final
 // results are sorted by primary key (pk), confirming that rescoring successfully restored the correct order.
-async fn rescoring_ranks_results_correctly_for_quantized_index(actors: TestActors) {
+async fn rescoring_ranks_results_correctly_for_quantized_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -298,10 +293,10 @@ async fn rescoring_ranks_results_correctly_for_quantized_index(actors: TestActor
     info!("finished");
 }
 
-#[framed]
+#[e2etest::test(group = quantization_and_rescoring)]
 // Binary quantization has a special implementation in vector-store.
 // Hence we need to verify that search and rescoring also work correctly with it.
-async fn searching_and_rescoring_works_for_binary_quantization(actors: TestActors) {
+async fn searching_and_rescoring_works_for_binary_quantization(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;

--- a/crates/validator/src/reconnect.rs
+++ b/crates/validator/src/reconnect.rs
@@ -5,8 +5,6 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use e2etest_firewall::FirewallExt;
 use e2etest_scylla_cluster::ScyllaClusterExt;
 use e2etest_scylla_proxy_cluster::ScyllaProxyClusterExt;
@@ -16,6 +14,7 @@ use scylla_proxy::Condition;
 use scylla_proxy::Reaction;
 use scylla_proxy::RequestReaction;
 use scylla_proxy::RequestRule;
+use std::sync::Arc;
 use std::time::Duration;
 use tap::Pipe;
 use tracing::info;
@@ -24,36 +23,31 @@ const FRAME_DELAY: Duration = Duration::from_millis(100);
 const DATASET_SIZE: i32 = 100;
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(12); // slightly more than default 10s
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init_with_proxy_single_vs)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "reconnect_doesnt_break_fullscan",
-            timeout,
-            reconnect_doesnt_break_fullscan,
-        )
-        .with_test(
-            "restarting_one_node_doesnt_break_fullscan",
-            timeout,
-            restarting_one_node_doesnt_break_fullscan,
-        )
-        .with_test(
-            "restarting_all_nodes_doesnt_break_fullscan",
-            timeout,
-            restarting_all_nodes_doesnt_break_fullscan,
-        )
-        .with_test(
-            "restarting_vs_cluster_does_not_break_setup",
-            timeout,
-            test_restarting_vs_cluster_does_not_break_setup,
-        )
+e2etest::group!(
+    name = reconnect,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn reconnect_doesnt_break_fullscan(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init_with_proxy_single_vs(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = reconnect)]
+async fn reconnect_doesnt_break_fullscan(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
@@ -214,8 +208,8 @@ async fn reconnect_doesnt_break_fullscan(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn restarting_one_node_doesnt_break_fullscan(actors: TestActors) {
+#[e2etest::test(group = reconnect)]
+async fn restarting_one_node_doesnt_break_fullscan(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
@@ -342,8 +336,8 @@ async fn restarting_one_node_doesnt_break_fullscan(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn restarting_all_nodes_doesnt_break_fullscan(actors: TestActors) {
+#[e2etest::test(group = reconnect)]
+async fn restarting_all_nodes_doesnt_break_fullscan(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
@@ -489,8 +483,8 @@ async fn restarting_all_nodes_doesnt_break_fullscan(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn test_restarting_vs_cluster_does_not_break_setup(actors: TestActors) {
+#[e2etest::test(group = reconnect)]
+async fn test_restarting_vs_cluster_does_not_break_setup(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;

--- a/crates/validator/src/routing.rs
+++ b/crates/validator/src/routing.rs
@@ -5,8 +5,6 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use e2etest_scylla_proxy_cluster::ScyllaProxyClusterExt;
 use httpapi::IndexInfo;
 use httpapi::IndexStatus;
@@ -15,43 +13,34 @@ use scylla_proxy::Condition;
 use scylla_proxy::Reaction;
 use scylla_proxy::RequestReaction;
 use scylla_proxy::RequestRule;
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::info;
 
 const ANN_LIMIT: usize = 5;
 const FRAME_DELAY: Duration = Duration::from_millis(100);
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, init_with_proxy_single_vs)
-        .with_cleanup(timeout, cleanup)
-        .with_test(
-            "ann_routes_to_serving_index_while_replacement_is_bootstrapping",
-            timeout,
-            ann_routes_to_serving_index_while_replacement_is_bootstrapping,
-        )
-        .with_test(
-            "ann_does_not_route_between_columns_while_requested_index_is_bootstrapping",
-            timeout,
-            ann_does_not_route_between_columns_while_requested_index_is_bootstrapping,
-        )
-        .with_test(
-            "ann_returns_not_found_for_nonexistent_index",
-            timeout,
-            ann_returns_not_found_for_nonexistent_index,
-        )
-        .with_test(
-            "ann_returns_unavailable_when_only_index_is_bootstrapping",
-            timeout,
-            ann_returns_unavailable_when_only_index_is_bootstrapping,
-        )
-        .with_test(
-            "ann_returns_not_found_after_index_is_dropped",
-            timeout,
-            ann_returns_not_found_after_index_is_dropped,
-        )
+e2etest::group!(
+    name = routing,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init_with_proxy_single_vs(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
 }
 
 async fn wait_for_bootstrapping(client: &HttpClient, index: &IndexInfo) {
@@ -72,8 +61,8 @@ async fn wait_for_bootstrapping(client: &HttpClient, index: &IndexInfo) {
     .await;
 }
 
-#[framed]
-async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping(actors: TestActors) {
+#[e2etest::test(group = routing)]
+async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
@@ -169,9 +158,9 @@ async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping(actors: 
     info!("finished");
 }
 
-#[framed]
+#[e2etest::test(group = routing)]
 async fn ann_does_not_route_between_columns_while_requested_index_is_bootstrapping(
-    actors: TestActors,
+    actors: Arc<TestActors>,
 ) {
     info!("started");
 
@@ -243,8 +232,8 @@ async fn ann_does_not_route_between_columns_while_requested_index_is_bootstrappi
     info!("finished");
 }
 
-#[framed]
-async fn ann_returns_not_found_for_nonexistent_index(actors: TestActors) {
+#[e2etest::test(group = routing)]
+async fn ann_returns_not_found_for_nonexistent_index(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, _clients) = prepare_connection_single_vs_no_tls(&actors).await;
@@ -275,8 +264,8 @@ async fn ann_returns_not_found_for_nonexistent_index(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn ann_returns_unavailable_when_only_index_is_bootstrapping(actors: TestActors) {
+#[e2etest::test(group = routing)]
+async fn ann_returns_unavailable_when_only_index_is_bootstrapping(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
@@ -336,8 +325,8 @@ async fn ann_returns_unavailable_when_only_index_is_bootstrapping(actors: TestAc
     info!("finished");
 }
 
-#[framed]
-async fn ann_returns_not_found_after_index_is_dropped(actors: TestActors) {
+#[e2etest::test(group = routing)]
+async fn ann_returns_not_found_after_index_is_dropped(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;

--- a/crates/validator/src/serde.rs
+++ b/crates/validator/src/serde.rs
@@ -6,32 +6,38 @@
 use crate::TestActors;
 use crate::common;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use scylla::statement::{Consistency, Statement};
 use scylla::value::CqlValue;
+use std::sync::Arc;
 use std::time::Duration;
 
 const CDC_WAIT: Duration = Duration::from_secs(2);
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, common::init)
-        .with_cleanup(timeout, common::cleanup)
-        .with_test(
-            "test_serialization_deserialization_all_types",
-            timeout,
-            test_serialization_deserialization_all_types,
-        )
-        .with_test("test_varint_filter", timeout, test_varint_filter)
-        .with_test("test_decimal_key", timeout, test_decimal_key)
-        .with_test("test_decimal_filter", timeout, test_decimal_filter)
+e2etest::group!(
+    name = serde,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
 }
 
-#[framed]
-async fn test_serialization_deserialization_all_types(actors: TestActors) {
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        common::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = serde)]
+async fn test_serialization_deserialization_all_types(actors: Arc<TestActors>) {
     let (session, clients) = common::prepare_connection(&actors).await;
 
     let cases = vec![
@@ -102,8 +108,8 @@ async fn test_serialization_deserialization_all_types(actors: TestActors) {
         .expect("failed to drop keyspace");
 }
 
-#[framed]
-async fn test_varint_filter(actors: TestActors) {
+#[e2etest::test(group = serde)]
+async fn test_varint_filter(actors: Arc<TestActors>) {
     let (session, clients) = common::prepare_connection(&actors).await;
     let keyspace = create_keyspace(&session).await;
 
@@ -203,8 +209,8 @@ async fn test_varint_filter(actors: TestActors) {
 /// - CK is semantic: `3.14` and `3.140` are the same row (overwrite).
 ///
 /// Verified via index_status.count and direct VS ANN queries (not CQL).
-#[framed]
-async fn test_decimal_key(actors: TestActors) {
+#[e2etest::test(group = serde)]
+async fn test_decimal_key(actors: Arc<TestActors>) {
     let (session, clients) = common::prepare_connection(&actors).await;
     let client = clients.first().unwrap();
     let keyspace = create_keyspace(&session).await;
@@ -325,8 +331,8 @@ async fn test_decimal_key(actors: TestActors) {
 /// Verify decimal filters use semantic BigDecimal comparison (not byte/unscaled comparison).
 /// Tests PK byte-identity (pk=1.0 vs pk=1.00 are separate partitions) and CK semantic
 /// comparison (cross-scale ordering, unnormalized CK match, beyond-i64 values).
-#[framed]
-async fn test_decimal_filter(actors: TestActors) {
+#[e2etest::test(group = serde)]
+async fn test_decimal_filter(actors: Arc<TestActors>) {
     let (session, clients) = common::prepare_connection(&actors).await;
     let keyspace = create_keyspace(&session).await;
 

--- a/crates/validator/src/similarity_functions.rs
+++ b/crates/validator/src/similarity_functions.rs
@@ -6,42 +6,31 @@
 use crate::TestActors;
 use crate::common;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use httpapi::IndexInfo;
+use std::sync::Arc;
 use tracing::info;
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_init(timeout, common::init)
-        .with_cleanup(timeout, common::cleanup)
-        .with_test(
-            "test_similarity_function_euclidean",
-            timeout,
-            test_similarity_function_euclidean,
-        )
-        .with_test(
-            "test_similarity_function_cosine",
-            timeout,
-            test_similarity_function_cosine,
-        )
-        .with_test(
-            "test_similarity_function_dot_product",
-            timeout,
-            test_similarity_function_dot_product,
-        )
-        .with_test(
-            "test_similarity_function_default_is_cosine",
-            timeout,
-            test_similarity_function_default_is_cosine,
-        )
-        .with_test(
-            "test_similarity_function_lowercase",
-            timeout,
-            test_similarity_function_lowercase,
-        )
+e2etest::group!(
+    name = similarity_function,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        common::init(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
 }
 
 async fn run_similarity_function_test(
@@ -121,8 +110,8 @@ async fn run_similarity_function_test(
         .expect("failed to drop a keyspace");
 }
 
-#[framed]
-async fn test_similarity_function_euclidean(actors: TestActors) {
+#[e2etest::test(group = similarity_function)]
+async fn test_similarity_function_euclidean(actors: Arc<TestActors>) {
     info!("started");
 
     let vectors = vec![
@@ -137,8 +126,8 @@ async fn test_similarity_function_euclidean(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn test_similarity_function_cosine(actors: TestActors) {
+#[e2etest::test(group = similarity_function)]
+async fn test_similarity_function_cosine(actors: Arc<TestActors>) {
     info!("started");
 
     // With cosine similarity, both pk=1 and pk=4 should have the same similarity (same direction)
@@ -154,8 +143,8 @@ async fn test_similarity_function_cosine(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn test_similarity_function_dot_product(actors: TestActors) {
+#[e2etest::test(group = similarity_function)]
+async fn test_similarity_function_dot_product(actors: Arc<TestActors>) {
     info!("started");
 
     // With dot product, pk=4 should have highest similarity (2.0 * 1.0 = 2.0)
@@ -171,8 +160,8 @@ async fn test_similarity_function_dot_product(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn test_similarity_function_default_is_cosine(actors: TestActors) {
+#[e2etest::test(group = similarity_function)]
+async fn test_similarity_function_default_is_cosine(actors: Arc<TestActors>) {
     info!("started");
 
     // Default is COSINE, so both pk=1 and pk=4 should have the same similarity (same direction)
@@ -188,8 +177,8 @@ async fn test_similarity_function_default_is_cosine(actors: TestActors) {
     info!("finished");
 }
 
-#[framed]
-async fn test_similarity_function_lowercase(actors: TestActors) {
+#[e2etest::test(group = similarity_function)]
+async fn test_similarity_function_lowercase(actors: Arc<TestActors>) {
     info!("started");
 
     let vectors = vec![

--- a/crates/validator/src/tls_reload.rs
+++ b/crates/validator/src/tls_reload.rs
@@ -5,13 +5,12 @@
 
 use crate::TestActors;
 use crate::common::*;
-use async_backtrace::framed;
-use e2etest::TestCase;
 use rcgen::CertificateParams;
 use rcgen::KeyPair;
 use reqwest::Certificate;
 use reqwest::Client;
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 use std::time::Duration;
 use tempfile::NamedTempFile;
 use tracing::info;
@@ -19,16 +18,26 @@ use tracing::info;
 const TLS_FILE_CHECK_INTERVAL: &str = "100ms";
 const TLS_RELOAD_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[framed]
-pub(crate) async fn new() -> TestCase<TestActors> {
-    let timeout = DEFAULT_TEST_TIMEOUT;
-    TestCase::empty()
-        .with_test(
-            "reloads_tls_identity_after_cert_file_rotation",
-            timeout,
-            reloads_tls_identity_after_cert_file_rotation,
-        )
-        .with_cleanup(timeout, cleanup)
+e2etest::group!(
+    name = tls_reload,
+    fixtures = (Fixture),
+    parent = crate::validator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
 }
 
 fn write_server_identity_pem(
@@ -71,8 +80,8 @@ async fn https_status_ok(vs_ips: &[Ipv4Addr], cert_pem: &[u8]) -> bool {
     true
 }
 
-#[framed]
-async fn reloads_tls_identity_after_cert_file_rotation(actors: TestActors) {
+#[e2etest::test(group = tls_reload)]
+async fn reloads_tls_identity_after_cert_file_rotation(actors: Arc<TestActors>) {
     info!("started");
 
     let cert_file = NamedTempFile::new().unwrap();
@@ -99,7 +108,7 @@ async fn reloads_tls_identity_after_cert_file_rotation(actors: TestActors) {
         );
     }
 
-    init_with_config(actors.clone(), scylla_configs, vs_configs).await;
+    init_with_config(&actors, scylla_configs, vs_configs).await;
 
     wait_for(
         || async { https_status_ok(&vs_ips, &cert_v1).await },


### PR DESCRIPTION
This PR updates e2etest framework and updates validator sources to use new macros. It also refactors common validator functions to use references instead of copies.

Followup: VECTOR-153