### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-cloud-images.yaml
+++ b/.github/workflows/build-cloud-images.yaml
@@ -19,22 +19,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Packer
-        uses: hashicorp/setup-packer@v3.0.0
+        uses: hashicorp/setup-packer@d38faf1295e2cddabf3ce395dc78405b7877be2d # v3.0.0
         with:
           version: '1.10.0'
 
       - name: Setup AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-access-key-id: ${{ secrets.VECTOR_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.VECTOR_AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
 
       - name: Setup GCP credentials
-        uses: google-github-actions/auth@v2.1.2
+        uses: google-github-actions/auth@55bd3a7c6e2ae7cf1877fd1ccb9d54c0503c457c # v2.1.2
         with:
           workload_identity_provider: ${{ secrets.VECTOR_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.VECTOR_GCP_SERVICE_ACCOUNT }}
@@ -60,14 +60,14 @@ jobs:
         working-directory: packer
 
       - name: Archive Packer manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vector-store-cloud-images-${{ env.VECTOR_VERSION }}
           path: packer/packer-manifest.json
 
       - name: Upload Packer manifest to the release
         if: github.event_name == 'release' && github.event.release
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -24,7 +24,7 @@ jobs:
       run: cat scylla-nightly-digest
 
     - name: Upload scylla-nightly digest as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: daily-scylla-nightly-digest
         path: scylla-nightly-digest
@@ -42,7 +42,7 @@ jobs:
             arch: arm64
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -50,7 +50,7 @@ jobs:
     - name: Try to download vector-store artifact
       id: download-vector-store
       continue-on-error: true
-      uses: dawidd6/action-download-artifact@v17
+      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
       with:
         workflow: daily.yml
         name: daily-vector-store-${{matrix.arch}}-${{github.sha}}
@@ -60,7 +60,7 @@ jobs:
     - name: Try to download vector-search-validator artifact
       id: download-vector-search-validator
       continue-on-error: true
-      uses: dawidd6/action-download-artifact@v17
+      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
       with:
         workflow: daily.yml
         name: daily-vector-search-validator-${{matrix.arch}}-${{github.sha}}
@@ -108,13 +108,13 @@ jobs:
       run: cp target/${{matrix.arch}}/release/vector-search-validator vector-search-validator-${{matrix.arch}}
 
     - name: Upload vector-store as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: daily-vector-store-${{matrix.arch}}-${{github.sha}}
         path: vector-store-${{matrix.arch}}
 
     - name: Upload vector-search-validator as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: daily-vector-search-validator-${{matrix.arch}}-${{github.sha}}
         path: vector-search-validator-${{matrix.arch}}
@@ -124,7 +124,7 @@ jobs:
 
     - name: Upload run-validator-with-scylla-docker as artifact
       if: matrix.arch == 'amd64' # Only upload the script once since it's architecture agnostic
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: run-validator-with-scylla-docker
         path: run-validator-with-scylla-docker
@@ -137,7 +137,7 @@ jobs:
 
     steps:
     - name: Download vector-search-validator artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: daily-vector-search-validator-amd64-${{github.sha}}
 
@@ -164,22 +164,22 @@ jobs:
             arch: arm64
     steps:
     - name: Download scylla-nightly digest artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: daily-scylla-nightly-digest
 
     - name: Download vector-store artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: daily-vector-store-${{matrix.arch}}-${{github.sha}}
 
     - name: Download vector-search-validator artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: daily-vector-search-validator-${{matrix.arch}}-${{github.sha}}
 
     - name: Download run-validator-with-scylla-docker artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: run-validator-with-scylla-docker
 
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download scylla-nightly digest artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: daily-scylla-nightly-digest
 
@@ -206,7 +206,7 @@ jobs:
       run: cat scylla-nightly-digest
 
     - name: Upload scylla-nightly digest artifact as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: scylla-nightly-digest
         path: scylla-nightly-digest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,10 +23,10 @@ jobs:
   cargo-clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         components: clippy
 
@@ -45,10 +45,10 @@ jobs:
   cargo-fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
       with:
         components: rustfmt
 
@@ -64,10 +64,10 @@ jobs:
   cargo-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
     - name: Print rustc version
       run: rustc --version
@@ -78,13 +78,13 @@ jobs:
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
     - name: Setup cargo-deny
-      uses: taiki-e/install-action@cargo-deny
+      uses: taiki-e/install-action@894ed6ded408bba4b650a982305dc5353e661648 # cargo-deny
 
     - name: Print cargo-deny version
       run: cargo deny --version
@@ -95,13 +95,13 @@ jobs:
   cargo-machete:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
     - name: Setup cargo-machete
-      uses: taiki-e/install-action@cargo-machete
+      uses: taiki-e/install-action@d56616f1be134d33d513c59d577b2c0142b64a83 # cargo-machete
 
     - name: Print cargo-machete version
       run: cargo machete --version
@@ -112,13 +112,13 @@ jobs:
   cargo-sbom:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup rust toolchain
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
     - name: Setup cargo-cyclonedx
-      uses: taiki-e/install-action@cargo-cyclonedx
+      uses: taiki-e/install-action@4fb4bfc098655bcd1461f113b03ff34ffb480d16 # cargo-cyclonedx
 
     - name: Print cargo-cyclonedx version
       run: cargo cyclonedx --version
@@ -133,7 +133,7 @@ jobs:
         python3 -c "import json; json.load(open('$file'))"
 
     - name: Upload SBOM artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: sbom
         path: crates/vector-store/vector-store.cdx.json

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Get scylla-nightly digest for the last working tag
       if: steps.get-scylla-nightly-latest-digest.outcome == 'skipped'
-      uses: dawidd6/action-download-artifact@v17
+      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
       with:
         workflow: daily.yml
         name: scylla-nightly-digest
@@ -40,7 +40,7 @@ jobs:
       run: cat scylla-nightly-digest
 
     - name: Upload scylla-nightly digest as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: scylla-nightly-digest
         path: scylla-nightly-digest
@@ -53,7 +53,7 @@ jobs:
       testcases: ${{ steps.testcases.outputs.testcases }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -80,13 +80,13 @@ jobs:
       run: cp target/${TARGETARCH}/release/vector-search-validator vector-search-validator
 
     - name: Upload vector-store as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: vector-store
         path: vector-store
 
     - name: Upload vector-search-validator as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: vector-search-validator
         path: vector-search-validator
@@ -95,7 +95,7 @@ jobs:
       run: cp scripts/run-validator-with-scylla-docker .
 
     - name: Upload run-validator-with-scylla-docker as artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: run-validator-with-scylla-docker
         path: run-validator-with-scylla-docker
@@ -115,22 +115,22 @@ jobs:
 
     steps:
     - name: Download scylla-nightly digest artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: scylla-nightly-digest
 
     - name: Download vector-store artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: vector-store
 
     - name: Download vector-search-validator artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: vector-search-validator
 
     - name: Download run-validator-with-scylla-docker artifact
-      uses: actions/download-artifact@v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: run-validator-with-scylla-docker
 


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions to full commit SHAs to reduce supply chain attack surface
- Upgrade outdated actions to their latest versions

**This PR was generated automatically. Please verify that GitHub Actions work as expected with these changes before merging.**

Reference: https://github.com/scylladb/scylladb/pull/29421