### PR TITLE
validator: add LWT test coverage for Alternator

### DIFF
--- a/crates/validator/src/alternator/delete_item.rs
+++ b/crates/validator/src/alternator/delete_item.rs
@@ -8,10 +8,11 @@ use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::TableContext;
 use crate::common;
+use aws_sdk_dynamodb::operation::delete_item::builders::DeleteItemFluentBuilder;
 use std::sync::Arc;
 use tracing::info;
 
-async fn ctx_delete_item(ctx: &TableContext, item: &Item) {
+fn ctx_delete_item(ctx: &TableContext, item: &Item) -> DeleteItemFluentBuilder {
     let mut req = ctx.client.delete_item().table_name(&ctx.table_name);
     let key_attrs: Vec<&str> = std::iter::once(ctx.shape.pk())
         .chain(ctx.shape.sk())
@@ -21,7 +22,7 @@ async fn ctx_delete_item(ctx: &TableContext, item: &Item) {
             req = req.key(attr_name, attr_val.clone());
         }
     }
-    req.send().await.expect("DeleteItem should succeed");
+    req
 }
 
 /// Inserts items, deletes one via `DeleteItem`, and verifies the VS index
@@ -47,11 +48,29 @@ async fn delete_item_updates_index(actors: Arc<TestActors>) {
             TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone(), c.clone()])
                 .await;
 
-        info!("Deleting item from '{}'", ctx.table_name);
-        ctx_delete_item(&ctx, &a).await;
+        info!("Step 1: deleting item from '{}'", ctx.table_name);
+        ctx_delete_item(&ctx, &a)
+            .send()
+            .await
+            .expect("DeleteItem should succeed");
 
         ctx.wait_for_count(2).await;
         ctx.wait_for_ann([1.0, 1.0, 1.0], &[b.clone(), c]).await;
+
+        // Conditional DeleteItem exercises the LWT/Paxos path under
+        // `only_rmw_uses_lwt` (ConditionExpression makes it RMW).
+        info!(
+            "Step 2: conditional DeleteItem (passing condition) in '{}'",
+            ctx.table_name
+        );
+        ctx_delete_item(&ctx, &b)
+            .expression_attribute_names("#pk", ctx.shape.pk())
+            .condition_expression("attribute_exists(#pk)")
+            .send()
+            .await
+            .expect("conditional DeleteItem with passing condition should succeed");
+
+        ctx.wait_for_count(1).await;
 
         ctx.done().await;
         info!("Shape {shape:?} passed");

--- a/crates/validator/src/alternator/lwt.rs
+++ b/crates/validator/src/alternator/lwt.rs
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+//! Integration test: Alternator with `--alternator-write-isolation=always_use_lwt`.
+//!
+//! Under `always_use_lwt` every write is routed through the LWT/Paxos path.
+//! The test verifies that Vector Store correctly indexes items written through
+//! this path by exercising `PutItem`, `DeleteItem`, `UpdateItem`, and
+//! `BatchWriteItem` (put-only, mixed put+delete, delete-only).
+
+use crate::TestActors;
+use crate::alternator;
+use crate::alternator::Item;
+use crate::common;
+use aws_sdk_dynamodb::types::AttributeValue;
+use httpapi::IndexInfo;
+use std::sync::Arc;
+use tracing::info;
+
+/// Helper: build a PutItem `WriteRequest` from an `Item`.
+fn put_write_request(item: &Item) -> aws_sdk_dynamodb::types::WriteRequest {
+    let mut builder = aws_sdk_dynamodb::types::PutRequest::builder();
+    for (attr_name, attr_val) in &item.0 {
+        builder = builder.item(attr_name, attr_val.clone());
+    }
+    aws_sdk_dynamodb::types::WriteRequest::builder()
+        .put_request(builder.build().expect("failed to build PutRequest"))
+        .build()
+}
+
+/// Helper: build a DeleteItem `WriteRequest` from a pk attribute.
+fn delete_write_request(
+    pk_attr: &str,
+    pk_val: AttributeValue,
+) -> aws_sdk_dynamodb::types::WriteRequest {
+    aws_sdk_dynamodb::types::WriteRequest::builder()
+        .delete_request(
+            aws_sdk_dynamodb::types::DeleteRequest::builder()
+                .key(pk_attr, pk_val)
+                .build()
+                .expect("failed to build DeleteRequest"),
+        )
+        .build()
+}
+
+/// Verifies that VS correctly indexes writes made through the LWT path when
+/// `--alternator-write-isolation=always_use_lwt` is active.
+#[e2etest::test(group = lwt)]
+async fn alternator_with_always_use_lwt(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (client, vs_clients) = alternator::make_clients(&actors).await;
+
+    let table_name = alternator::unique_table_name();
+    let index_name = alternator::unique_index_name();
+    let pk_attr = "pk";
+    let vec_attr = "vec";
+
+    info!("Creating table '{table_name}' with index '{index_name}'");
+    alternator::create_table(
+        &client,
+        &table_name,
+        pk_attr,
+        aws_sdk_dynamodb::types::ScalarAttributeType::S,
+        None,
+        &[(index_name.as_ref(), vec_attr, 3)],
+    )
+    .await
+    .expect("CreateTable with vector index should succeed");
+
+    let index = IndexInfo::new(
+        alternator::keyspace(&table_name).as_ref(),
+        index_name.as_ref(),
+    );
+
+    alternator::wait_for_index(&vs_clients, &index).await;
+    info!("VS discovered index '{index_name}'");
+
+    info!("Writing item-a and item-b via PutItem (LWT path)");
+    client
+        .put_item()
+        .table_name(&table_name)
+        .item(pk_attr, AttributeValue::S("item-a".into()))
+        .item(vec_attr, alternator::float_list([1.0_f32, 2.0, 4.0]))
+        .send()
+        .await
+        .expect("PutItem item-a should succeed");
+
+    client
+        .put_item()
+        .table_name(&table_name)
+        .item(pk_attr, AttributeValue::S("item-b".into()))
+        .item(vec_attr, alternator::float_list([4.0_f32, 2.0, 1.0]))
+        .send()
+        .await
+        .expect("PutItem item-b should succeed");
+
+    common::wait_for_index_count(&vs_clients, &index, 2).await;
+    info!("VS indexed 2 items via PutItem LWT path");
+
+    info!("Deleting item-b via DeleteItem (LWT path)");
+    client
+        .delete_item()
+        .table_name(&table_name)
+        .key(pk_attr, AttributeValue::S("item-b".into()))
+        .send()
+        .await
+        .expect("DeleteItem item-b should succeed");
+
+    common::wait_for_index_count(&vs_clients, &index, 1).await;
+    info!("VS correctly removed deleted item from index");
+
+    // Count doesn't change, so we verify via ANN ordering.
+    info!("Updating item-a vector via UpdateItem SET (LWT path)");
+    client
+        .update_item()
+        .table_name(&table_name)
+        .key(pk_attr, AttributeValue::S("item-a".into()))
+        .update_expression("SET #vec = :vec")
+        .expression_attribute_names("#vec", vec_attr)
+        .expression_attribute_values(":vec", alternator::float_list([1.0_f32, 1.0, 1.0]))
+        .send()
+        .await
+        .expect("UpdateItem item-a should succeed");
+
+    alternator::wait_for_ann(
+        &vs_clients,
+        &index,
+        pk_attr,
+        None,
+        [1.0, 1.0, 1.0],
+        &[Item::new(pk_attr, AttributeValue::S("item-a".into()))],
+    )
+    .await;
+    info!("VS correctly reflects UpdateItem vector change via LWT path");
+
+    let batch_a =
+        Item::new(pk_attr, AttributeValue::S("batch-a".into())).vec(vec_attr, [1.0_f32, 2.0, 4.0]);
+    let batch_b =
+        Item::new(pk_attr, AttributeValue::S("batch-b".into())).vec(vec_attr, [4.0_f32, 2.0, 1.0]);
+
+    info!("Writing batch-a and batch-b via BatchWriteItem (LWT path)");
+    client
+        .batch_write_item()
+        .request_items(
+            &table_name,
+            vec![put_write_request(&batch_a), put_write_request(&batch_b)],
+        )
+        .send()
+        .await
+        .expect("BatchWriteItem (put batch-a, batch-b) should succeed");
+
+    common::wait_for_index_count(&vs_clients, &index, 3).await;
+    info!("VS indexed BatchWriteItem puts via LWT path");
+
+    // ANN([-1,-1,-1], limit=3): batch-c first, batch-b second, item-a last.
+    let batch_c = Item::new(pk_attr, AttributeValue::S("batch-c".into()))
+        .vec(vec_attr, [-1.0_f32, -1.0, -1.0]);
+
+    info!("Mixed BatchWriteItem (put batch-c, delete batch-a) via LWT path");
+    client
+        .batch_write_item()
+        .request_items(
+            &table_name,
+            vec![
+                put_write_request(&batch_c),
+                delete_write_request(pk_attr, AttributeValue::S("batch-a".into())),
+            ],
+        )
+        .send()
+        .await
+        .expect("BatchWriteItem (put batch-c, delete batch-a) should succeed");
+
+    common::wait_for_index_count(&vs_clients, &index, 3).await;
+
+    alternator::wait_for_ann(
+        &vs_clients,
+        &index,
+        pk_attr,
+        None,
+        [-1.0, -1.0, -1.0],
+        &[
+            Item::new(pk_attr, AttributeValue::S("batch-c".into())),
+            Item::new(pk_attr, AttributeValue::S("batch-b".into())),
+            Item::new(pk_attr, AttributeValue::S("item-a".into())),
+        ],
+    )
+    .await;
+    info!("VS correctly reflects mixed BatchWriteItem via LWT path");
+
+    info!("Delete-only BatchWriteItem (delete batch-b, batch-c) via LWT path");
+    client
+        .batch_write_item()
+        .request_items(
+            &table_name,
+            vec![
+                delete_write_request(pk_attr, AttributeValue::S("batch-b".into())),
+                delete_write_request(pk_attr, AttributeValue::S("batch-c".into())),
+            ],
+        )
+        .send()
+        .await
+        .expect("BatchWriteItem (delete batch-b, batch-c) should succeed");
+
+    common::wait_for_index_count(&vs_clients, &index, 1).await;
+    info!("VS correctly reflects delete-only BatchWriteItem via LWT path");
+
+    info!("finished");
+}
+
+e2etest::group!(
+    name = lwt,
+    fixtures = (Fixture),
+    parent = alternator::alternator
+);
+
+struct Fixture {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for Fixture {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+
+        alternator::init_with_args(
+            &actors,
+            [("--alternator-write-isolation", "always_use_lwt")],
+        )
+        .await;
+
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        common::cleanup(&self.actors).await;
+    }
+}

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -24,6 +24,7 @@ use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
 use aws_sdk_dynamodb::operation::delete_table::DeleteTableError;
+use aws_sdk_dynamodb::operation::put_item::builders::PutItemFluentBuilder;
 use aws_sdk_dynamodb::primitives::Blob;
 use aws_sdk_dynamodb::types::AttributeDefinition;
 use aws_sdk_dynamodb::types::AttributeValue;
@@ -848,21 +849,12 @@ impl TableContext {
         }
     }
 
-    async fn put(&self, item: &Item) {
+    fn put(&self, item: &Item) -> PutItemFluentBuilder {
         let mut req = self.client.put_item().table_name(&self.table_name);
         for (attr_name, attr_val) in &item.0 {
             req = req.item(attr_name, attr_val.clone());
         }
-        req.send().await.expect("PutItem should succeed");
-    }
-
-    /// Inserts an item, asserting that Scylla rejects it with `expected_err`.
-    async fn put_expecting_error(&self, item: &Item, expected_err: &str) {
-        let mut req = self.client.put_item().table_name(&self.table_name);
-        for (attr_name, attr_val) in &item.0 {
-            req = req.item(attr_name, attr_val.clone());
-        }
-        assert_service_error(req.send().await, expected_err);
+        req
     }
 
     /// Creates a table, inserts items, and adds a vector index via
@@ -890,7 +882,7 @@ impl TableContext {
         let ctx = Self::create(actors, &no_vec_shape).await;
 
         for item in items.iter().chain(invalid_items.iter()) {
-            ctx.put(item).await;
+            ctx.put(item).send().await.expect("PutItem should succeed");
         }
 
         let vec_attr = match &shape.vec_name {

--- a/crates/validator/src/alternator/mod.rs
+++ b/crates/validator/src/alternator/mod.rs
@@ -6,6 +6,7 @@
 mod batch_write_item;
 mod create_table;
 mod delete_item;
+mod lwt;
 mod put_item;
 mod query;
 mod ttl;
@@ -39,6 +40,7 @@ use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::base64;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::config_bag::ConfigBag;
+use e2etest_scylla_cluster::ScyllaNodeConfig;
 use http::HeaderValue;
 use http::header::CONTENT_LENGTH;
 use httpapi::ColumnName;
@@ -615,11 +617,13 @@ where
     );
 }
 
-/// Standard test init: starts ScyllaDB with the Alternator endpoint enabled on
-/// each node's own IP, alongside the Vector Store.
-#[framed]
-pub async fn init(actors: &TestActors) {
-    info!("started");
+/// Applies the standard alternator base arguments plus `extra_args` overrides
+/// to default scylla node configs.
+async fn get_scylla_configs(
+    actors: &TestActors,
+    extra_args: impl IntoIterator<Item = (&str, &str)>,
+) -> Vec<ScyllaNodeConfig> {
+    let args: Vec<(&str, &str)> = extra_args.into_iter().collect();
 
     let mut scylla_configs = common::get_default_scylla_node_configs(actors).await;
 
@@ -633,15 +637,36 @@ pub async fn init(actors: &TestActors) {
             // NOTE: --alternator-ttl-period-in-seconds is already set in
             // DEFAULT_SCYLLA_ARGS (0.5s). ScyllaDB rejects duplicate flags.
         ]);
+
+        for (name, value) in &args {
+            config.args.retain(|arg| !arg.starts_with(name));
+            config.args.push(format!("{name}={value}"));
+        }
     }
+    scylla_configs
+}
+
+/// Starts ScyllaDB with the Alternator endpoint enabled alongside the Vector
+/// Store. `extra_args` is a list of `(name, value)` pairs that override or
+/// extend the default alternator arguments.
+async fn init_with_args(actors: &TestActors, extra_args: impl IntoIterator<Item = (&str, &str)>) {
+    info!("started");
+    let scylla_configs = get_scylla_configs(actors, extra_args).await;
+    let vs_configs = common::get_default_vs_node_configs(actors).await;
 
     // Capture db_ip before actors is moved into init_with_config.
     let db_ip = actors.services_subnet.ip(common::DB_OCTET_1);
-    let vs_configs = common::get_default_vs_node_configs(actors).await;
     common::init_with_config(actors, scylla_configs, vs_configs).await;
 
     wait_for_alternator(db_ip).await;
     info!("finished");
+}
+
+/// Standard test init: starts ScyllaDB with the Alternator endpoint enabled on
+/// each node's own IP, alongside the Vector Store.
+#[framed]
+pub async fn init(actors: &TestActors) {
+    init_with_args(actors, []).await;
 }
 
 /// Describes the key schema, attribute names, and name prefixes for a test

--- a/crates/validator/src/alternator/put_item.rs
+++ b/crates/validator/src/alternator/put_item.rs
@@ -32,20 +32,40 @@ async fn put_item_updates_index(actors: Arc<TestActors>) {
         let b = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "b").vec(vec_attr, [1.0, 2.0, 4.0]);
         let c = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "c").vec(vec_attr, [1.0, 4.0, 8.0]);
 
+        info!("Step 1: inserting initial items into '{}'", ctx.table_name);
         for item in [&a, &b, &c] {
-            ctx.put(item).await;
+            ctx.put(item).send().await.expect("PutItem should succeed");
         }
         ctx.wait_for_count(3).await;
         ctx.wait_for_ann([1.0, 1.0, 1.0], &[a, b.clone(), c.clone()])
             .await;
 
-        // Replace item a with a vector pointing in the opposite direction -
+        // Replace item 'a' with a vector pointing in the opposite direction -
         // a_replaced=[-1,-1,-1] has cosine=-1.0 (antipodal to [1,1,1]) so it falls
         // to last position.  b=[1,2,4] and c=[1,4,8] retain their order.
+        info!("Step 2: replacing item in '{}'", ctx.table_name);
         let a_replaced =
             Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "a").vec(vec_attr, [-1.0, -1.0, -1.0]);
-        ctx.put(&a_replaced).await;
+        ctx.put(&a_replaced)
+            .send()
+            .await
+            .expect("PutItem should succeed");
         ctx.wait_for_ann([1.0, 1.0, 1.0], &[b, c, a_replaced]).await;
+
+        // Conditional PutItem exercises the LWT/Paxos path under
+        // `only_rmw_uses_lwt` (ConditionExpression makes it RMW).
+        info!(
+            "Step 3: conditional PutItem (passing condition) in '{}'",
+            ctx.table_name
+        );
+        let d = Item::key(ctx.shape.pk(), ctx.shape.sk(), "pk", "d").vec(vec_attr, [1.0, 1.0, 1.0]);
+        ctx.put(&d)
+            .condition_expression("attribute_not_exists(#pk)")
+            .expression_attribute_names("#pk", ctx.shape.pk())
+            .send()
+            .await
+            .expect("conditional PutItem with passing condition should succeed");
+        ctx.wait_for_count(4).await;
 
         ctx.done().await;
         info!("Shape {shape:?} passed");
@@ -78,50 +98,68 @@ async fn put_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>) {
     ]);
 
     let no_vec = Item::key(pk, None, "pk", "no-vec");
-    ctx.put(&no_vec).await;
+    ctx.put(&no_vec)
+        .send()
+        .await
+        .expect("PutItem should succeed");
 
     let wrong_type_string = Item::key(pk, None, "pk", "wrong-type-string")
         .attr(vec_attr, AttributeValue::S("not-a-vector".into()));
-    ctx.put_expecting_error(&wrong_type_string, "ValidationException")
-        .await;
+    alternator::assert_service_error(
+        ctx.put(&wrong_type_string).send().await,
+        "ValidationException",
+    );
 
     let wrong_type_mostly_float_one_s = Item::key(pk, None, "pk", "wrong-type-mostly-float-one-s")
         .attr(vec_attr, vec_with_string_elem);
-    ctx.put_expecting_error(&wrong_type_mostly_float_one_s, "ValidationException")
-        .await;
+    alternator::assert_service_error(
+        ctx.put(&wrong_type_mostly_float_one_s).send().await,
+        "ValidationException",
+    );
 
     let wrong_type_mostly_float_one_null =
         Item::key(pk, None, "pk", "wrong-type-mostly-float-one-null")
             .attr(vec_attr, vec_with_null_elem);
-    ctx.put_expecting_error(&wrong_type_mostly_float_one_null, "ValidationException")
-        .await;
+    alternator::assert_service_error(
+        ctx.put(&wrong_type_mostly_float_one_null).send().await,
+        "ValidationException",
+    );
 
     let wrong_type_too_short = Item::key(pk, None, "pk", "wrong-type-too-short")
         .attr(vec_attr, alternator::float_list([1.0_f32, 1.0]));
-    ctx.put_expecting_error(&wrong_type_too_short, "ValidationException")
-        .await;
+    alternator::assert_service_error(
+        ctx.put(&wrong_type_too_short).send().await,
+        "ValidationException",
+    );
 
     let wrong_type_too_long = Item::key(pk, None, "pk", "wrong-type-too-long")
         .attr(vec_attr, alternator::float_list([1.0_f32, 1.0, 1.0, 1.0]));
-    ctx.put_expecting_error(&wrong_type_too_long, "ValidationException")
-        .await;
+    alternator::assert_service_error(
+        ctx.put(&wrong_type_too_long).send().await,
+        "ValidationException",
+    );
 
     // valid is put last so that wait_for_ann acts as a sequencing barrier:
     // when VS has indexed valid it must have already processed the no_vec CDC
     // event before it (CDC events are ordered), proving that the item without
     // a vector attribute was correctly ignored.
     let valid = Item::key(pk, None, "pk", "valid").vec(vec_attr, [1.0, 1.0, 1.0]);
-    ctx.put(&valid).await;
+    ctx.put(&valid)
+        .send()
+        .await
+        .expect("PutItem should succeed");
     ctx.wait_for_ann([1.0, 1.0, 1.0], &[valid]).await;
 
     let valid_no_vec = Item::key(pk, None, "pk", "valid");
-    ctx.put(&valid_no_vec).await;
+    ctx.put(&valid_no_vec)
+        .send()
+        .await
+        .expect("PutItem should succeed");
     ctx.wait_for_count(0).await;
 
     let wrong_type2 =
         Item::key(pk, None, "pk", "valid").attr(vec_attr, AttributeValue::S("bad".into()));
-    ctx.put_expecting_error(&wrong_type2, "ValidationException")
-        .await;
+    alternator::assert_service_error(ctx.put(&wrong_type2).send().await, "ValidationException");
     ctx.wait_for_count(0).await;
 
     ctx.done().await;

--- a/crates/validator/src/alternator/types.rs
+++ b/crates/validator/src/alternator/types.rs
@@ -30,7 +30,7 @@ async fn query_with_key_type(
     let ctx = TableContext::create_with_data(actors, shape, initial).await;
 
     for item in extra {
-        ctx.put(item).await;
+        ctx.put(item).send().await.expect("PutItem should succeed");
     }
     ctx.wait_for_count(initial.len() + extra.len()).await;
 

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -230,6 +230,157 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
     info!("finished");
 }
 
+/// Tests element-level `UpdateItem` operations on the vector column
+/// (`SET #vec[i]`, `REMOVE #vec[i]`, `list_append`, `ADD #vec[i]`) and
+/// verifies that VS reindexes or de-indexes items correctly.
+///
+/// Starts with 2 valid items and 3 invalid-vector items (mixed types, wrong
+/// dimensions). Steps 1-5 exercise mutations on a valid item (accepted and
+/// rejected). Steps 6-8 fix the invalid items. Step 9 tests ADD (LWT path).
+#[e2etest::test(group = update_item)]
+async fn update_item_vector_element_operations(actors: Arc<TestActors>) {
+    info!("started");
+
+    let patterns = alternator::name_patterns();
+    let shape = &patterns[0]; // plain names, HASH-only
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[0] always has vec");
+    let pk = shape.pk();
+
+    // Two valid items so ANN order is meaningful and vector changes are
+    // detectable.  Invalid items are pre-inserted before the index exists.
+    let valid_a = Item::key(pk, None, "pk", "valid-a").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let valid_b = Item::key(pk, None, "pk", "valid-b").vec(vec_attr, [4.0, 2.0, 1.0]);
+    let mixed = Item::key(pk, None, "pk", "mixed").attr(
+        vec_attr,
+        AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::S("3.0".into()),
+        ]),
+    );
+    let too_short = Item::key(pk, None, "pk", "too-short")
+        .attr(vec_attr, alternator::float_list([1.0_f32, 2.0]));
+    let too_long = Item::key(pk, None, "pk", "too-long")
+        .attr(vec_attr, alternator::float_list([1.0_f32, 2.0, 4.0, 8.0]));
+
+    let ctx = TableContext::create_with_invalid_data(
+        &actors,
+        shape,
+        &[valid_a.clone(), valid_b.clone()],
+        &[mixed.clone(), too_short.clone(), too_long.clone()],
+    )
+    .await;
+
+    info!("Step 1: SET #vec[0] on 'valid_a'");
+    update_item_expr(
+        &ctx,
+        &valid_a,
+        "SET #vec[0] = :val",
+        Some(AttributeValue::N("5.0".into())),
+    )
+    .send()
+    .await
+    .expect("UpdateItem should succeed");
+    let valid_a_step1 = Item::key(pk, None, "pk", "valid-a").vec(vec_attr, [5.0, 2.0, 4.0]);
+    ctx.wait_for_ann([5.0, 2.0, 4.0], &[valid_a_step1.clone(), valid_b.clone()])
+        .await;
+
+    info!("Step 2: SET #vec[0] = S on 'valid_a' (rejected)");
+    alternator::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &valid_a,
+            "SET #vec[0] = :val",
+            Some(AttributeValue::S("bad".into())),
+        )
+        .send()
+        .await,
+        "ValidationException",
+    );
+
+    info!("Step 3: SET #vec[2] = NULL on 'valid_a' (rejected)");
+    alternator::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &valid_a,
+            "SET #vec[2] = :val",
+            Some(AttributeValue::Null(true)),
+        )
+        .send()
+        .await,
+        "ValidationException",
+    );
+
+    info!("Step 4: REMOVE #vec[0] on 'valid_a' (rejected - wrong dimension)");
+    alternator::assert_service_error(
+        update_item_expr(&ctx, &valid_a, "REMOVE #vec[0]", None)
+            .send()
+            .await,
+        "ValidationException",
+    );
+
+    info!("Step 5: list_append on 'valid_a' (rejected - wrong dimension)");
+    alternator::assert_service_error(
+        update_item_expr(
+            &ctx,
+            &valid_a,
+            "SET #vec = list_append(#vec, :val)",
+            Some(AttributeValue::L(vec![AttributeValue::N("1.0".into())])),
+        )
+        .send()
+        .await,
+        "ValidationException",
+    );
+
+    info!("Step 6: SET #vec[2] on 'mixed'");
+    update_item_expr(
+        &ctx,
+        &mixed,
+        "SET #vec[2] = :val",
+        Some(AttributeValue::N("3.0".into())),
+    )
+    .send()
+    .await
+    .expect("UpdateItem should succeed");
+    ctx.wait_for_count(3).await;
+
+    info!("Step 7: SET #vec[2] on 'too_short' (out-of-range index appends)");
+    update_item_expr(
+        &ctx,
+        &too_short,
+        "SET #vec[2] = :val",
+        Some(AttributeValue::N("4.0".into())),
+    )
+    .send()
+    .await
+    .expect("UpdateItem should succeed");
+    ctx.wait_for_count(4).await;
+
+    info!("Step 8: REMOVE #vec[3] on 'too_long'");
+    update_item_expr(&ctx, &too_long, "REMOVE #vec[3]", None)
+        .send()
+        .await
+        .expect("UpdateItem should succeed");
+    ctx.wait_for_count(5).await;
+
+    info!("Step 9: ADD #vec[0] on 'valid_b' (ADD is always RMW -> LWT path)");
+    update_item_expr(
+        &ctx,
+        &valid_b,
+        "ADD #vec[0] :val",
+        Some(AttributeValue::N("1.0".into())),
+    )
+    .send()
+    .await
+    .expect("UpdateItem ADD #vec[0] should succeed");
+    let valid_b_step9 = Item::key(pk, None, "pk", "valid-b").vec(vec_attr, [5.0, 2.0, 1.0]);
+    ctx.wait_for_count(5).await;
+    ctx.wait_for_ann([5.0, 2.0, 1.0], &[valid_b_step9]).await;
+
+    ctx.done().await;
+    info!("finished");
+}
+
 e2etest::group!(
     name = update_item,
     fixtures = (Fixture),

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -8,24 +8,22 @@ use crate::alternator;
 use crate::alternator::Item;
 use crate::alternator::TableContext;
 use crate::common;
-use aws_sdk_dynamodb::error::SdkError;
-use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
-use aws_sdk_dynamodb::operation::update_item::UpdateItemOutput;
+use aws_sdk_dynamodb::operation::update_item::builders::UpdateItemFluentBuilder;
 use aws_sdk_dynamodb::types::AttributeValue;
 use std::sync::Arc;
 use tracing::info;
 
-/// Issues an `UpdateItem` on the vector column of `item`.
+/// Builds an `UpdateItem` request on the vector column of `item`.
 ///
 /// The expression is supplied by the caller and may reference:
 /// - `#vec` - the vector attribute name (always bound to `ctx.shape.vec_name`)
 /// - `:val` - the new value (bound when `value` is `Some`)
-async fn update_item_expr(
+fn update_item_expr(
     ctx: &TableContext,
     item: &Item,
     update_expr: &str,
     value: Option<AttributeValue>,
-) -> Result<UpdateItemOutput, SdkError<UpdateItemError>> {
+) -> UpdateItemFluentBuilder {
     let va = ctx.shape.vec().expect("TableContext has no vec_attr");
     let mut req = ctx
         .client
@@ -41,7 +39,7 @@ async fn update_item_expr(
     if let Some(val) = value {
         req = req.expression_attribute_values(":val", val);
     }
-    req.send().await
+    req
 }
 
 /// Updates a vector via `UpdateItem` and verifies the VS index reflects the
@@ -79,6 +77,7 @@ async fn update_item_updates_index(actors: Arc<TestActors>) {
             "SET #vec = :val",
             Some(alternator::float_list(b_vec)),
         )
+        .send()
         .await
         .expect("UpdateItem should succeed");
 
@@ -94,6 +93,7 @@ async fn update_item_updates_index(actors: Arc<TestActors>) {
             "SET #vec = :val",
             Some(alternator::float_list(c_vec)),
         )
+        .send()
         .await
         .expect("UpdateItem should succeed");
 
@@ -101,7 +101,35 @@ async fn update_item_updates_index(actors: Arc<TestActors>) {
         // a=[1,2,4] has cosine similarity ≈ -0.882 (second).
         // b_updated=[1,1,1] is antipodal to [-1,-1,-1] (similarity=-1, last).
         ctx.wait_for_count(3).await;
-        ctx.wait_for_ann([-1.0, -1.0, -1.0], &[c_with_vec, a, b_updated])
+        ctx.wait_for_ann(
+            [-1.0, -1.0, -1.0],
+            &[c_with_vec.clone(), a.clone(), b_updated.clone()],
+        )
+        .await;
+
+        // Conditional UpdateItem exercises the LWT/Paxos path under
+        // `only_rmw_uses_lwt` (ConditionExpression makes it RMW).
+        info!(
+            "Step 3: conditional UpdateItem (passing condition) in '{}'",
+            ctx.table_name
+        );
+        let a_new_vec = [4.0_f32, 2.0, 1.0];
+        let a_updated = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, a_new_vec);
+        update_item_expr(
+            &ctx,
+            &a_updated,
+            "SET #vec = :val",
+            Some(alternator::float_list(a_new_vec)),
+        )
+        .expression_attribute_names("#pk", ctx.shape.pk())
+        .condition_expression("attribute_exists(#pk)")
+        .send()
+        .await
+        .expect("conditional UpdateItem with passing condition should succeed");
+        // a_updated=[4,2,1]: ANN([4,2,1]) ->
+        //   a_updated first (sim=1.0), b_updated=[1,1,1] second (sim≈0.882),
+        //   c=[-1,-1,-1] last (sim≈-0.882).
+        ctx.wait_for_ann([4.0, 2.0, 1.0], &[a_updated, b_updated, c_with_vec])
             .await;
 
         ctx.done().await;
@@ -141,6 +169,7 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
     ]);
 
     update_item_expr(&ctx, &b, "REMOVE #vec", None)
+        .send()
         .await
         .expect("UpdateItem should succeed");
     ctx.wait_for_count(1).await;
@@ -154,17 +183,22 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
             "SET #vec = :val",
             Some(AttributeValue::S("not-a-vector".into())),
         )
+        .send()
         .await,
         "ValidationException",
     );
 
     alternator::assert_service_error(
-        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_string_elem)).await,
+        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_string_elem))
+            .send()
+            .await,
         "ValidationException",
     );
 
     alternator::assert_service_error(
-        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_null_elem)).await,
+        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_null_elem))
+            .send()
+            .await,
         "ValidationException",
     );
 
@@ -175,6 +209,7 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
             "SET #vec = :val",
             Some(alternator::float_list([1.0_f32, 1.0])),
         )
+        .send()
         .await,
         "ValidationException",
     );
@@ -186,6 +221,7 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
             "SET #vec = :val",
             Some(alternator::float_list([1.0_f32, 1.0, 1.0, 1.0])),
         )
+        .send()
         .await,
         "ValidationException",
     );

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -222,7 +222,9 @@ async fn delete_vector_index_via_update_table(actors: Arc<TestActors>) {
             &Item::key(shape.pk(), shape.sk(), "pk", "c")
                 .attr(vec_attr, AttributeValue::S("not-a-vector".into())),
         )
-        .await;
+        .send()
+        .await
+        .expect("PutItem should succeed");
 
         ctx.done().await;
         info!("Shape {shape:?} passed");


### PR DESCRIPTION
Add test coverage for Vector Store indexing through the LWT/Paxos code
path on Alternator writes — conditional expressions, element-level
UpdateItem operations, and a dedicated `always_use_lwt` test suite.