### PR TITLE
vector-store: implement BM25 search HTTP API

### DIFF
--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -15,6 +15,8 @@ use httpapi::NodeStatus;
 use httpapi::PostIndexAnnFilter;
 use httpapi::PostIndexAnnRequest;
 use httpapi::PostIndexAnnResponse;
+use httpapi::PostIndexBm25Request;
+use httpapi::PostIndexBm25Response;
 use httpapi::SimilarityScore;
 use httpapi::Vector;
 use reqwest::Client;
@@ -105,6 +107,41 @@ impl HttpClient {
                 self.url_api, keyspace_name, index_name
             ))
             .json(data)
+            .send()
+            .await
+            .unwrap()
+    }
+
+    pub async fn bm25(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+        query: String,
+        limit: Limit,
+    ) -> (HashMap<ColumnName, Vec<Value>>, Vec<f32>) {
+        let resp = self
+            .post_bm25(keyspace_name, index_name, query, limit)
+            .await
+            .json::<PostIndexBm25Response>()
+            .await
+            .unwrap();
+        (resp.primary_keys, resp.scores)
+    }
+
+    pub async fn post_bm25(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+        query: String,
+        limit: Limit,
+    ) -> reqwest::Response {
+        let request = PostIndexBm25Request { query, limit };
+        self.client
+            .post(format!(
+                "{}/indexes/{}/{}/bm25",
+                self.url_api, keyspace_name, index_name
+            ))
+            .json(&request)
             .send()
             .await
             .unwrap()

--- a/crates/vector-store/src/fts_index/tantivy.rs
+++ b/crates/vector-store/src/fts_index/tantivy.rs
@@ -315,8 +315,8 @@ pub(crate) fn new(
                 FtsIndex::Count { tx, index_key, .. } => {
                     let result = get_state(&states, table.as_ref(), &index_key)
                         .map(|s| s.reader.searcher().num_docs() as usize)
-                        .ok_or_else(|| anyhow!("fts: index not found for {index_key:?}"));
-                    let _ = tx.send(result);
+                        .unwrap_or(0);
+                    _ = tx.send(Ok(result));
                 }
                 FtsIndex::Search {
                     index_key,
@@ -325,7 +325,7 @@ pub(crate) fn new(
                     tx,
                 } => {
                     let Some(state) = get_state(&states, table.as_ref(), &index_key) else {
-                        let _ = tx.send(Err(anyhow!("fts: index not found for {index_key:?}")));
+                        _ = tx.send(Ok((vec![], vec![])));
                         continue;
                     };
                     let table = Arc::clone(&table);
@@ -333,7 +333,7 @@ pub(crate) fn new(
                         .spawn_blocking(move || {
                             let result =
                                 handle_search(&state, table.as_ref(), &index_key, &query, limit);
-                            let _ = tx.send(result);
+                            _ = tx.send(result);
                         })
                         .await;
                 }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -765,13 +765,126 @@ If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
     )
 )]
 async fn post_index_bm25(
-    Path((_keyspace, _index_name)): Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
+    State(state): State<RoutesInnerState>,
+    extensions: Extensions,
+    Path((keyspace, index_name)): Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
+    extract::Json(request): extract::Json<httpapi::PostIndexBm25Request>,
 ) -> Response {
-    (
-        StatusCode::NOT_IMPLEMENTED,
-        "Full-text search is not yet implemented",
-    )
-        .into_response()
+    let keyspace: crate::KeyspaceName = keyspace.into();
+    let index_name: crate::IndexName = index_name.into();
+    if state.use_tls
+        && extensions
+            .get::<Protocol>()
+            .is_some_and(|protocol| *protocol == Protocol::Plain)
+    {
+        let msg = "TLS is required, but the request \
+            was made over an insecure connection."
+            .to_string();
+        debug!("post_index_bm25: {msg}");
+        return (StatusCode::FORBIDDEN, msg).into_response();
+    }
+
+    let index_key = IndexKey::new(&keyspace, &index_name);
+
+    let (fts_sender, primary_key_columns) = {
+        let indexes = state.indexes.read().unwrap();
+        let Some(entry) = indexes.get_fts(&index_key) else {
+            let msg = format!("missing index: {keyspace}.{index_name}");
+            debug!("post_index_bm25: {msg}");
+            return (StatusCode::NOT_FOUND, msg).into_response();
+        };
+        if entry.status() != crate::node_state::IndexStatus::Serving {
+            match entry.progress() {
+                Progress::InProgress(percentage) => {
+                    let msg = format!(
+                        "Index {keyspace}.{index_name} is not available yet as it is still being constructed, progress: {:.3}%",
+                        percentage.get()
+                    );
+                    debug!("post_index_bm25: {msg}");
+                    return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
+                }
+                Progress::Done => {
+                    let msg = format!(
+                        "Index {keyspace}.{index_name} is not serving, but full scan did finish."
+                    );
+                    debug!("post_index_bm25: {msg}");
+                    return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
+                }
+            }
+        }
+        (
+            entry.index().clone(),
+            Arc::clone(entry.primary_key_columns()),
+        )
+    };
+
+    let search_result = fts_sender
+        .search(index_key, request.query, request.limit.into())
+        .await;
+
+    match search_result {
+        Err(err) => {
+            let msg = format!("index.bm25 request error: {err}");
+            debug!("post_index_bm25: {msg}");
+            (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+        }
+        Ok((primary_keys, scores)) => {
+            if primary_keys.len() != scores.len() {
+                let msg = format!(
+                    "wrong size of a bm25 response: \
+                    number of primary_keys = {}, number of scores = {}",
+                    primary_keys.len(),
+                    scores.len()
+                );
+                debug!("post_index_bm25: {msg}");
+                return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
+            }
+
+            let primary_keys: anyhow::Result<_> = primary_key_columns
+                .iter()
+                .cloned()
+                .enumerate()
+                .map(|(idx_column, column)| {
+                    let primary_keys: anyhow::Result<_> = primary_keys
+                        .iter()
+                        .map(|primary_key| {
+                            if primary_key.len() != primary_key_columns.len() {
+                                bail!(
+                                    "wrong size of a primary key: {}, {}",
+                                    primary_key_columns.len(),
+                                    primary_key.len()
+                                );
+                            }
+                            Ok(primary_key)
+                        })
+                        .map_ok(|primary_key| {
+                            primary_key
+                                .get(idx_column)
+                                .expect("primary key index out of bounds after length check")
+                        })
+                        .map_ok(try_to_json)
+                        .map(|primary_key| primary_key.flatten())
+                        .collect();
+                    primary_keys.map(|primary_keys| (column.into(), primary_keys))
+                })
+                .collect();
+
+            match primary_keys {
+                Err(err) => {
+                    debug!("post_index_bm25: {err}");
+                    (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                }
+                Ok(primary_keys) => (
+                    StatusCode::OK,
+                    response::Json(httpapi::PostIndexBm25Response {
+                        primary_keys,
+                        scores,
+                    }),
+                )
+                    .into_response(),
+            }
+        }
+    }
 }
 
 fn try_from_post_index_ann_filter(

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -518,16 +518,8 @@ async fn post_index_ann(
     perf::hotpath_async(async move {
         let keyspace: crate::KeyspaceName = keyspace.into();
         let index_name: crate::IndexName = index_name.into();
-        if state.use_tls
-            && extensions
-                .get::<Protocol>()
-                .is_some_and(|protocol| *protocol == Protocol::Plain)
-        {
-            let msg = "TLS is required, but the request \
-            was made over an insecure connection."
-                .to_string();
-            debug!("post_index_ann: {msg}");
-            return (StatusCode::FORBIDDEN, msg).into_response();
+        if let Some(resp) = check_insecure_tls(state.use_tls, &extensions, "post_index_ann") {
+            return resp;
         }
 
         // Start timing
@@ -662,34 +654,8 @@ async fn post_index_ann(
                         .map(httpapi::SimilarityScore::from)
                         .collect();
 
-                    let primary_keys: anyhow::Result<_> = primary_key_columns
-                        .iter()
-                        .cloned()
-                        .enumerate()
-                        .map(|(idx_column, column)| {
-                            let primary_keys: anyhow::Result<_> = primary_keys
-                                .iter()
-                                .map(|primary_key| {
-                                    if primary_key.len() != primary_key_columns.len() {
-                                        bail!(
-                                            "wrong size of a primary key: {}, {}",
-                                            primary_key_columns.len(),
-                                            primary_key.len()
-                                        );
-                                    }
-                                    Ok(primary_key)
-                                })
-                                .map_ok(|primary_key| {
-                                    primary_key.get(idx_column).expect(
-                                        "primary key index out of bounds after length check",
-                                    )
-                                })
-                                .map_ok(try_to_json)
-                                .map(|primary_key| primary_key.flatten())
-                                .collect();
-                            primary_keys.map(|primary_keys| (column.into(), primary_keys))
-                        })
-                        .collect();
+                    let primary_keys =
+                        try_collect_primary_keys(&primary_key_columns, &primary_keys);
 
                     match primary_keys {
                         Err(err) => {
@@ -772,16 +738,8 @@ async fn post_index_bm25(
 ) -> Response {
     let keyspace: crate::KeyspaceName = keyspace.into();
     let index_name: crate::IndexName = index_name.into();
-    if state.use_tls
-        && extensions
-            .get::<Protocol>()
-            .is_some_and(|protocol| *protocol == Protocol::Plain)
-    {
-        let msg = "TLS is required, but the request \
-            was made over an insecure connection."
-            .to_string();
-        debug!("post_index_bm25: {msg}");
-        return (StatusCode::FORBIDDEN, msg).into_response();
+    if let Some(resp) = check_insecure_tls(state.use_tls, &extensions, "post_index_bm25") {
+        return resp;
     }
 
     let index_key = IndexKey::new(&keyspace, &index_name);
@@ -840,34 +798,7 @@ async fn post_index_bm25(
                 return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
             }
 
-            let primary_keys: anyhow::Result<_> = primary_key_columns
-                .iter()
-                .cloned()
-                .enumerate()
-                .map(|(idx_column, column)| {
-                    let primary_keys: anyhow::Result<_> = primary_keys
-                        .iter()
-                        .map(|primary_key| {
-                            if primary_key.len() != primary_key_columns.len() {
-                                bail!(
-                                    "wrong size of a primary key: {}, {}",
-                                    primary_key_columns.len(),
-                                    primary_key.len()
-                                );
-                            }
-                            Ok(primary_key)
-                        })
-                        .map_ok(|primary_key| {
-                            primary_key
-                                .get(idx_column)
-                                .expect("primary key index out of bounds after length check")
-                        })
-                        .map_ok(try_to_json)
-                        .map(|primary_key| primary_key.flatten())
-                        .collect();
-                    primary_keys.map(|primary_keys| (column.into(), primary_keys))
-                })
-                .collect();
+            let primary_keys = try_collect_primary_keys(&primary_key_columns, &primary_keys);
 
             match primary_keys {
                 Err(err) => {
@@ -1045,6 +976,59 @@ fn try_from_post_index_ann_filter(
             .collect::<anyhow::Result<_>>()?,
         allow_filtering: json_filter.allow_filtering,
     })
+}
+
+fn check_insecure_tls(
+    use_tls: bool,
+    extensions: &Extensions,
+    route_name: &str,
+) -> Option<Response> {
+    if use_tls
+        && extensions
+            .get::<Protocol>()
+            .is_some_and(|protocol| *protocol == Protocol::Plain)
+    {
+        let msg = "TLS is required, but the request \
+            was made over an insecure connection."
+            .to_string();
+        debug!("{route_name}: {msg}");
+        return Some((StatusCode::FORBIDDEN, msg).into_response());
+    }
+    None
+}
+
+fn try_collect_primary_keys(
+    primary_key_columns: &[crate::ColumnName],
+    primary_keys: &[crate::PrimaryKey],
+) -> anyhow::Result<HashMap<httpapi::ColumnName, Vec<Value>>> {
+    primary_key_columns
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(idx_column, column)| {
+            let primary_keys: anyhow::Result<_> = primary_keys
+                .iter()
+                .map(|primary_key| {
+                    if primary_key.len() != primary_key_columns.len() {
+                        bail!(
+                            "wrong size of a primary key: {}, {}",
+                            primary_key_columns.len(),
+                            primary_key.len()
+                        );
+                    }
+                    Ok(primary_key)
+                })
+                .map_ok(|primary_key| {
+                    primary_key
+                        .get(idx_column)
+                        .expect("primary key index out of bounds after length check")
+                })
+                .map_ok(try_to_json)
+                .map(|primary_key| primary_key.flatten())
+                .collect();
+            primary_keys.map(|primary_keys| (column.into(), primary_keys))
+        })
+        .collect()
 }
 
 fn try_to_json(value: CqlValue) -> anyhow::Result<Value> {

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -81,6 +81,7 @@ pub(crate) struct IndexEntry<I, D = ()> {
     db_index: mpsc::Sender<DbIndex>,
     status: IndexStatus,
     progress: Progress,
+    primary_key_columns: Arc<Vec<ColumnName>>,
     data: D,
 }
 
@@ -101,7 +102,6 @@ pub(crate) type FtsIndexEntry = IndexEntry<FtsIndex>;
 pub(crate) struct VsIndexData {
     routing_group: RoutingGroupKey,
     partitioning: DbIndexPartitioning,
-    primary_key_columns: Arc<Vec<ColumnName>>,
     filtering_columns: Arc<Vec<ColumnName>>,
     table_columns: Arc<HashMap<ColumnName, NativeType>>,
     version: IndexVersion,
@@ -131,6 +131,10 @@ impl<I, D> IndexEntry<I, D> {
 
     pub(crate) fn set_status(&mut self, status: IndexStatus) {
         self.status = status;
+    }
+
+    pub(crate) fn primary_key_columns(&self) -> &Arc<Vec<ColumnName>> {
+        &self.primary_key_columns
     }
 }
 
@@ -165,10 +169,10 @@ impl VsIndexEntry {
             db_index,
             status: IndexStatus::Initializing,
             progress,
+            primary_key_columns,
             data: VsIndexData {
                 routing_group,
                 partitioning: metadata.partitioning,
-                primary_key_columns,
                 filtering_columns,
                 table_columns,
                 version: metadata.version,
@@ -233,6 +237,7 @@ impl FtsIndexEntry {
         monitor: mpsc::Sender<MonitorItems>,
         db_index: mpsc::Sender<DbIndex>,
     ) -> Self {
+        let primary_key_columns = db_index.get_primary_key_columns().await;
         let progress = db_index.full_scan_progress().await;
         Self {
             index,
@@ -240,6 +245,7 @@ impl FtsIndexEntry {
             db_index,
             status: IndexStatus::Initializing,
             progress,
+            primary_key_columns,
             data: (),
         }
     }
@@ -383,7 +389,7 @@ impl Indexes {
                 BestIndexState::Serving {
                     key: routed_key.clone(),
                     index: routed_entry.index.clone(),
-                    primary_key_columns: Arc::clone(&routed_entry.data.primary_key_columns),
+                    primary_key_columns: Arc::clone(&routed_entry.primary_key_columns),
                     table_columns: Arc::clone(&routed_entry.data.table_columns),
                     needs_filtering: needs_filtering.clone(),
                 }

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -11,10 +11,12 @@ use crate::db_basic::Table;
 use crate::wait_for;
 use httpapi::IndexStatus;
 use httpclient::HttpClient;
+use reqwest::StatusCode;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
@@ -137,4 +139,205 @@ async fn fts_index_returns_proper_count() {
         "Waiting for FTS index to be serving with count == 2",
     )
     .await;
+}
+
+async fn setup_fts_and_wait(
+    documents: impl IntoIterator<Item = (Vec<CqlValue>, &str, u64)>,
+    expected_count: usize,
+) -> (
+    HttpClient,
+    httpapi::KeyspaceName,
+    httpapi::IndexName,
+    impl Sized,
+) {
+    let docs: Vec<_> = documents
+        .into_iter()
+        .map(|(pk, doc, ts)| {
+            (
+                pk.into_iter().collect(),
+                Some(doc.to_string()),
+                Timestamp::from_unix_timestamp(ts),
+            )
+        })
+        .collect();
+
+    let (run, index, db, node_state) = setup_fts_store(
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_documents(docs)),
+        None,
+    )
+    .await;
+
+    let (client, server, config_tx) = run.await;
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| {
+                    status.status == IndexStatus::Serving && status.count == expected_count
+                })
+        },
+        "Waiting for FTS index to be serving",
+    )
+    .await;
+
+    (
+        client,
+        keyspace_name,
+        index_name,
+        (server, config_tx, db, node_state),
+    )
+}
+
+#[tokio::test]
+async fn fts_bm25_search_returns_matching_docs() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait(
+        [
+            (vec![CqlValue::Int(1)], "the quick brown fox", 10),
+            (vec![CqlValue::Int(2)], "lazy dog sleeps all day", 20),
+        ],
+        2,
+    )
+    .await;
+
+    let (primary_keys, scores) = client
+        .bm25(
+            &keyspace_name,
+            &index_name,
+            "fox".into(),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(primary_keys.get(&"pk".into()).unwrap().len(), 1);
+    assert_eq!(scores.len(), 1);
+    assert!(scores[0] > 0.0);
+    assert_eq!(
+        primary_keys.get(&"pk".into()).unwrap()[0].as_i64().unwrap(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn fts_bm25_search_returns_empty_for_no_match() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
+
+    let (primary_keys, scores) = client
+        .bm25(
+            &keyspace_name,
+            &index_name,
+            "nonexistentterm".into(),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert!(primary_keys.get(&"pk".into()).unwrap().is_empty());
+    assert!(scores.is_empty());
+}
+
+#[tokio::test]
+async fn fts_bm25_search_respects_limit() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait(
+        [
+            (vec![CqlValue::Int(1)], "rust programming language", 10),
+            (vec![CqlValue::Int(2)], "rust systems programming", 20),
+            (vec![CqlValue::Int(3)], "rust is fast and safe", 30),
+            (vec![CqlValue::Int(4)], "rust memory safety", 40),
+            (vec![CqlValue::Int(5)], "rust concurrency model", 50),
+        ],
+        5,
+    )
+    .await;
+
+    let (primary_keys, scores) = client
+        .bm25(
+            &keyspace_name,
+            &index_name,
+            "rust".into(),
+            NonZeroUsize::new(2).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(primary_keys.get(&"pk".into()).unwrap().len(), 2);
+    assert_eq!(scores.len(), 2);
+}
+
+#[tokio::test]
+async fn fts_bm25_search_not_found_returns_404() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
+
+    let _ = (keyspace_name, index_name);
+    let response = client
+        .post_bm25(
+            &"nonexistent_ks".into(),
+            &"nonexistent_idx".into(),
+            "hello".into(),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn fts_bm25_search_not_serving_returns_503() {
+    crate::enable_tracing();
+
+    let fullscan_fn = |_| {
+        use futures::FutureExt;
+        async move {
+            // wait indefinitely to simulate a long-running indexing operation (Bootstrapping)
+            std::future::pending::<()>().await;
+        }
+        .boxed()
+    };
+    let (run, index, _db, _node_state) = setup_fts_store(
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(Box::new(fullscan_fn)),
+        None,
+    )
+    .await;
+    let (client, _server, _config_tx) = run.await;
+    let keyspace_name: httpapi::KeyspaceName = index.keyspace_name.clone().into();
+    let index_name: httpapi::IndexName = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Bootstrapping)
+        },
+        "Waiting for FTS index to be bootstrapping",
+    )
+    .await;
+
+    let response = client
+        .post_bm25(
+            &keyspace_name,
+            &index_name,
+            "hello".into(),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -341,3 +341,37 @@ async fn fts_bm25_search_not_serving_returns_503() {
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 }
+
+#[tokio::test]
+async fn fts_empty_index_has_zero_count() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait([], 0).await;
+
+    let status = client
+        .index_status(&keyspace_name, &index_name)
+        .await
+        .unwrap();
+
+    assert_eq!(status.status, IndexStatus::Serving);
+    assert_eq!(status.count, 0);
+}
+
+#[tokio::test]
+async fn fts_empty_index_returns_empty_bm25_results() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait([], 0).await;
+
+    let (primary_keys, scores) = client
+        .bm25(
+            &keyspace_name,
+            &index_name,
+            "anyterm".into(),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert!(primary_keys.get(&"pk".into()).unwrap().is_empty());
+    assert!(scores.is_empty());
+}

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -1679,3 +1679,59 @@ async fn similarity_scores_are_decreasing_and_correctly_converted() {
         scores[2]
     );
 }
+
+#[tokio::test]
+async fn empty_index_has_zero_count() {
+    crate::enable_tracing();
+
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors(std::iter::empty())),
+        None,
+        Some(0),
+    )
+    .await;
+
+    let status = client
+        .index_status(
+            &index.keyspace_name.clone().into(),
+            &index.index_name.clone().into(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status.status, IndexStatus::Serving);
+    assert_eq!(status.count, 0);
+}
+
+#[tokio::test]
+async fn empty_index_returns_empty_ann_results() {
+    crate::enable_tracing();
+
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors(std::iter::empty())),
+        None,
+        Some(0),
+    )
+    .await;
+
+    let (primary_keys, distances, similarity_scores) = client
+        .ann(
+            &index.keyspace_name.clone().into(),
+            &index.index_name.clone().into(),
+            vec![1.0, 1.0, 1.0].into(),
+            None,
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert!(primary_keys.get(&"pk".into()).unwrap().is_empty());
+    assert!(distances.is_empty());
+    assert!(similarity_scores.is_empty());
+}


### PR DESCRIPTION
Implements the `POST /indexes/{keyspace}/{index_name}/bm25` HTTP endpoint for full-text search using BM25 ranking. The endpoint was previously a stub returning `NOT_IMPLEMENTED`; it now resolves the requested index, validates its serving status, executes the BM25 query against the FTS engine, and returns ranked primary keys with scores.

The HTTP client gains corresponding methods for calling the new endpoint. Integration tests covering the BM25 search path are added, including error conditions and expected ranking behavior.

Closes: VECTOR-617