### PR TITLE
vector-store: remove metric labels when an index is deleted

### DIFF
--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -189,4 +189,18 @@ impl HttpClient {
             .json()
             .await?)
     }
+
+    pub async fn get_metrics_text(&self) -> String {
+        self.client
+            .get(format!(
+                "{}/metrics",
+                self.url_api.trim_end_matches("/api/v1")
+            ))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    }
 }

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -160,7 +160,7 @@ pub(crate) async fn new(
                                 .await
                             }
 
-                            Engine::DelIndex { key } => del_index(key, &indexes).await,
+                            Engine::DelIndex { key } => del_index(key, &indexes, &metrics).await,
 
                             Engine::GetVsIndex { key, tx } => get_vs_index(key, tx, &indexes).await,
 
@@ -340,9 +340,10 @@ async fn add_index_fts(ctx: AddIndexContext<'_>) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn del_index(key: IndexKey, indexes: &RwLock<Indexes>) {
+async fn del_index(key: IndexKey, indexes: &RwLock<Indexes>, metrics: &Metrics) {
     if indexes.write().unwrap().remove(&key) {
         info!("removed the index {key}");
+        metrics.remove_index_labels(key.keyspace().as_ref(), key.index().as_ref());
     }
 }
 

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -9,6 +9,11 @@ use prometheus::HistogramVec;
 use prometheus::Registry;
 use std::sync::Arc;
 
+pub const OP_INSERT: &str = "insert";
+pub const OP_UPDATE: &str = "update";
+pub const OP_REMOVE: &str = "remove";
+pub const OPERATIONS: &[&str] = &[OP_INSERT, OP_UPDATE, OP_REMOVE];
+
 #[derive(Clone)]
 pub struct Metrics {
     pub registry: Registry,
@@ -91,5 +96,93 @@ impl Metrics {
             self.dirty_indexes.remove(k);
         }
         keys
+    }
+
+    pub fn remove_index_labels(&self, keyspace: &str, index_name: &str) {
+        let _ = self.latency.remove_label_values(&[keyspace, index_name]);
+        let _ = self.size.remove_label_values(&[keyspace, index_name]);
+        for op in OPERATIONS {
+            let _ = self
+                .modified
+                .remove_label_values(&[keyspace, index_name, op]);
+        }
+        self.dirty_indexes
+            .remove(&(keyspace.to_owned(), index_name.to_owned()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus::Encoder;
+    use prometheus::TextEncoder;
+
+    fn metric_families_text(metrics: &Metrics) -> String {
+        let mut buf = Vec::new();
+        TextEncoder::new()
+            .encode(&metrics.registry.gather(), &mut buf)
+            .unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn remove_index_labels_clears_all_metric_series_for_index() {
+        let metrics = Metrics::new();
+
+        metrics.size.with_label_values(&["ks", "idx"]).set(10.0);
+        metrics
+            .modified
+            .with_label_values(&["ks", "idx", OP_INSERT])
+            .inc();
+        metrics
+            .latency
+            .with_label_values(&["ks", "idx"])
+            .observe(0.001);
+
+        metrics.remove_index_labels("ks", "idx");
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            !output.contains(r#"keyspace="ks""#),
+            "metric output should not contain labels for deleted index, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn remove_index_labels_is_noop_when_index_has_no_metrics() {
+        let metrics = Metrics::new();
+        metrics.remove_index_labels("ks", "nonexistent");
+        assert!(metric_families_text(&metrics).is_empty());
+    }
+
+    #[test]
+    fn remove_index_labels_only_removes_target_index() {
+        let metrics = Metrics::new();
+
+        metrics.size.with_label_values(&["ks", "idx1"]).set(1.0);
+        metrics.size.with_label_values(&["ks", "idx2"]).set(2.0);
+
+        metrics.remove_index_labels("ks", "idx1");
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            !output.contains(r#"index_name="idx1""#),
+            "idx1 labels should be removed"
+        );
+        assert!(
+            output.contains(r#"index_name="idx2""#),
+            "idx2 labels should remain"
+        );
+    }
+
+    #[test]
+    fn remove_index_labels_clears_dirty_index_entry() {
+        let metrics = Metrics::new();
+
+        metrics.mark_dirty("ks", "idx");
+        assert_eq!(metrics.dirty_indexes.len(), 1);
+
+        metrics.remove_index_labels("ks", "idx");
+        assert!(metrics.dirty_indexes.is_empty());
     }
 }

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -10,6 +10,9 @@ use crate::IndexKey;
 use crate::Metrics;
 use crate::fts_index::FtsIndex;
 use crate::fts_index::FtsIndexExt;
+use crate::metrics::OP_INSERT;
+use crate::metrics::OP_REMOVE;
+use crate::metrics::OP_UPDATE;
 use crate::perf;
 use crate::table::Operation;
 use crate::table::PartitionId;
@@ -177,7 +180,7 @@ async fn add<I: IndexDispatch>(
                 value,
                 is_update,
             } => {
-                let op_label = if is_update { "update" } else { "insert" };
+                let op_label = if is_update { OP_UPDATE } else { OP_INSERT };
                 index
                     .add_value(partition_id, primary_id, value, in_progress.take())
                     .await;
@@ -201,7 +204,7 @@ async fn add<I: IndexDispatch>(
                     .await;
                 metrics
                     .modified
-                    .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref(), "remove"])
+                    .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref(), OP_REMOVE])
                     .inc();
             }
             Operation::RemovePartition { partition_id } => {
@@ -230,21 +233,21 @@ mod tests {
         assert_eq!(
             metrics
                 .modified
-                .with_label_values(&["vector", "store", "insert"])
+                .with_label_values(&["vector", "store", OP_INSERT])
                 .get(),
             insert,
         );
         assert_eq!(
             metrics
                 .modified
-                .with_label_values(&["vector", "store", "update"])
+                .with_label_values(&["vector", "store", OP_UPDATE])
                 .get(),
             update,
         );
         assert_eq!(
             metrics
                 .modified
-                .with_label_values(&["vector", "store", "remove"])
+                .with_label_values(&["vector", "store", OP_REMOVE])
                 .get(),
             remove,
         );

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -8,6 +8,7 @@ mod fts;
 mod https;
 mod info;
 mod memory_limit;
+mod metrics;
 mod mock_opensearch;
 mod mtls;
 mod openapi;

--- a/crates/vector-store/tests/integration/metrics.rs
+++ b/crates/vector-store/tests/integration/metrics.rs
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::db_basic;
+use crate::db_basic::DbBasic;
+use crate::usearch;
+use crate::wait_for;
+use httpclient::HttpClient;
+use scylla::cluster::metadata::NativeType;
+use scylla::value::CqlValue;
+use tokio::sync::mpsc::Sender;
+use vector_store::DbIndexPartitioning;
+use vector_store::IndexMetadata;
+use vector_store::Timestamp;
+use vector_store::node_state::NodeState;
+
+async fn setup_single_vector_index() -> (
+    IndexMetadata,
+    HttpClient,
+    DbBasic,
+    impl Sized,
+    Sender<NodeState>,
+) {
+    usearch::setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into(), "ck".into()],
+        1,
+        [
+            ("pk".to_string().into(), NativeType::Int),
+            ("ck".to_string().into(), NativeType::Text),
+        ],
+        Some(db_basic::scan_fn_vectors([(
+            [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
+            Some(vec![1., 1., 1.].into()),
+            Timestamp::from_unix_timestamp(10),
+        )])),
+        None,
+        Some(1),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn index_labels_present_in_metrics_endpoint() {
+    crate::enable_tracing();
+
+    let (index, client, _db, _server, _node_state) = setup_single_vector_index().await;
+
+    let expected_labels = format!(
+        r#"index_name="{}",keyspace="{}""#,
+        index.index_name, index.keyspace_name,
+    );
+    wait_for(
+        || async { client.get_metrics_text().await.contains(&expected_labels) },
+        "Waiting for index labels to appear in /metrics",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn deleted_index_labels_absent_from_metrics_endpoint() {
+    crate::enable_tracing();
+
+    let (index, client, db, _server, _node_state) = setup_single_vector_index().await;
+
+    let expected_labels = format!(
+        r#"index_name="{}",keyspace="{}""#,
+        index.index_name, index.keyspace_name,
+    );
+    wait_for(
+        || async { client.get_metrics_text().await.contains(&expected_labels) },
+        "Waiting for index labels to appear in /metrics",
+    )
+    .await;
+
+    db.del_index(&index.keyspace_name, &index.index_name)
+        .unwrap();
+
+    wait_for(
+        || async { !client.get_metrics_text().await.contains(&expected_labels) },
+        "Waiting for deleted index labels to disappear from /metrics",
+    )
+    .await;
+}


### PR DESCRIPTION
When del_index is called, the index is removed from the in-memory map but the corresponding label sets in the Prometheus metrics were never removed from the registry.  This caused deleted indexes to remain visible in monitoring indefinitely.

Add Metrics::remove_index_labels that calls remove_label_values on all three metric vectors and evicts the index from dirty_indexes. Call it from del_index in engine.rs immediately after the index is removed from the index map.

Fixes: VECTOR-692