### PR TITLE
vector-store: fix cdc reader shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,9 +1002,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytes-utils"
@@ -5953,6 +5953,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bcrypt",
+ "bytes",
  "clap",
  "derive_more",
  "e2etest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ axum-server-dual-protocol = "0.8.0"
 axum-test = "20.0.0"
 bcrypt = "0.15"
 bigdecimal = "0.4"
+bytes = "1.12.0"
 const-hex = "1.18.1"
 clap = { version = "4.5.40", features = ["derive"] }
 chrono = "0.4.43"

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-dynamodb.workspace = true
 aws-smithy-runtime-api.workspace = true
 aws-smithy-types.workspace = true
 bcrypt.workspace = true
+bytes.workspace = true
 clap.workspace = true
 derive_more.workspace = true
 e2etest.workspace = true

--- a/crates/validator/src/cdc.rs
+++ b/crates/validator/src/cdc.rs
@@ -5,6 +5,9 @@
 
 use crate::TestActors;
 use crate::common::*;
+use itertools::Itertools;
+use std::array;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -639,6 +642,88 @@ async fn cql_per_row_ttl_expires_from_index(actors: Arc<TestActors>) {
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
         .await
         .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Check if null clustering keys are skipped by the index.
+///
+/// Use static columns as updating a static column gives a CDC's row with null clustering key.
+///
+/// Steps:
+/// 1. Create a table with a clustering key and a static column.
+/// 2. Create an index on the vector column.
+/// 3. Insert rows with a clustering key and a static column value.
+/// 4. Verify that the index count is correct and the ANN query returns the inserted rows.
+/// 5. Drop the keyspace and verify that the index is dropped.
+#[e2etest::test(group = cdc)]
+async fn skip_null_ck(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs(&actors).await;
+    let client = clients.first().unwrap();
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, ck INT, v VECTOR<FLOAT, 3>, s INT STATIC, PRIMARY KEY (pk, ck)",
+        None,
+    )
+    .await;
+    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    let status = wait_for_index(client, &index).await;
+    assert_eq!(status.count, 0, "Index should start empty");
+
+    info!("Insert data to the table for CDC");
+    let pks: BTreeSet<_> = array::from_fn::<i32, 10, _>(|i| i as i32)
+        .into_iter()
+        .collect();
+    for pk in &pks {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, ck, v, s) VALUES ({pk}, 2, [1.0, 2.0, 3.0], 3)"),
+                (),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    wait_for(
+        || async {
+            let status = client.index_status(&index.keyspace, &index.index).await;
+            matches!(status, Ok(s) if s.count == pks.len())
+        },
+        "Waiting for all rows to be indexed",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+
+    // Verify ANN query returns the inserted row
+    let rows = wait_for_value(
+        || async {
+            let result = get_opt_query_results(
+                format!("SELECT pk FROM {table} ORDER BY v ANN OF [1.0, 2.0, 3.0] LIMIT 100"),
+                &session,
+            )
+            .await?;
+            let rows = result
+                .rows::<(i32,)>()
+                .ok()?
+                .map_ok(|row| row.0)
+                .collect::<Result<BTreeSet<_>, _>>()
+                .ok()?;
+            (rows.len() == pks.len()).then_some(rows)
+        },
+        "Waiting for ANN query after CDC insert",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+    assert_eq!(rows, pks);
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
 
     info!("finished");
 }

--- a/crates/validator/src/cdc.rs
+++ b/crates/validator/src/cdc.rs
@@ -5,7 +5,14 @@
 
 use crate::TestActors;
 use crate::common::*;
+use bytes::BytesMut;
+use e2etest_scylla_proxy_cluster::ScyllaProxyClusterExt;
 use itertools::Itertools;
+use scylla_proxy::Condition;
+use scylla_proxy::Reaction;
+use scylla_proxy::ResponseOpcode;
+use scylla_proxy::ResponseReaction;
+use scylla_proxy::ResponseRule;
 use std::array;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -19,13 +26,17 @@ const CDC_MAX_LATENCY: Duration = Duration::from_secs(60);
 const CDC_ACTOR_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const TTL_EXPIRATION_TIMEOUT: Duration = Duration::from_secs(10);
 
-e2etest::group!(name = cdc, fixtures = (Fixture), parent = crate::validator);
+e2etest::group!(
+    name = cdc_direct,
+    fixtures = (FixtureDirect),
+    parent = crate::validator
+);
 
-struct Fixture {
+struct FixtureDirect {
     actors: Arc<TestActors>,
 }
 
-impl e2etest::Fixture for Fixture {
+impl e2etest::Fixture for FixtureDirect {
     async fn setup(setup: &mut impl e2etest::Setup) -> Self {
         setup.setup::<TestActors>().await;
         let actors = setup.get::<TestActors>().await.unwrap();
@@ -38,7 +49,30 @@ impl e2etest::Fixture for Fixture {
     }
 }
 
-#[e2etest::test(group = cdc)]
+e2etest::group!(
+    name = cdc_proxy,
+    fixtures = (FixtureProxy),
+    parent = crate::validator
+);
+
+struct FixtureProxy {
+    actors: Arc<TestActors>,
+}
+
+impl e2etest::Fixture for FixtureProxy {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+        setup.setup::<TestActors>().await;
+        let actors = setup.get::<TestActors>().await.unwrap();
+        init_with_proxy_single_vs(&actors).await;
+        Self { actors }
+    }
+
+    async fn teardown(self) {
+        cleanup(&self.actors).await;
+    }
+}
+
+#[e2etest::test(group = cdc_direct)]
 async fn cdc_insert_visible_immediately(actors: Arc<TestActors>) {
     info!("started");
 
@@ -87,7 +121,7 @@ async fn cdc_insert_visible_immediately(actors: Arc<TestActors>) {
     info!("finished");
 }
 
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn cdc_update_visible_immediately(actors: Arc<TestActors>) {
     info!("started");
 
@@ -182,7 +216,7 @@ fn now_epoch_secs() -> i64 {
         .as_secs() as i64
 }
 
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn cdc_delete_visible_immediately(actors: Arc<TestActors>) {
     info!("started");
 
@@ -231,7 +265,7 @@ async fn cdc_delete_visible_immediately(actors: Arc<TestActors>) {
     info!("finished");
 }
 
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn cdc_lwt_insert_visible(actors: Arc<TestActors>) {
     info!("started");
 
@@ -279,7 +313,7 @@ async fn cdc_lwt_insert_visible(actors: Arc<TestActors>) {
     info!("finished");
 }
 
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn cdc_lwt_update_visible(actors: Arc<TestActors>) {
     info!("started");
 
@@ -371,7 +405,7 @@ async fn cdc_lwt_update_visible(actors: Arc<TestActors>) {
     info!("finished");
 }
 
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn cdc_lwt_delete_visible(actors: Arc<TestActors>) {
     info!("started");
 
@@ -426,7 +460,7 @@ async fn cdc_lwt_delete_visible(actors: Arc<TestActors>) {
 /// DROP + CREATE of the same index), old CDC actors must terminate. If
 /// they are orphaned, the same index ends up with multiple CDC readers
 /// running concurrently, which is the symptom observed in the field.
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn recreating_index_terminates_old_cdc_actors(actors: Arc<TestActors>) {
     info!("started");
 
@@ -520,6 +554,7 @@ async fn recreating_index_terminates_old_cdc_actors(actors: Arc<TestActors>) {
         counters.get(&fine_stopped).copied().unwrap_or(0),
     );
 }
+
 /// Test that rows inserted with CQL per-row TTL are not returned by ANN
 /// queries after they expire, and that the index count decrements accordingly.
 ///
@@ -528,7 +563,7 @@ async fn recreating_index_terminates_old_cdc_actors(actors: Arc<TestActors>) {
 /// 2. Create an index and verify all rows are queryable via ANN.
 /// 3. Wait for the expiration service to delete expired rows (via CDC).
 /// 4. Verify the index count drops and ANN queries return only non-TTL rows.
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn cql_per_row_ttl_expires_from_index(actors: Arc<TestActors>) {
     info!("started");
 
@@ -656,7 +691,7 @@ async fn cql_per_row_ttl_expires_from_index(actors: Arc<TestActors>) {
 /// 3. Insert rows with a clustering key and a static column value.
 /// 4. Verify that the index count is correct and the ANN query returns the inserted rows.
 /// 5. Drop the keyspace and verify that the index is dropped.
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn skip_null_ck(actors: Arc<TestActors>) {
     info!("started");
 
@@ -739,7 +774,7 @@ async fn skip_null_ck(actors: Arc<TestActors>) {
 /// 6. Verify that the index count after index and the ANN query returns the updated and inserted
 ///    rows.
 /// 7. Drop the keyspace and verify that the index is dropped.
-#[e2etest::test(group = cdc)]
+#[e2etest::test(group = cdc_direct)]
 async fn skip_null_target(actors: Arc<TestActors>) {
     info!("started");
 
@@ -840,6 +875,150 @@ async fn skip_null_target(actors: Arc<TestActors>) {
     )
     .await;
     assert_eq!(rows, expected);
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}
+
+/// Check that the CDC reader retries after encountering an error in the response from the
+/// database.
+///
+/// Steps:
+/// 1. Create a table and an index using a scylla proxy.
+/// 2. Create an index and wait for it to be built.
+/// 3. Setup the proxy to inject an artificial error into the CDC reader response.
+/// 4. Insert a row with a marker in pk into the table.
+/// 5. Wait for the CDC reader to stop and start again, indicating that it retried after the error.
+/// 6. Remove the error injection and wait for the index to be built successfully.
+/// 7. Drop the keyspace.
+#[e2etest::test(group = cdc_proxy)]
+async fn reader_retries_after_error(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs_no_tls(&actors).await;
+    let client = clients.first().unwrap();
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "pk ASCII PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+
+    let index_name = unique_index_name();
+    let index_ident = format!("{keyspace}.{index_name}");
+
+    let index = create_index(
+        CreateIndexQuery::new(&session, &clients, table.as_ref(), "v").index_name(index_name),
+    )
+    .await;
+    wait_for_index(client, &index).await;
+
+    const MARKER: &str = "test-cdc-retry";
+
+    info!("Inject artificial errors into the CDC reader to test retry logic");
+    actors
+        .db_proxy
+        .change_response_rules(Some(vec![ResponseRule(
+            Condition::And(
+                Box::new(Condition::ResponseOpcode(ResponseOpcode::Result)),
+                Box::new(Condition::BodyContainsCaseSensitive(
+                    MARKER.as_bytes().iter().copied().collect(),
+                )),
+            ),
+            ResponseReaction::transform_frame(Arc::new(|mut input| {
+                let marker = MARKER.as_bytes();
+                let Some(offset) =
+                    (0..input.body.len()).find(|i| input.body[*i..].starts_with(marker))
+                else {
+                    return input;
+                };
+                // Corrupt the marker in the frame body to trigger an error in the CDC reader
+                let mut body = BytesMut::from(input.body);
+                body[offset..offset + MARKER.len()].fill(0xff);
+                input.body = body.freeze();
+                input
+            })),
+        )]))
+        .await;
+
+    let wide_started = format!("{index_ident}-wide-cdc-handler-started");
+    let wide_stopped = format!("{index_ident}-wide-cdc-handler-stopped");
+    let fine_started = format!("{index_ident}-fine-cdc-handler-started");
+    let fine_stopped = format!("{index_ident}-fine-cdc-handler-stopped");
+
+    client.internals_clear_counters().await.unwrap();
+    for name in [&wide_started, &wide_stopped, &fine_started, &fine_stopped] {
+        client.internals_start_counter(name.clone()).await.unwrap();
+    }
+
+    let log_counters = async || {
+        let counters = client.internals_counters().await.unwrap();
+        info!(
+            "counters: wide started={} stopped={}, fine started={} stopped={}",
+            counters.get(&wide_started).copied().unwrap_or(0),
+            counters.get(&wide_stopped).copied().unwrap_or(0),
+            counters.get(&fine_started).copied().unwrap_or(0),
+            counters.get(&fine_stopped).copied().unwrap_or(0),
+        );
+    };
+
+    info!("Insert rows with marker");
+    let pk = format!("{MARKER}-pk");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, v) VALUES ('{pk}', [1.0, 2.0, 3.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert data");
+
+    for count in 1..=3 {
+        log_counters().await;
+        wait_for(
+            || async {
+                let counters = match client.internals_counters().await {
+                    Ok(c) => c,
+                    Err(_) => return false,
+                };
+                counters.get(&wide_stopped).copied().unwrap_or(0) >= count
+                    && counters.get(&fine_stopped).copied().unwrap_or(0) >= count
+            },
+            format!("waiting for index readers to stop (iteration {count})"),
+            DEFAULT_OPERATION_TIMEOUT,
+        )
+        .await;
+
+        log_counters().await;
+        wait_for(
+            || async {
+                let counters = match client.internals_counters().await {
+                    Ok(c) => c,
+                    Err(_) => return false,
+                };
+                counters.get(&wide_started).copied().unwrap_or(0) >= count
+                    && counters.get(&fine_started).copied().unwrap_or(0) >= count
+            },
+            format!("waiting for index readers to start (iteration {count})"),
+            DEFAULT_OPERATION_TIMEOUT,
+        )
+        .await;
+    }
+
+    log_counters().await;
+
+    info!("Remove the error injection");
+    actors.db_proxy.turn_off_rules().await;
+
+    wait_for(
+        || async {
+            let status = client.index_status(&index.keyspace, &index.index).await;
+            matches!(status, Ok(s) if s.count == 1)
+        },
+        "Waiting for all rows to be indexed after error injection is removed",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
 
     session
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())

--- a/crates/validator/src/cdc.rs
+++ b/crates/validator/src/cdc.rs
@@ -727,3 +727,124 @@ async fn skip_null_ck(actors: Arc<TestActors>) {
 
     info!("finished");
 }
+
+/// Check if null target columns are skipped by the index.
+///
+/// Steps:
+/// 1. Create a table with a non-vector column.
+/// 2. Create an index on the vector column.
+/// 3. Insert rows.
+/// 4. Update non-vector column to trigger CDC with null vector value.
+/// 5. Insert new rows to wait for the CDC reader to process the update with null vector value.
+/// 6. Verify that the index count after index and the ANN query returns the updated and inserted
+///    rows.
+/// 7. Drop the keyspace and verify that the index is dropped.
+#[e2etest::test(group = cdc)]
+async fn skip_null_target(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs(&actors).await;
+    let client = clients.first().unwrap();
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>, i INT",
+        None,
+    )
+    .await;
+    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    let status = wait_for_index(client, &index).await;
+    assert_eq!(status.count, 0, "Index should start empty");
+
+    info!("Insert data to the table for CDC");
+    let pks: BTreeSet<_> = array::from_fn::<i32, 10, _>(|i| i as i32 + 1)
+        .into_iter()
+        .collect();
+    for pk in &pks {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, v, i) VALUES ({pk}, [1.0, 2.0, 3.0], {pk})"),
+                (),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    wait_for(
+        || async {
+            let status = client.index_status(&index.keyspace, &index.index).await;
+            matches!(status, Ok(s) if s.count == pks.len())
+        },
+        "Waiting for all rows to be indexed",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+
+    for pk in &pks {
+        session
+            .query_unpaged(
+                format!("UPDATE {table} SET i = {i} WHERE pk = {pk}", i = pk + 10),
+                (),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    for pk in &pks {
+        session
+            .query_unpaged(
+                format!(
+                    "INSERT INTO {table} (pk, v, i) VALUES ({pk}, [1.0, 2.0, 3.0], {i})",
+                    pk = pk + 100,
+                    i = pk,
+                ),
+                (),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    wait_for(
+        || async {
+            let status = client.index_status(&index.keyspace, &index.index).await;
+            matches!(status, Ok(s) if s.count == pks.len() * 2)
+        },
+        "Waiting for all rows to be indexed after updates and inserts",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+
+    // Verify ANN query returns the inserted and updated rows
+    let expected: BTreeSet<_> = pks
+        .into_iter()
+        .flat_map(|pk| [pk, pk + 10].into_iter())
+        .collect();
+    let rows = wait_for_value(
+        || async {
+            let result = get_opt_query_results(
+                format!("SELECT pk, i FROM {table} ORDER BY v ANN OF [1.0, 2.0, 3.0] LIMIT 100"),
+                &session,
+            )
+            .await?;
+            let rows = result
+                .rows::<(i32, i32)>()
+                .ok()?
+                .map_ok(|row| row.1)
+                .collect::<Result<BTreeSet<_>, _>>()
+                .ok()?;
+            (rows.len() == expected.len()).then_some(rows)
+        },
+        "Waiting for ANN query after CDC insert",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+    assert_eq!(rows, expected);
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -31,6 +31,7 @@ use scylla_cdc::consumer::Consumer;
 use scylla_cdc::consumer::ConsumerFactory;
 use scylla_cdc::consumer::OperationType;
 use scylla_cdc::log_reader::CDCLogReaderBuilder;
+use std::future;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
@@ -56,12 +57,8 @@ const DEFAULT_CONSISTENT_SLEEP_INTERVAL: Duration = Duration::from_secs(10);
 const DEFAULT_REALTIME_SAFETY_INTERVAL: Duration = Duration::from_millis(100);
 const DEFAULT_REALTIME_SLEEP_INTERVAL: Duration = Duration::from_millis(500);
 
-/// Maximum consecutive errors before a CDC reader with Backoff policy escalates to session teardown.
-const DEFAULT_MAX_CONSECUTIVE_ERRORS: u32 = 3;
-
-/// Base backoff duration for CDC reader restarts after errors.
-/// The actual backoff is `DEFAULT_BACKOFF_BASE * consecutive_error_count`.
-const DEFAULT_BACKOFF_BASE: Duration = Duration::from_secs(5);
+/// Default backoff duration for CDC reader restarts after errors.
+const DEFAULT_BACKOFF_DURATION: Duration = Duration::from_secs(5);
 
 /// Parameters for a CDC reader instance.
 #[derive(Clone, Debug)]
@@ -109,14 +106,8 @@ pub(crate) enum CdcReaderConfig {
 impl From<CdcReaderConfig> for CdcReaderState {
     fn from(config: CdcReaderConfig) -> Self {
         match config {
-            CdcReaderConfig::Wide => {
-                Self::new("wide", CdcErrorPolicy::Propagate, CdcReaderParams::wide)
-            }
-            CdcReaderConfig::Fine => Self::new(
-                "fine",
-                CdcErrorPolicy::backoff_and_retry(),
-                CdcReaderParams::fine,
-            ),
+            CdcReaderConfig::Wide => Self::new("wide", CdcReaderParams::wide),
+            CdcReaderConfig::Fine => Self::new("fine", CdcReaderParams::fine),
         }
     }
 }
@@ -146,6 +137,9 @@ pub(crate) fn new(
                 .increment_counter(format!("{actor_key}-{name}-cdc-actor-started"))
                 .await;
 
+            let mut backoff_duration = None;
+            let mut err_counter = 0usize;
+
             loop {
                 tokio::select! {
                     // Shut down when all senders are dropped
@@ -162,15 +156,21 @@ pub(crate) fn new(
                             session_opt, &config_rx, &metadata,
                             &tx_embeddings, &internals,
                         ).await;
+                        err_counter = 0;
+                        backoff_duration = None;
                     }
 
                     _ = reader.error_notify.notified() => {
-                        if reader.handle_error() {
-                            break;
-                        }
+                        err_counter += 1;
+                        backoff_duration = Some(DEFAULT_BACKOFF_DURATION);
+                        warn!(
+                            "{name} CDC reader error {err_counter}, restarting after {duration:?} backoff",
+                            name = reader.name,
+                            duration = backoff_duration.unwrap(),
+                        );
                     }
 
-                    Some(()) = select_backoff(reader.backoff_deadline) => {
+                    _ = sleep_for_retry(backoff_duration.take()) => {
                         reader.restart_after_backoff(
                             &session_rx, &config_rx, &metadata,
                             &tx_embeddings, &internals,
@@ -193,57 +193,26 @@ pub(crate) fn new(
     tx
 }
 
-/// Defines how a CDC reader handles errors from its handler task.
-enum CdcErrorPolicy {
-    /// Propagate errors immediately by closing the channel.
-    Propagate,
-    /// Handle errors locally with backoff and retry.
-    /// After `max_consecutive_errors` consecutive failures, close the channel.
-    BackoffAndRetry {
-        max_consecutive_errors: u32,
-        backoff_base: Duration,
-        consecutive_errors: u32,
-    },
-}
-
-impl CdcErrorPolicy {
-    fn backoff_and_retry() -> Self {
-        Self::BackoffAndRetry {
-            max_consecutive_errors: DEFAULT_MAX_CONSECUTIVE_ERRORS,
-            backoff_base: DEFAULT_BACKOFF_BASE,
-            consecutive_errors: 0,
-        }
-    }
-}
-
 /// State for managing a CDC reader's lifecycle.
 struct CdcReaderState {
     reader: Option<scylla_cdc::log_reader::CDCLogReader>,
     handler_task: Option<tokio::task::JoinHandle<Duration>>,
     shutdown_notify: Arc<Notify>,
-    backoff_deadline: Option<time::Instant>,
     error_notify: Arc<Notify>,
     start: Duration,
     name: &'static str,
-    error_policy: CdcErrorPolicy,
     params_fn: fn(&Config) -> CdcReaderParams,
 }
 
 impl CdcReaderState {
-    fn new(
-        name: &'static str,
-        error_policy: CdcErrorPolicy,
-        params_fn: fn(&Config) -> CdcReaderParams,
-    ) -> Self {
+    fn new(name: &'static str, params_fn: fn(&Config) -> CdcReaderParams) -> Self {
         Self {
             reader: None,
             handler_task: None,
             shutdown_notify: Arc::new(Notify::new()),
             error_notify: Arc::new(Notify::new()),
-            backoff_deadline: None,
             start: cdc_now(),
             name,
-            error_policy,
             params_fn,
         }
     }
@@ -256,19 +225,6 @@ impl CdcReaderState {
         if let Some(task) = self.handler_task.take() {
             self.shutdown_notify.notify_one();
             self.start = task.await.unwrap_or(cdc_now());
-        }
-    }
-
-    /// Drains stale error notifications, cancels any pending backoff,
-    /// and resets the consecutive error counter.
-    fn reset_on_session_change(&mut self) {
-        drain_pending_notifications(&self.error_notify);
-        self.backoff_deadline = None;
-        if let CdcErrorPolicy::BackoffAndRetry {
-            consecutive_errors, ..
-        } = &mut self.error_policy
-        {
-            *consecutive_errors = 0;
         }
     }
 
@@ -315,6 +271,7 @@ impl CdcReaderState {
             }
             Err(e) => {
                 error!("Failed to create {} CDC reader: {e}", self.name);
+                self.error_notify.notify_one();
             }
         }
     }
@@ -338,7 +295,7 @@ impl CdcReaderState {
 
                 let config = config_rx.borrow().clone();
 
-                self.reset_on_session_change();
+                drain_pending_notifications(&self.error_notify);
                 let params = (self.params_fn)(&config);
                 self.restart(params, &session, metadata, tx_embeddings, internals)
                     .await;
@@ -355,39 +312,6 @@ impl CdcReaderState {
         }
     }
 
-    /// Handles an error according to the reader's [`CdcErrorPolicy`].
-    /// Returns `true` if the error should be propagated by closing the channel.
-    fn handle_error(&mut self) -> bool {
-        match &mut self.error_policy {
-            CdcErrorPolicy::Propagate => true,
-            CdcErrorPolicy::BackoffAndRetry {
-                max_consecutive_errors,
-                backoff_base,
-                consecutive_errors,
-            } => {
-                *consecutive_errors += 1;
-                let count = *consecutive_errors;
-                let limit = *max_consecutive_errors;
-
-                if count >= limit {
-                    warn!(
-                        "{} CDC reader failed {count} consecutive times, closing channel",
-                        self.name
-                    );
-                    true
-                } else {
-                    let backoff = *backoff_base * count;
-                    warn!(
-                        "{} CDC reader error ({count}/{limit}), restarting after {backoff:?} backoff",
-                        self.name,
-                    );
-                    self.backoff_deadline = Some(time::Instant::now() + backoff);
-                    false
-                }
-            }
-        }
-    }
-
     /// Completes a pending backoff by restarting the CDC reader.
     async fn restart_after_backoff(
         &mut self,
@@ -397,7 +321,6 @@ impl CdcReaderState {
         tx_embeddings: &mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
         internals: &Sender<Internals>,
     ) {
-        self.backoff_deadline = None;
         let session = session_rx.borrow().clone();
         if let Some(session) = session {
             let config = config_rx.borrow().clone();
@@ -414,10 +337,13 @@ fn cdc_now() -> Duration {
         .unwrap()
 }
 
-/// Waits for the backoff deadline to expire, returning `None` if no deadline is set.
-async fn select_backoff(deadline: Option<time::Instant>) -> Option<()> {
-    time::sleep_until(deadline?).await;
-    Some(())
+/// Sleep for the specified duration, or indefinitely if None, to implement backoff.
+async fn sleep_for_retry(duration: Option<Duration>) {
+    if let Some(duration) = duration {
+        time::sleep(duration).await;
+    } else {
+        future::pending::<()>().await;
+    }
 }
 
 /// Drains any pending shutdown notifications to avoid stale wakeups.
@@ -470,15 +396,18 @@ fn spawn_handler_task(
 ) -> tokio::task::JoinHandle<Duration> {
     let handler_key = metadata.key();
     let span_name = format!("{reader_name}_cdc_handler");
-    let counter_name = format!("{handler_key}-{reader_name}-cdc-handler-errors");
+    let started_counter_name = format!("{handler_key}-{reader_name}-cdc-handler-started");
+    let stopped_counter_name = format!("{handler_key}-{reader_name}-cdc-handler-stopped");
+    let errors_counter_name = format!("{handler_key}-{reader_name}-cdc-handler-errors");
 
     tokio::spawn(
         async move {
+            internals.increment_counter(started_counter_name).await;
             tokio::select! {
                 result = handler => {
                     if let Err(err) = result {
                         warn!("CDC handler error: {err}");
-                        internals.increment_counter(counter_name).await;
+                        internals.increment_counter(errors_counter_name).await;
                         cdc_error_notify.notify_one();
                     }
                 }
@@ -486,6 +415,7 @@ fn spawn_handler_task(
                     debug!("CDC handler: shutdown requested");
                 }
             }
+            internals.increment_counter(stopped_counter_name).await;
             debug!("CDC handler finished");
             cdc_now()
         }

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -536,22 +536,16 @@ impl Consumer for CdcConsumer {
             .transpose()?
             .flatten();
 
-        let primary_key = self
+        let Some(primary_key) = self
             .0
             .primary_key_columns
             .iter()
-            .map(|column| {
-                if !row.column_exists(column.as_ref()) {
-                    bail!("CDC error: primary key column {column} should exist");
-                }
-                if row.column_deletable(column.as_ref()) {
-                    bail!("CDC error: primary key column {column} should not be deletable");
-                }
-                row.take_value(column.as_ref()).ok_or(anyhow!(
-                    "CDC error: primary key column {column} value should exist"
-                ))
-            })
-            .collect::<anyhow::Result<_>>()?;
+            .map(|column| row.take_value(column.as_ref()))
+            .collect()
+        else {
+            // If any primary key column is missing skip this row.
+            return Ok(());
+        };
 
         const HUNDREDS_NANOS_TO_MICROS: u64 = 10;
         let timestamp = (self.0.gregorian_epoch

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -29,6 +29,7 @@ use scylla::value::CqlValue;
 use scylla_cdc::consumer::CDCRow;
 use scylla_cdc::consumer::Consumer;
 use scylla_cdc::consumer::ConsumerFactory;
+use scylla_cdc::consumer::OperationType;
 use scylla_cdc::log_reader::CDCLogReaderBuilder;
 use std::sync::Arc;
 use std::time::Duration;
@@ -530,11 +531,31 @@ impl Consumer for CdcConsumer {
         if !row.column_deletable(column) {
             bail!("CDC error: column {column} should be deletable");
         }
-        let value = row
-            .take_value(column)
-            .map(|v| extract_indexed_value(source, v, &self.0.kind))
-            .transpose()?
-            .flatten();
+
+        let value = match row.operation {
+            OperationType::PartitionDelete | OperationType::RowDelete => None,
+
+            OperationType::RowUpdate | OperationType::RowInsert | OperationType::PostImage => {
+                if row.is_value_deleted(column) {
+                    None
+                } else {
+                    let Some(value) = row.take_value(column) else {
+                        // If the column is not deleted but also has no value, skip this row.
+                        return Ok(());
+                    };
+                    extract_indexed_value(source, value, &self.0.kind)?
+                }
+            }
+
+            OperationType::PreImage
+            | OperationType::RowRangeDelInclLeft
+            | OperationType::RowRangeDelExclLeft
+            | OperationType::RowRangeDelInclRight
+            | OperationType::RowRangeDelExclRight => {
+                // These operations are unspported by our CDC reader, skip them.
+                return Ok(());
+            }
+        };
 
         let Some(primary_key) = self
             .0


### PR DESCRIPTION
This PR provides two commits for fixing unexpected CDC reader shutdown in production. The first fixes wrong assumption that all primary key columns in CDC Row must exists (for static columns it is not true). The second fixes limited CDC restart tries - it introduces unlimited restarts for both wide and fine CDC readers.

Fixes: VECTOR-693