### PR TITLE
vector-store: fix flaky memory_limit test

### DIFF
--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -8,6 +8,7 @@ use crate::DbIndexPartitioning;
 use crate::IndexKey;
 use crate::IndexKind;
 use crate::IndexMetadata;
+use crate::Internals;
 use crate::Metrics;
 use crate::db::Db;
 use crate::db::DbExt;
@@ -110,6 +111,7 @@ pub(crate) async fn new(
     node_state: Sender<NodeState>,
     metrics: Arc<Metrics>,
     indexes: Arc<RwLock<Indexes>>,
+    internals: Sender<Internals>,
     config_rx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<mpsc::Sender<Engine>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
@@ -125,7 +127,7 @@ pub(crate) async fn new(
         .borrow()
         .engine_status_update_interval
         .unwrap_or(Duration::from_secs(1));
-    let memory_actor = memory::new(config_rx);
+    let memory_actor = memory::new(internals, config_rx);
 
     tokio::spawn(
         async move {

--- a/crates/vector-store/src/index/usearch.rs
+++ b/crates/vector-store/src/index/usearch.rs
@@ -1272,6 +1272,7 @@ mod tests {
     #[tokio::test]
     async fn add_or_replace_size_ann() {
         let (_, config_rx) = watch::channel(Arc::new(Config::default()));
+        let (internals_tx, _rx) = mpsc::channel(100);
 
         let options = IndexOptions {
             dimensions: 3,
@@ -1287,7 +1288,7 @@ mod tests {
             NonZeroUsize::new(3).unwrap().into(),
             Arc::clone(&table),
             worker::new(),
-            memory::new(config_rx),
+            memory::new(internals_tx, config_rx),
         )
         .unwrap();
 
@@ -1477,6 +1478,7 @@ mod tests {
         // Exceeding this limit results in a "No available threads to lock" error.
         // This test verifies our concurrency control by spawning a high number of parallel adds and searches (2 x num of cores).
         let (_, config_rx) = watch::channel(Arc::new(Config::default()));
+        let (internals_tx, _rx) = mpsc::channel(100);
 
         let dimensions = NonZeroUsize::new(1024).unwrap();
         let options = IndexOptions {
@@ -1493,7 +1495,7 @@ mod tests {
             dimensions.into(),
             Arc::clone(&table),
             worker::new(),
-            memory::new(config_rx),
+            memory::new(internals_tx, config_rx),
         )
         .unwrap();
 

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -700,6 +700,7 @@ pub async fn run(
         node_state.clone(),
         metrics.clone(),
         Arc::clone(&indexes),
+        internals.clone(),
         receivers.config,
     )
     .await?;

--- a/crates/vector-store/src/memory.rs
+++ b/crates/vector-store/src/memory.rs
@@ -4,6 +4,8 @@
  */
 
 use crate::Config;
+use crate::internals::Internals;
+use crate::internals::InternalsExt;
 use crate::perf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -49,7 +51,10 @@ impl MemoryExt for mpsc::Sender<Memory> {
     }
 }
 
-pub(crate) fn new(mut config_rx: watch::Receiver<Arc<Config>>) -> mpsc::Sender<Memory> {
+pub(crate) fn new(
+    internals: mpsc::Sender<Internals>,
+    mut config_rx: watch::Receiver<Arc<Config>>,
+) -> mpsc::Sender<Memory> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     tokio::spawn(async move {
@@ -70,7 +75,7 @@ pub(crate) fn new(mut config_rx: watch::Receiver<Arc<Config>>) -> mpsc::Sender<M
         info!("Memory usage check interval set to {:?}", interval.period());
 
         let (allocate_tx, allocate_rx) = watch::channel(
-            can_allocate(used_memory(&system_info), memory_limit, Allocate::Can));
+            can_allocate(&internals, used_memory(&system_info), memory_limit, Allocate::Can).await);
 
         loop {
             select! {
@@ -96,7 +101,7 @@ pub(crate) fn new(mut config_rx: watch::Receiver<Arc<Config>>) -> mpsc::Sender<M
                     system_info.refresh_memory();
                     let allocate = *allocate_tx.borrow();
                     _ = allocate_tx.send(
-                        can_allocate(used_memory(&system_info), memory_limit, allocate));
+                        can_allocate(&internals, used_memory(&system_info), memory_limit, allocate).await);
                 }
 
                 msg = rx.recv() => {
@@ -153,15 +158,26 @@ fn calculate_memory_limit(available_memory: u64, config: &Config) -> u64 {
     }
 }
 
-fn can_allocate(used_memory: u64, memory_limit: u64, current: Allocate) -> Allocate {
+async fn can_allocate(
+    internals: &mpsc::Sender<Internals>,
+    used_memory: u64,
+    memory_limit: u64,
+    current: Allocate,
+) -> Allocate {
     if used_memory < memory_limit {
         if current == Allocate::Cannot {
             info!("Memory usage below limit ({used_memory}), can allocate more memory");
+            internals
+                .increment_counter("memory-usage-below-limit".to_string())
+                .await;
         }
         Allocate::Can
     } else {
         if current == Allocate::Can {
             info!("Memory usage above limit ({used_memory}), cannot allocate more memory");
+            internals
+                .increment_counter("memory-usage-above-limit".to_string())
+                .await;
         }
         Allocate::Cannot
     }
@@ -215,14 +231,33 @@ mod tests {
         );
     }
 
-    #[test]
-    fn check_can_allocate() {
-        assert_eq!(can_allocate(99, 100, Allocate::Can), Allocate::Can);
-        assert_eq!(can_allocate(99, 100, Allocate::Cannot), Allocate::Can);
-        assert_eq!(can_allocate(100, 100, Allocate::Can), Allocate::Cannot);
-        assert_eq!(can_allocate(100, 100, Allocate::Cannot), Allocate::Cannot);
-        assert_eq!(can_allocate(101, 100, Allocate::Can), Allocate::Cannot);
-        assert_eq!(can_allocate(101, 100, Allocate::Cannot), Allocate::Cannot);
+    #[tokio::test]
+    async fn check_can_allocate() {
+        let (tx, _rx) = mpsc::channel(100);
+        assert_eq!(
+            can_allocate(&tx, 99, 100, Allocate::Can).await,
+            Allocate::Can
+        );
+        assert_eq!(
+            can_allocate(&tx, 99, 100, Allocate::Cannot).await,
+            Allocate::Can
+        );
+        assert_eq!(
+            can_allocate(&tx, 100, 100, Allocate::Can).await,
+            Allocate::Cannot
+        );
+        assert_eq!(
+            can_allocate(&tx, 100, 100, Allocate::Cannot).await,
+            Allocate::Cannot
+        );
+        assert_eq!(
+            can_allocate(&tx, 101, 100, Allocate::Can).await,
+            Allocate::Cannot
+        );
+        assert_eq!(
+            can_allocate(&tx, 101, 100, Allocate::Cannot).await,
+            Allocate::Cannot
+        );
     }
 
     #[tokio::test]
@@ -232,7 +267,8 @@ mod tests {
             memory_usage_check_interval: Some(Duration::from_secs(3600)),
             ..Config::default()
         }));
-        let memory_actor = new(config_rx);
+        let (tx, _rx) = mpsc::channel(100);
+        let memory_actor = new(tx, config_rx);
         let allocator_rx = memory_actor.subscribe_allocate().await;
 
         // be sure the actor has started

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -7,6 +7,7 @@ use crate::create_config_channels;
 use crate::db_basic;
 use crate::db_basic::Table;
 use crate::usearch::test_config;
+use futures::FutureExt;
 use httpapi::NodeStatus;
 use httpclient::HttpClient;
 use scylla::cluster::metadata::NativeType;
@@ -14,12 +15,14 @@ use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
-use sysinfo::System;
+use tokio::sync::mpsc;
 use tracing::info;
 use uuid::Uuid;
 use vector_store::Config;
 use vector_store::Connectivity;
 use vector_store::DbIndexPartitioning;
+use vector_store::DbIndexedRow;
+use vector_store::DbIndexedValue;
 use vector_store::ExpansionAdd;
 use vector_store::ExpansionSearch;
 use vector_store::HttpServerExt;
@@ -79,42 +82,45 @@ async fn memory_limit_during_index_build() {
     )
     .unwrap();
 
-    const VECTOR_COUNT: i32 = 1_000;
+    let (tx_outer, mut rx_outer) = mpsc::channel(1);
     db.add_index(
         index.clone(),
-        Some(db_basic::scan_fn((0..VECTOR_COUNT).map(|i| {
-            (
-                [CqlValue::Int(i)].into(),
-                Some(vec![0.0, 0.0, 0.0].into()),
-                Timestamp::from_unix_timestamp(10),
-            )
-        }))),
+        Some(Box::new(move |tx_inner| {
+            async move {
+                let mut pk = 0;
+                while let Some(item) = rx_outer.recv().await {
+                    pk += 1;
+                    let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                    tx_inner
+                        .send((
+                            DbIndexedRow {
+                                primary_key: [CqlValue::Int(pk)].into(),
+                                value: Some(DbIndexedValue::Vector(item)),
+                                timestamp: Timestamp::from_unix_timestamp(10),
+                            },
+                            Some(tx_in_progress.clone().into()),
+                        ))
+                        .await
+                        .unwrap();
+                    // wait until in-progress marker is dropped
+                    drop(tx_in_progress);
+                    while rx_in_progress.recv().await.is_some() {}
+                }
+            }
+            .boxed()
+        })),
         None,
     )
     .unwrap();
 
-    // Set memory limit for Vector Store
-    let mut system_info = System::new_all();
-    system_info.refresh_memory();
-    let used_memory = if let Some(cgroup) = system_info.cgroup_limits() {
-        cgroup.rss
-    } else {
-        system_info.used_memory()
-    };
-
-    const LIMIT_MEMORY: u64 = 20 * 1024 * 1024; // 20 MB - it shouldn't be enough to index all vectors
-    let limit_memory = used_memory + LIMIT_MEMORY;
-    info!(
-        "Setting VS memory limit to {LIMIT_MEMORY} bytes, current used memory is {used_memory} bytes, "
-    );
-
-    let config = Config {
-        memory_limit: Some(limit_memory),
+    const LIMIT_MEMORY: u64 = 20 * 1024 * 1024; // 20 MB - it shouldn't be enough to index any vector
+    let mut config = Config {
+        memory_limit: Some(LIMIT_MEMORY),
         memory_usage_check_interval: Some(Duration::from_millis(10)),
         ..test_config()
     };
 
-    let (receivers, _senders) = create_config_channels(config).await;
+    let (receivers, senders) = create_config_channels(config.clone()).await;
     let index_factory = vector_store::new_index_factory_usearch(receivers.config.clone()).unwrap();
 
     let node_state = node_state.clone();
@@ -126,26 +132,86 @@ async fn memory_limit_during_index_build() {
 
     let client = HttpClient::new(addr);
 
+    info!("Waiting for index to be bootstrapping");
     crate::wait_for(
         || async {
             client
                 .status()
                 .await
-                .ok()
-                .map(|status| status == NodeStatus::Serving)
-                .unwrap_or(false)
+                .is_ok_and(|status| status == NodeStatus::Bootstrapping)
         },
-        "Waiting for index to be build",
+        "Waiting for index to be bootstrapping",
     )
     .await;
 
-    assert!(
+    const VECTOR_COUNT: usize = 10;
+
+    info!("Send vectors to be indexed - they shouldn't be indexed, because of the memory limit");
+    for i in 0..VECTOR_COUNT {
+        tx_outer
+            .send(vec![i as f32, i as f32, i as f32].into())
+            .await
+            .unwrap();
+    }
+
+    let keyspace_name = index.keyspace_name.into();
+    let index_name = index.index_name.into();
+    assert_eq!(
         client
-            .index_status(&index.keyspace_name.into(), &index.index_name.into())
+            .index_status(&keyspace_name, &index_name)
             .await
             .unwrap()
-            .count
-            < VECTOR_COUNT as usize,
-        "Expected less than {VECTOR_COUNT} vectors to be indexed"
+            .count,
+        0,
+        "Expected all vectors not to be indexed"
+    );
+
+    info!("Remove memory limit - it should allow to index all vectors");
+    client
+        .internals_start_counter("memory-usage-below-limit".to_string())
+        .await
+        .unwrap();
+    config.memory_limit = None;
+    senders.config.send(Arc::new(config)).unwrap();
+    crate::wait_for(
+        || async {
+            client.internals_counters().await.is_ok_and(|map| {
+                map.get("memory-usage-below-limit")
+                    .is_some_and(|counter| *counter == 1)
+            })
+        },
+        "Waiting for memory usage to be below limit after removing the memory limit",
+    )
+    .await;
+
+    info!("Send vectors to be indexed - they should be indexed");
+    for i in 0..VECTOR_COUNT {
+        tx_outer
+            .send(vec![i as f32, i as f32, i as f32].into())
+            .await
+            .unwrap();
+    }
+
+    info!("Waiting for index to be serving");
+    drop(tx_outer);
+    crate::wait_for(
+        || async {
+            client
+                .status()
+                .await
+                .is_ok_and(|status| status == NodeStatus::Serving)
+        },
+        "Waiting for index to be serving",
+    )
+    .await;
+
+    assert_eq!(
+        client
+            .index_status(&keyspace_name, &index_name)
+            .await
+            .unwrap()
+            .count,
+        VECTOR_COUNT,
+        "Expected only last part of vectors to be indexed"
     );
 }


### PR DESCRIPTION
The root cause of flakiness was the expectation that memory usage is stable during test. As it cannot be guarantee in CI or local environment sometimes test failed, because memory usage dropped during test (probably other tests in background finished).

The commit fixes this by setup memory limit to 20MB of all usage (single vector-store engine takes more than that). It divides stream of vectors into two parts - first should be not indexed, then switch off memory limit and push the second part of vectors. Only the second part should be indexes.

To check if the memory limit is observed correctly this commit adds internal counter to count memory usage above or below limit.

In the future this test could be moved to the validator as it doesn't depend on internal knowledge (it depends on internal counters available by http).

Fixes: VECTOR-667