### PR TITLE
vector-store: BM25 full-text search HTTP endpoint

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "LicenseRef-ScyllaDB-Source-Available-1.0"
     },
-    "version": "1.4.0"
+    "version": "1.5.0"
   },
   "paths": {
     "/api/v1/indexes": {
@@ -113,6 +113,107 @@
           },
           "500": {
             "description": "Error while searching vectors. Possible causes: internal error, or search engine issues.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable. Indicates that a full scan of the index is in progress and the search cannot be performed at this time.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/indexes/{keyspace}/{index}/bm25": {
+      "post": {
+        "tags": [
+          "scylla-vector-store-index"
+        ],
+        "description": "Performs a full-text search query against the specified index. Returns primary keys of the documents most relevant to the provided text query, ranked by BM25 score. The maximum number of results is controlled by the optional 'limit' parameter in the payload. If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
+        "operationId": "post_index_bm25",
+        "parameters": [
+          {
+            "name": "keyspace",
+            "in": "path",
+            "description": "The name of the ScyllaDB keyspace containing the index.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/KeyspaceName"
+            }
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "description": "The name of the full-text index within the specified keyspace to search.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IndexName"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PostIndexBm25Request"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful full-text search. Returns a list of primary keys and their corresponding relevance scores for the most relevant documents found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostIndexBm25Response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. Possible causes: malformed input, or missing required fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. TLS is enabled in the configuration, but the client connected over plain HTTP.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error while searching. Possible causes: internal error, or search engine issues.",
             "content": {
               "application/json": {
                 "schema": {
@@ -731,6 +832,50 @@
           }
         ],
         "description": "A filter restriction used in ANN search requests."
+      },
+      "PostIndexBm25Request": {
+        "type": "object",
+        "description": "Request body for full-text search.",
+        "required": [
+          "query"
+        ],
+        "properties": {
+          "limit": {
+            "$ref": "#/components/schemas/Limit"
+          },
+          "query": {
+            "type": "string",
+            "description": "The text query to search for."
+          }
+        }
+      },
+      "PostIndexBm25Response": {
+        "type": "object",
+        "description": "Response for full-text search.",
+        "required": [
+          "primary_keys",
+          "scores"
+        ],
+        "properties": {
+          "primary_keys": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {}
+            },
+            "propertyNames": {
+              "type": "string",
+              "description": "Name of the column in a db table."
+            }
+          },
+          "scores": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "float"
+            }
+          }
+        }
       },
       "SimilarityScore": {
         "type": "number",

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -299,3 +299,19 @@ pub struct SimilarityScore(f32);
 )]
 /// The vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index.
 pub struct Vector(Vec<f32>);
+
+#[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+/// Request body for full-text search.
+pub struct PostIndexBm25Request {
+    /// The text query to search for.
+    pub query: String,
+    #[serde(default)]
+    pub limit: Limit,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+/// Response for full-text search.
+pub struct PostIndexBm25Response {
+    pub primary_keys: HashMap<ColumnName, Vec<Value>>,
+    pub scores: Vec<f32>,
+}

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -87,7 +87,7 @@ use utoipa_swagger_ui::SwaggerUi;
             name = "LicenseRef-ScyllaDB-Source-Available-1.0"
         ),
         // version should be updated manually when there are changes in API
-        version = "1.4.0"
+        version = "1.5.0"
     ),
     tags(
         (
@@ -160,6 +160,7 @@ fn new_open_api_router() -> (Router<RoutesInnerState>, utoipa::openapi::OpenApi)
                 .routes(routes!(get_indexes))
                 .routes(routes!(get_index_status))
                 .routes(routes!(post_index_ann))
+                .routes(routes!(post_index_bm25))
                 .routes(routes!(get_info))
                 .routes(routes!(get_status)),
         )
@@ -700,6 +701,67 @@ async fn post_index_ann(
         }
     })
     .await
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/indexes/{keyspace}/{index}/bm25",
+    tag = "scylla-vector-store-index",
+    description = "Performs a full-text search query against the specified index. \
+Returns primary keys of the documents most relevant to the provided text query, ranked by BM25 score. \
+The maximum number of results is controlled by the optional 'limit' parameter in the payload. \
+If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
+    params(
+        ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the index."),
+        ("index" = httpapi::IndexName, Path, description = "The name of the full-text index within the specified keyspace to search.")
+    ),
+    request_body = httpapi::PostIndexBm25Request,
+    responses(
+        (
+            status = 200,
+            description = "Successful full-text search. Returns a list of primary keys and their corresponding relevance scores for the most relevant documents found.",
+            body = httpapi::PostIndexBm25Response
+        ),
+        (
+            status = 400,
+            description = "Bad request. Possible causes: malformed input, or missing required fields.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 403,
+            description = "Forbidden. TLS is enabled in the configuration, but the client connected over plain HTTP.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 404,
+            description = "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 500,
+            description = "Error while searching. Possible causes: internal error, or search engine issues.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 503,
+            description = "Service Unavailable. Indicates that a full scan of the index is in progress and the search cannot be performed at this time.",
+            content_type = "application/json",
+            body = ErrorMessage
+        )
+    )
+)]
+async fn post_index_bm25(
+    Path((_keyspace, _index_name)): Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
+) -> Response {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "Full-text search is not yet implemented",
+    )
+        .into_response()
 }
 
 fn try_from_post_index_ann_filter(


### PR DESCRIPTION
Add the `POST /api/v1/indexes/{keyspace}/{index}/bm25` endpoint for BM25 full-text search.

## Changes

- Add `PostIndexBm25Request` and `PostIndexBm25Response` types to `httpapi` crate
- Add `post_index_25` route handler with OpenAPI documentation
- Endpoint currently returns `501 Not Implemented` as a stub
- Update `openapi.json` with the new endpoint spec

## API

**Request:**
```json
{
  "query": "search text",
  "limit": 10
}
```

**Response (200):**
```json
{
  "primary_keys": { "column_name": [...] },
  "scores": [0.95, 0.87, ...]
}
```

Fixes: VECTOR-685