### PR TITLE
vector-store: monitor CDC indexing lag for vector search index

### DIFF
--- a/crates/validator/src/cdc.rs
+++ b/crates/validator/src/cdc.rs
@@ -1027,3 +1027,83 @@ async fn reader_retries_after_error(actors: Arc<TestActors>) {
 
     info!("finished");
 }
+
+#[e2etest::test(group = cdc_direct)]
+async fn cdc_indexing_lag_metric_exported(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection_single_vs(&actors).await;
+    let client = clients.first().unwrap();
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    let status = wait_for_index(client, &index).await;
+    assert_eq!(status.count, 0, "Index should start empty");
+
+    // Insert after index creation - picked up by the CDC reader, which should
+    // record an indexing_lag_seconds observation.
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, v) VALUES (1, [1.0, 2.0, 3.0])"),
+            (),
+        )
+        .await
+        .expect("failed to insert data");
+
+    // Wait for the vector to be indexed (proves the CDC pipeline ran).
+    wait_for_value(
+        || async {
+            let result = get_opt_query_results(
+                format!("SELECT pk FROM {table} ORDER BY v ANN OF [1.0, 2.0, 3.0] LIMIT 1"),
+                &session,
+            )
+            .await?;
+            let mut rows = result.rows::<(i32,)>().ok()?;
+            let pk = rows.next()?.ok()?.0;
+            (pk == 1).then_some(pk)
+        },
+        "Waiting for ANN query after CDC insert",
+        FINE_GRAINED_CDC_MAX_LATENCY,
+    )
+    .await;
+
+    // Scrape the /metrics endpoint and verify indexing_lag_seconds is present
+    // with the expected labels and at least one observation.
+    let metrics_output = wait_for_value(
+        || async {
+            let output = client.get_metrics_text().await;
+            output
+                .contains("# TYPE indexing_lag_seconds histogram")
+                .then_some(output)
+        },
+        "Waiting for indexing_lag_seconds histogram in /metrics output",
+        FINE_GRAINED_CDC_MAX_LATENCY,
+    )
+    .await;
+    assert!(
+        metrics_output.contains(&format!(r#"keyspace="{}""#, keyspace.as_ref())),
+        "expected keyspace label in indexing_lag_seconds metric:\n{metrics_output}"
+    );
+    assert!(
+        metrics_output.contains(&format!(r#"index_name="{}""#, index.index.as_ref())),
+        "expected index_name label in indexing_lag_seconds metric:\n{metrics_output}"
+    );
+    // The _count suffix confirms at least one observation was recorded.
+    let expected_count_line = format!(
+        r#"indexing_lag_seconds_count{{index_name="{}",keyspace="{}"}}"#,
+        index.index.as_ref(),
+        keyspace.as_ref()
+    );
+    assert!(
+        metrics_output.contains(&expected_count_line),
+        "expected indexing_lag_seconds_count with labels in /metrics output:\n{metrics_output}"
+    );
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop keyspace");
+
+    info!("finished");
+}

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -256,12 +256,7 @@ fn wait_until_all_tasks_finished(runtime: &Runtime) {
 }
 
 fn scan_fn_mpsc(
-    mut items: mpsc::Receiver<(
-        PrimaryKey,
-        Option<Vector>,
-        Timestamp,
-        Option<AsyncInProgress>,
-    )>,
+    mut items: mpsc::Receiver<(PrimaryKey, Option<Vector>, Timestamp, AsyncInProgress)>,
 ) -> ScanFn {
     Box::new(move |tx| {
         async move {
@@ -347,7 +342,7 @@ fn fullscan_add(c: &mut Criterion) {
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
                                 Some(vec![it as f32; DIMENSIONS].into()),
                                 Timestamp::from_unix_timestamp(0),
-                                Some(tx_in_progress.into()),
+                                AsyncInProgress::Fullscan(tx_in_progress),
                             );
                             let start = Instant::now();
                             tx.send(request).await.unwrap();
@@ -417,7 +412,7 @@ fn search(c: &mut Criterion) {
                         [(CqlValue::BigInt(it))].into_iter().collect(),
                         Some(vec![it as f32; DIMENSIONS].into()),
                         Timestamp::from_unix_timestamp(0),
-                        Some(tx_in_progress.clone().into()),
+                        AsyncInProgress::Fullscan(tx_in_progress.clone()),
                     ))
                     .await
                     .unwrap();
@@ -552,7 +547,7 @@ fn cdc_add(c: &mut Criterion) {
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
                                 Some(vec![it as f32; DIMENSIONS].into()),
                                 Timestamp::from_unix_timestamp(0),
-                                Some(tx_in_progress.into()),
+                                AsyncInProgress::Fullscan(tx_in_progress),
                             );
                             let start = Instant::now();
                             tx.send(request).await.unwrap();
@@ -629,7 +624,7 @@ fn cdc_update(c: &mut Criterion) {
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
                             Timestamp::from_unix_timestamp(0),
-                            Some(tx_in_progress.clone().into()),
+                            AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
                         .unwrap();
@@ -677,7 +672,7 @@ fn cdc_update(c: &mut Criterion) {
                                     [(CqlValue::BigInt(id))].into_iter().collect(),
                                     Some(vector),
                                     Timestamp::from_unix_timestamp(timestamp),
-                                    Some(tx_in_progress.clone().into()),
+                                    AsyncInProgress::Fullscan(tx_in_progress.clone()),
                                 ))
                                 .await
                                 .unwrap();
@@ -780,7 +775,7 @@ fn search_while_updating(c: &mut Criterion) {
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
                             Timestamp::from_unix_timestamp(0),
-                            Some(tx_in_progress.clone().into()),
+                            AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
                         .unwrap();
@@ -789,7 +784,7 @@ fn search_while_updating(c: &mut Criterion) {
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
                             Timestamp::from_unix_timestamp(0),
-                            Some(tx_in_progress.clone().into()),
+                            AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
                         .unwrap();
@@ -822,7 +817,7 @@ fn search_while_updating(c: &mut Criterion) {
                                 [(CqlValue::BigInt(id))].into_iter().collect(),
                                 Some(vector),
                                 Timestamp::from_unix_timestamp(timestamp),
-                                Some(tx_in_progress.clone().into()),
+                                AsyncInProgress::Fullscan(tx_in_progress.clone()),
                             ))
                             .await
                             .is_err()
@@ -850,7 +845,7 @@ fn search_while_updating(c: &mut Criterion) {
                                     [(CqlValue::BigInt(id))].into_iter().collect(),
                                     Some(vector),
                                     Timestamp::from_unix_timestamp(timestamp),
-                                    Some(tx_in_progress.clone().into()),
+                                    AsyncInProgress::Fullscan(tx_in_progress.clone()),
                                 ))
                                 .await
                                 .is_err()
@@ -1012,7 +1007,7 @@ fn search_while_inserting(c: &mut Criterion) {
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
                                 Some(vector),
                                 timestamp,
-                                Some(tx_in_progress.clone().into()),
+                                AsyncInProgress::Fullscan(tx_in_progress.clone()),
                             ))
                             .await
                             .is_err()
@@ -1039,7 +1034,7 @@ fn search_while_inserting(c: &mut Criterion) {
                                     [(CqlValue::BigInt(pk))].into_iter().collect(),
                                     Some(vector),
                                     timestamp,
-                                    Some(tx_in_progress.clone().into()),
+                                    AsyncInProgress::Fullscan(tx_in_progress.clone()),
                                 ))
                                 .await
                                 .is_err()

--- a/crates/vector-store/src/async_in_progress.rs
+++ b/crates/vector-store/src/async_in_progress.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::Timestamp;
+use prometheus::Histogram;
+use tokio::sync::mpsc;
+
+pub struct CdcInProgress {
+    histogram: Histogram,
+    timestamp: Timestamp,
+}
+
+pub enum AsyncInProgress {
+    None,
+    Fullscan(mpsc::Sender<()>),
+    Cdc(Box<CdcInProgress>),
+}
+
+impl AsyncInProgress {
+    pub(crate) fn cdc(histogram: Histogram, timestamp: Timestamp) -> Self {
+        Self::Cdc(Box::new(CdcInProgress {
+            histogram,
+            timestamp,
+        }))
+    }
+
+    pub(crate) fn take(&mut self) -> Self {
+        std::mem::replace(self, AsyncInProgress::None)
+    }
+}
+
+impl Drop for AsyncInProgress {
+    fn drop(&mut self) {
+        if let AsyncInProgress::Cdc(cdc) = self {
+            cdc.histogram.observe(cdc.timestamp.elapsed().as_secs_f64());
+        }
+    }
+}

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -69,7 +69,7 @@ use uuid::Uuid;
 
 type GetDbIndexR = anyhow::Result<(
     mpsc::Sender<DbIndex>,
-    mpsc::Receiver<(DbIndexedRow, Option<AsyncInProgress>)>,
+    mpsc::Receiver<(DbIndexedRow, AsyncInProgress)>,
 )>;
 pub(crate) type LatestSchemaVersionR = anyhow::Result<Option<CqlTimeuuid>>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -118,7 +118,7 @@ pub(crate) fn new(
     mut session_rx: watch::Receiver<Option<Arc<Session>>>,
     metadata: IndexMetadata,
     internals: Sender<Internals>,
-    tx_embeddings: mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+    tx_embeddings: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     config: CdcReaderConfig,
 ) -> mpsc::Sender<DbCdc> {
     let (tx, mut rx) = mpsc::channel::<DbCdc>(perf::channel_size().into());
@@ -234,7 +234,7 @@ impl CdcReaderState {
         params: CdcReaderParams,
         session: &Arc<Session>,
         metadata: &IndexMetadata,
-        tx_embeddings: &mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+        tx_embeddings: &mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
         internals: &Sender<Internals>,
     ) {
         self.stop().await;
@@ -282,7 +282,7 @@ impl CdcReaderState {
         session: Option<Arc<Session>>,
         config_rx: &watch::Receiver<Arc<Config>>,
         metadata: &IndexMetadata,
-        tx_embeddings: &mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+        tx_embeddings: &mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
         internals: &Sender<Internals>,
     ) {
         match session {
@@ -318,7 +318,7 @@ impl CdcReaderState {
         session_rx: &watch::Receiver<Option<Arc<Session>>>,
         config_rx: &watch::Receiver<Arc<Config>>,
         metadata: &IndexMetadata,
-        tx_embeddings: &mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+        tx_embeddings: &mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
         internals: &Sender<Internals>,
     ) {
         let session = session_rx.borrow().clone();
@@ -357,7 +357,7 @@ async fn create_cdc_reader(
     params: CdcReaderParams,
     session: Arc<Session>,
     metadata: IndexMetadata,
-    tx_embeddings: mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+    tx_embeddings: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     reader_name: &str,
 ) -> anyhow::Result<(
     scylla_cdc::log_reader::CDCLogReader,
@@ -442,7 +442,7 @@ struct CdcConsumerData {
     primary_key_columns: Vec<ColumnName>,
     backend: DbIndexBackend,
     kind: IndexKind,
-    tx: mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+    tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     gregorian_epoch: PrimitiveDateTime,
 }
 
@@ -519,7 +519,7 @@ impl Consumer for CdcConsumer {
                     value,
                     timestamp,
                 },
-                None,
+                AsyncInProgress::None,
             ))
             .await;
         Ok(())
@@ -539,7 +539,7 @@ impl CdcConsumerFactory {
     fn new(
         session: Arc<Session>,
         metadata: &IndexMetadata,
-        tx: mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+        tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     ) -> anyhow::Result<Self> {
         let cluster_state = session.get_cluster_state();
         let table = cluster_state

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -154,7 +154,7 @@ pub(crate) async fn new(
     cdc_error_notify: Arc<Notify>,
 ) -> anyhow::Result<(
     mpsc::Sender<DbIndex>,
-    mpsc::Receiver<(DbIndexedRow, Option<AsyncInProgress>)>,
+    mpsc::Receiver<(DbIndexedRow, AsyncInProgress)>,
 )> {
     let key = metadata.key();
 
@@ -438,7 +438,7 @@ impl Statements {
     /// to send read embeddings into the pipeline.
     async fn initial_scan(
         &self,
-        tx: mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>,
+        tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
         completed_scan_length: Arc<AtomicU64>,
     ) {
         let semaphore_capacity = self.nr_parallel_queries().get();
@@ -459,7 +459,7 @@ impl Statements {
                             let tx_in_progress = tx_in_progress.clone();
                             async move {
                                 _ = tx
-                                    .send((embedding, Some(AsyncInProgress(tx_in_progress))))
+                                    .send((embedding, AsyncInProgress::Fullscan(tx_in_progress)))
                                     .await;
                             }
                         })

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -279,7 +279,7 @@ async fn add_index(
 struct AddIndexContext<'a> {
     key: IndexKey,
     table: Arc<RwLock<Table>>,
-    embeddings_stream: mpsc::Receiver<(crate::DbIndexedRow, Option<crate::AsyncInProgress>)>,
+    embeddings_stream: mpsc::Receiver<(crate::DbIndexedRow, crate::AsyncInProgress)>,
     metrics: Arc<Metrics>,
     db_index: mpsc::Sender<DbIndex>,
     indexes: &'a RwLock<Indexes>,

--- a/crates/vector-store/src/fts_index/actor.rs
+++ b/crates/vector-store/src/fts_index/actor.rs
@@ -19,11 +19,11 @@ pub(crate) enum FtsIndex {
     AddDocument {
         primary_id: PrimaryId,
         document: String,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     },
     RemoveDocument {
         primary_id: PrimaryId,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     },
     Count {
         index_key: IndexKey,
@@ -43,9 +43,9 @@ pub(crate) trait FtsIndexExt {
         &self,
         primary_id: PrimaryId,
         document: String,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     );
-    async fn remove_document(&self, primary_id: PrimaryId, in_progress: Option<AsyncInProgress>);
+    async fn remove_document(&self, primary_id: PrimaryId, in_progress: AsyncInProgress);
     async fn count(&self, index_key: IndexKey) -> CountR;
     async fn search(&self, index_key: IndexKey, query: String, limit: Limit) -> FtsSearchR;
 }
@@ -55,7 +55,7 @@ impl FtsIndexExt for mpsc::Sender<FtsIndex> {
         &self,
         primary_id: PrimaryId,
         document: String,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) {
         self.send(FtsIndex::AddDocument {
             primary_id,
@@ -66,7 +66,7 @@ impl FtsIndexExt for mpsc::Sender<FtsIndex> {
         .expect("internal actor should receive request");
     }
 
-    async fn remove_document(&self, primary_id: PrimaryId, in_progress: Option<AsyncInProgress>) {
+    async fn remove_document(&self, primary_id: PrimaryId, in_progress: AsyncInProgress) {
         self.send(FtsIndex::RemoveDocument {
             primary_id,
             in_progress,

--- a/crates/vector-store/src/fts_index/tantivy.rs
+++ b/crates/vector-store/src/fts_index/tantivy.rs
@@ -347,6 +347,7 @@ pub(crate) fn new(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::AsyncInProgress;
     use crate::IndexKey;
     use crate::PrimaryKey;
     use crate::table::IndexIdGenerator;
@@ -400,7 +401,11 @@ mod tests {
     async fn add_doc(sender: &mpsc::Sender<FtsIndex>, primary: u64, content: &str) {
         let (tx, mut rx) = mpsc::channel(1);
         sender
-            .add_document(primary.into(), content.into(), Some(tx.into()))
+            .add_document(
+                primary.into(),
+                content.into(),
+                AsyncInProgress::Fullscan(tx),
+            )
             .await;
         rx.recv().await;
     }
@@ -408,7 +413,7 @@ mod tests {
     async fn rm_doc(sender: &mpsc::Sender<FtsIndex>, primary: u64) {
         let (tx, mut rx) = mpsc::channel(1);
         sender
-            .remove_document(primary.into(), Some(tx.into()))
+            .remove_document(primary.into(), AsyncInProgress::Fullscan(tx))
             .await;
         rx.recv().await;
     }

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod async_in_progress;
 mod config_manager;
 pub mod db;
 mod db_cdc;
@@ -72,7 +73,6 @@ use std::sync::RwLock;
 use std::time::Duration;
 use tokio::runtime::Builder;
 use tokio::signal;
-use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 use utoipa::openapi::OpenApi;
@@ -662,10 +662,7 @@ pub struct DbIndexedRow {
     pub timestamp: Timestamp,
 }
 
-#[derive(Clone, derive_more::From)]
-/// Marker struct to indicate that an async operation is in progress.
-#[allow(dead_code)]
-pub struct AsyncInProgress(mpsc::Sender<()>);
+pub use async_in_progress::AsyncInProgress;
 
 pub fn block_on<Output>(threads: Option<usize>, f: impl AsyncFnOnce() -> Output) -> Output {
     let mut builder = match threads {

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -20,6 +20,7 @@ pub struct Metrics {
     pub latency: HistogramVec,
     pub size: GaugeVec,
     pub modified: CounterVec,
+    pub indexing_lag: HistogramVec,
     dirty_indexes: Arc<DashSet<(String, String)>>,
 }
 
@@ -69,18 +70,49 @@ impl Metrics {
         )
         .unwrap();
 
+        // Custom buckets spanning the realtime (sub-second) and consistent
+        // (tens of seconds) CDC reader regimes, up to a few minutes to surface
+        // stalled indexing.
+        let lag_buckets = vec![
+            0.05,  // 50 ms
+            0.1,   // 0.1 second
+            0.25,  // 0.25 seconds
+            0.5,   // 0.5 seconds
+            1.0,   // 1 second
+            2.5,   // 2.5 seconds
+            5.0,   // 5 seconds
+            10.0,  // 10 seconds
+            30.0,  // 30 seconds
+            60.0,  // 1 minute
+            120.0, // 2 minutes
+            300.0, // 5 minutes
+        ];
+
+        let indexing_lag = HistogramVec::new(
+            prometheus::HistogramOpts::new(
+                "indexing_lag_seconds",
+                "Time in seconds between a CDC-recorded change in ScyllaDB and its indexing in the vector store",
+            )
+            .buckets(lag_buckets),
+            &["keyspace", "index_name"],
+        )
+        .unwrap();
+
         registry.register(Box::new(latency.clone())).unwrap();
         registry.register(Box::new(size.clone())).unwrap();
         registry.register(Box::new(modified.clone())).unwrap();
+        registry.register(Box::new(indexing_lag.clone())).unwrap();
 
         Self {
             registry,
             latency,
             size,
             modified,
+            indexing_lag,
             dirty_indexes: Arc::new(DashSet::new()),
         }
     }
+
     pub fn mark_dirty(&self, keyspace: &str, index_name: &str) {
         self.dirty_indexes
             .insert((keyspace.to_owned(), index_name.to_owned()));

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -217,4 +217,53 @@ mod tests {
         metrics.remove_index_labels("ks", "idx");
         assert!(metrics.dirty_indexes.is_empty());
     }
+
+    #[test]
+    fn indexing_lag_is_observed_and_exported() {
+        use crate::AsyncInProgress;
+        use crate::Timestamp;
+
+        let metrics = Metrics::new();
+
+        // Create and immediately drop a Cdc marker to trigger observation.
+        let histogram = metrics.indexing_lag.with_label_values(&["ks", "idx"]);
+        drop(AsyncInProgress::cdc(
+            histogram.clone(),
+            Timestamp::from_unix_timestamp(0),
+        ));
+
+        assert_eq!(histogram.get_sample_count(), 1);
+        assert!(histogram.get_sample_sum() > 0.0);
+
+        // The metric must be exported through the same registry the `/metrics`
+        // endpoint scrapes, with the expected name, type, and labels.
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains("# TYPE indexing_lag_seconds histogram"),
+            "indexing_lag_seconds histogram missing from export:\n{output}"
+        );
+        assert!(
+            output.contains(r#"keyspace="ks""#) && output.contains(r#"index_name="idx""#),
+            "expected keyspace/index_name labels in export:\n{output}"
+        );
+        assert!(
+            output.contains(r#"indexing_lag_seconds_count{index_name="idx",keyspace="ks"} 1"#),
+            "expected a single observed sample in export:\n{output}"
+        );
+    }
+
+    #[test]
+    fn indexing_lag_not_exported_until_observed() {
+        let metrics = Metrics::new();
+
+        // A histogram with no observations is still registered, but reports a
+        // zero sample count for any label set.
+        assert_eq!(
+            metrics
+                .indexing_lag
+                .with_label_values(&["ks", "idx"])
+                .get_sample_count(),
+            0
+        );
+    }
 }

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -37,14 +37,14 @@ pub(crate) trait IndexDispatch {
         partition_id: PartitionId,
         primary_id: PrimaryId,
         value: DbIndexedValue,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) -> impl Future<Output = ()> + Send;
 
     fn remove_value(
         &self,
         partition_id: PartitionId,
         primary_id: PrimaryId,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) -> impl Future<Output = ()> + Send;
 
     fn remove_partition(&self, partition_id: PartitionId) -> impl Future<Output = ()> + Send;
@@ -56,7 +56,7 @@ impl IndexDispatch for mpsc::Sender<VsIndex> {
         partition_id: PartitionId,
         primary_id: PrimaryId,
         value: DbIndexedValue,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) {
         match value {
             DbIndexedValue::Vector(vector) => {
@@ -73,7 +73,7 @@ impl IndexDispatch for mpsc::Sender<VsIndex> {
         &self,
         partition_id: PartitionId,
         primary_id: PrimaryId,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) {
         self.remove_vector(partition_id, primary_id, in_progress)
             .await;
@@ -90,7 +90,7 @@ impl IndexDispatch for mpsc::Sender<FtsIndex> {
         _partition_id: PartitionId,
         primary_id: PrimaryId,
         value: DbIndexedValue,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) {
         match value {
             DbIndexedValue::Document(document) => {
@@ -106,7 +106,7 @@ impl IndexDispatch for mpsc::Sender<FtsIndex> {
         &self,
         _partition_id: PartitionId,
         primary_id: PrimaryId,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) {
         self.remove_document(primary_id, in_progress).await;
     }
@@ -119,7 +119,7 @@ pub(crate) enum MonitorItems {}
 pub(crate) async fn new<T>(
     key: IndexKey,
     table: Arc<RwLock<impl TableAdd + Send + Sync + 'static>>,
-    mut embeddings: Receiver<(DbIndexedRow, Option<AsyncInProgress>)>,
+    mut embeddings: Receiver<(DbIndexedRow, AsyncInProgress)>,
     index: mpsc::Sender<T>,
     metrics: Arc<Metrics>,
 ) -> anyhow::Result<Sender<MonitorItems>>
@@ -157,10 +157,22 @@ async fn add<I: IndexDispatch>(
     table: &Arc<RwLock<impl TableAdd>>,
     index: &I,
     embedding: DbIndexedRow,
-    mut in_progress: Option<AsyncInProgress>,
+    mut in_progress: AsyncInProgress,
     metrics: &Metrics,
     key: &IndexKey,
 ) {
+    // Rows arriving without a progress marker come from CDC. Wrap them in a
+    // Cdc marker so that the indexing-lag metric is observed when the marker
+    // is dropped (i.e. when the index actor finishes processing the row).
+    if matches!(in_progress, AsyncInProgress::None) {
+        in_progress = AsyncInProgress::cdc(
+            metrics
+                .indexing_lag
+                .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref()]),
+            embedding.timestamp,
+        );
+    }
+
     let Ok(operations) = table
         .write()
         .unwrap()
@@ -193,7 +205,9 @@ async fn add<I: IndexDispatch>(
                 primary_id,
                 partition_id,
             } => {
-                index.remove_value(partition_id, primary_id, None).await;
+                index
+                    .remove_value(partition_id, primary_id, AsyncInProgress::None)
+                    .await;
             }
             Operation::RemoveValue {
                 primary_id,
@@ -253,6 +267,13 @@ mod tests {
         );
     }
 
+    fn indexing_lag_sample_count(metrics: &Metrics) -> u64 {
+        metrics
+            .indexing_lag
+            .with_label_values(&["vector", "store"])
+            .get_sample_count()
+    }
+
     #[tokio::test]
     async fn do_nothing_on_error() {
         let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
@@ -282,7 +303,10 @@ mod tests {
             .with(eq(index_key), eq(embedding.clone()))
             .once()
             .returning(|_, _| Err(anyhow!("some error")));
-        tx_embeddings.send((embedding, None)).await.unwrap();
+        tx_embeddings
+            .send((embedding, AsyncInProgress::None))
+            .await
+            .unwrap();
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());
@@ -326,7 +350,7 @@ mod tests {
                 }])
             });
         tx_embeddings
-            .send((embedding, Some(AsyncInProgress(tx_progress))))
+            .send((embedding, AsyncInProgress::Fullscan(tx_progress)))
             .await
             .unwrap();
         let VsIndex::AddVector {
@@ -341,11 +365,16 @@ mod tests {
         assert_eq!(primary_id, 2.into());
         assert_eq!(partition_id, 3.into());
         assert_eq!(embedding, vec![4.].into());
-        assert!(in_progress.is_some());
+        assert!(matches!(in_progress, AsyncInProgress::Fullscan(_)));
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 1., 0., 0.);
+        assert_eq!(
+            indexing_lag_sample_count(&metrics),
+            0,
+            "full-scan rows must not record indexing lag"
+        );
     }
 
     #[tokio::test]
@@ -384,7 +413,10 @@ mod tests {
                     is_update: false,
                 }])
             });
-        tx_embeddings.send((embedding, None)).await.unwrap();
+        tx_embeddings
+            .send((embedding, AsyncInProgress::None))
+            .await
+            .unwrap();
         let Some(VsIndex::AddVector {
             partition_id,
             primary_id,
@@ -397,11 +429,17 @@ mod tests {
         assert_eq!(primary_id, 2.into());
         assert_eq!(partition_id, 3.into());
         assert_eq!(embedding, vec![4.].into());
-        assert!(in_progress.is_none());
+        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
+        drop(in_progress);
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 1., 0., 0.);
+        assert_eq!(
+            indexing_lag_sample_count(&metrics),
+            1,
+            "CDC rows must record indexing lag"
+        );
     }
 
     #[tokio::test]
@@ -446,12 +484,15 @@ mod tests {
                     },
                 ])
             });
-        tx_embeddings.send((embedding, None)).await.unwrap();
+        tx_embeddings
+            .send((embedding, AsyncInProgress::None))
+            .await
+            .unwrap();
 
         let Some(VsIndex::RemoveVector {
             partition_id,
             primary_id,
-            in_progress: None,
+            in_progress: AsyncInProgress::None,
         }) = rx_index.recv().await
         else {
             unreachable!();
@@ -463,7 +504,7 @@ mod tests {
             partition_id,
             primary_id,
             embedding,
-            in_progress: None,
+            in_progress,
         }) = rx_index.recv().await
         else {
             unreachable!();
@@ -471,6 +512,7 @@ mod tests {
         assert_eq!(primary_id, 3.into());
         assert_eq!(partition_id, 3.into());
         assert_eq!(embedding, vec![4.].into());
+        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());
@@ -527,7 +569,10 @@ mod tests {
                     },
                 ])
             });
-        tx_embeddings.send((embedding, None)).await.unwrap();
+        tx_embeddings
+            .send((embedding, AsyncInProgress::None))
+            .await
+            .unwrap();
 
         // First: plain insert
         let Some(VsIndex::AddVector {
@@ -542,13 +587,13 @@ mod tests {
         assert_eq!(primary_id, 1.into());
         assert_eq!(partition_id, 2.into());
         assert_eq!(embedding, vec![10.].into());
-        assert!(in_progress.is_none());
+        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
 
         // Second: remove half of the update
         let Some(VsIndex::RemoveVector {
             partition_id,
             primary_id,
-            in_progress: None,
+            in_progress: AsyncInProgress::None,
         }) = rx_index.recv().await
         else {
             unreachable!();
@@ -561,7 +606,7 @@ mod tests {
             partition_id,
             primary_id,
             embedding,
-            in_progress: None,
+            in_progress: AsyncInProgress::None,
         }) = rx_index.recv().await
         else {
             unreachable!();
@@ -609,18 +654,22 @@ mod tests {
                     partition_id: 6.into(),
                 }])
             });
-        tx_embeddings.send((embedding, None)).await.unwrap();
+        tx_embeddings
+            .send((embedding, AsyncInProgress::None))
+            .await
+            .unwrap();
 
         let Some(VsIndex::RemoveVector {
             partition_id,
             primary_id,
-            in_progress: None,
+            in_progress,
         }) = rx_index.recv().await
         else {
             unreachable!();
         };
         assert_eq!(primary_id, 5.into());
         assert_eq!(partition_id, 6.into());
+        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());
@@ -660,7 +709,10 @@ mod tests {
                     partition_id: 6.into(),
                 }])
             });
-        tx_embeddings.send((embedding, None)).await.unwrap();
+        tx_embeddings
+            .send((embedding, AsyncInProgress::None))
+            .await
+            .unwrap();
 
         let Some(VsIndex::RemovePartition { partition_id }) = rx_index.recv().await else {
             unreachable!();

--- a/crates/vector-store/src/timestamp.rs
+++ b/crates/vector-store/src/timestamp.rs
@@ -6,6 +6,7 @@
 use std::ops::Add;
 use std::time::Duration;
 use time::Date;
+use time::OffsetDateTime;
 use time::PrimitiveDateTime;
 use time::Time;
 
@@ -24,6 +25,20 @@ impl Timestamp {
     pub fn from_unix_timestamp(timestamp: u64) -> Self {
         Self::UNIX_EPOCH + Duration::from_secs(timestamp)
     }
+
+    /// Returns the current time in UTC.
+    pub fn now() -> Self {
+        let now = OffsetDateTime::now_utc();
+        Timestamp(PrimitiveDateTime::new(now.date(), now.time()))
+    }
+
+    /// Returns the amount of time elapsed from this timestamp until now.
+    ///
+    /// Returns [`Duration::ZERO`] when this timestamp lies in the future, which
+    /// can happen due to clock skew between ScyllaDB and the vector store.
+    pub fn elapsed(&self) -> Duration {
+        Duration::try_from(Self::now().0 - self.0).unwrap_or(Duration::ZERO)
+    }
 }
 
 impl Add<Duration> for Timestamp {
@@ -31,5 +46,22 @@ impl Add<Duration> for Timestamp {
 
     fn add(self, rhs: Duration) -> Self::Output {
         Timestamp(self.0 + rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elapsed_is_zero_for_future_timestamp() {
+        let future = Timestamp::now() + Duration::from_secs(3600);
+        assert_eq!(future.elapsed(), Duration::ZERO);
+    }
+
+    #[test]
+    fn elapsed_is_positive_for_past_timestamp() {
+        let past = Timestamp::from_unix_timestamp(0);
+        assert!(past.elapsed() > Duration::ZERO);
     }
 }

--- a/crates/vector-store/src/vs_index/actor.rs
+++ b/crates/vector-store/src/vs_index/actor.rs
@@ -22,12 +22,12 @@ pub enum VsIndex {
         partition_id: PartitionId,
         primary_id: PrimaryId,
         embedding: Vector,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     },
     RemoveVector {
         partition_id: PartitionId,
         primary_id: PrimaryId,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     },
     RemovePartition {
         partition_id: PartitionId,
@@ -57,13 +57,13 @@ pub(crate) trait VsIndexExt {
         partition_id: PartitionId,
         primary_id: PrimaryId,
         embedding: Vector,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     );
     async fn remove_vector(
         &self,
         partition_id: PartitionId,
         primary_id: PrimaryId,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     );
     async fn remove_partition(&self, partition_id: PartitionId);
     async fn ann(&self, index_key: IndexKey, embedding: Vector, limit: Limit) -> AnnR;
@@ -84,7 +84,7 @@ impl VsIndexExt for mpsc::Sender<VsIndex> {
         partition_id: PartitionId,
         primary_id: PrimaryId,
         embedding: Vector,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) {
         self.send(VsIndex::AddVector {
             partition_id,
@@ -101,7 +101,7 @@ impl VsIndexExt for mpsc::Sender<VsIndex> {
         &self,
         partition_id: PartitionId,
         primary_id: PrimaryId,
-        in_progress: Option<AsyncInProgress>,
+        in_progress: AsyncInProgress,
     ) {
         self.send(VsIndex::RemoveVector {
             partition_id,

--- a/crates/vector-store/src/vs_index/usearch.rs
+++ b/crates/vector-store/src/vs_index/usearch.rs
@@ -1199,6 +1199,7 @@ fn f32_to_b1x8(f32_vec: &[f32]) -> Vec<b1x8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::AsyncInProgress;
     use crate::Config;
     use crate::IndexKey;
     use crate::memory;
@@ -1233,7 +1234,7 @@ mod tests {
                             partition_id,
                             id.into(),
                             vec![0.0f32; dimensions.get()].into(),
-                            None,
+                            AsyncInProgress::None,
                         )
                         .await;
                 }
@@ -1295,13 +1296,28 @@ mod tests {
         let index_id = IndexIdGenerator::new().next(true).unwrap();
         let partition_id = PartitionId::global(index_id);
         actor
-            .add_vector(partition_id, 1.into(), vec![1., 1., 1.].into(), None)
+            .add_vector(
+                partition_id,
+                1.into(),
+                vec![1., 1., 1.].into(),
+                AsyncInProgress::None,
+            )
             .await;
         actor
-            .add_vector(partition_id, 2.into(), vec![2., -2., 2.].into(), None)
+            .add_vector(
+                partition_id,
+                2.into(),
+                vec![2., -2., 2.].into(),
+                AsyncInProgress::None,
+            )
             .await;
         actor
-            .add_vector(partition_id, 3.into(), vec![3., 3., 3.].into(), None)
+            .add_vector(
+                partition_id,
+                3.into(),
+                vec![3., 3., 3.].into(),
+                AsyncInProgress::None,
+            )
             .await;
 
         table
@@ -1347,9 +1363,16 @@ mod tests {
         assert_eq!(distances.len(), 1);
         assert_eq!(primary_keys.first().unwrap(), &[CqlValue::Int(2)].into());
 
-        actor.remove_vector(partition_id, 3.into(), None).await;
         actor
-            .add_vector(partition_id, 3.into(), vec![2.1, -2.1, 2.1].into(), None)
+            .remove_vector(partition_id, 3.into(), AsyncInProgress::None)
+            .await;
+        actor
+            .add_vector(
+                partition_id,
+                3.into(),
+                vec![2.1, -2.1, 2.1].into(),
+                AsyncInProgress::None,
+            )
             .await;
 
         table
@@ -1380,7 +1403,9 @@ mod tests {
         .await
         .unwrap();
 
-        actor.remove_vector(partition_id, 3.into(), None).await;
+        actor
+            .remove_vector(partition_id, 3.into(), AsyncInProgress::None)
+            .await;
 
         time::timeout(Duration::from_secs(10), async {
             while actor.count(index_key.clone()).await.unwrap() != 2 {
@@ -1444,7 +1469,12 @@ mod tests {
         let index_id = IndexIdGenerator::new().next(true).unwrap();
         let partition_id = PartitionId::global(index_id);
         actor
-            .add_vector(partition_id, 1.into(), vec![1., 1., 1.].into(), None)
+            .add_vector(
+                partition_id,
+                1.into(),
+                vec![1., 1., 1.].into(),
+                AsyncInProgress::None,
+            )
             .await;
 
         table
@@ -1458,7 +1488,12 @@ mod tests {
 
         allocate_tx.send(Allocate::Can).unwrap();
         actor
-            .add_vector(partition_id, 1.into(), vec![1., 1., 1.].into(), None)
+            .add_vector(
+                partition_id,
+                1.into(),
+                vec![1., 1., 1.].into(),
+                AsyncInProgress::None,
+            )
             .await;
 
         // Wait for the add operation to complete, as it runs in a separate task.

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -40,8 +40,8 @@ use vector_store::db_index::DbIndex;
 use vector_store::node_state::Event;
 use vector_store::node_state::NodeState;
 
-pub(crate) type RxIndexedRow = mpsc::Receiver<(DbIndexedRow, Option<AsyncInProgress>)>;
-pub(crate) type TxIndexedRow = mpsc::Sender<(DbIndexedRow, Option<AsyncInProgress>)>;
+pub(crate) type RxIndexedRow = mpsc::Receiver<(DbIndexedRow, AsyncInProgress)>;
+pub(crate) type TxIndexedRow = mpsc::Sender<(DbIndexedRow, AsyncInProgress)>;
 pub(crate) type ScanFn = Box<dyn FnOnce(TxIndexedRow) -> BoxFuture<'static, ()> + Send + Sync>;
 
 fn make_scan_fn(rows: impl Iterator<Item = DbIndexedRow> + Send + Sync + 'static) -> ScanFn {
@@ -50,7 +50,9 @@ fn make_scan_fn(rows: impl Iterator<Item = DbIndexedRow> + Send + Sync + 'static
             let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
 
             for row in rows {
-                let _ = tx.send((row, Some(tx_in_progress.clone().into()))).await;
+                let _ = tx
+                    .send((row, AsyncInProgress::Fullscan(tx_in_progress.clone())))
+                    .await;
             }
 
             drop(tx_in_progress);

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::info;
 use uuid::Uuid;
+use vector_store::AsyncInProgress;
 use vector_store::Config;
 use vector_store::Connectivity;
 use vector_store::DbIndexPartitioning;
@@ -98,7 +99,7 @@ async fn memory_limit_during_index_build() {
                                 value: Some(DbIndexedValue::Vector(item)),
                                 timestamp: Timestamp::from_unix_timestamp(10),
                             },
-                            Some(tx_in_progress.clone().into()),
+                            AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
                         .unwrap();


### PR DESCRIPTION
Add an `indexing_lag_seconds` histogram metric that records the time
between when a change was written in ScyllaDB (its CDC writetime) and
when it is indexed in the vector store. The lag is observed per indexed
value, labelled by keyspace and index name.

Only CDC-driven changes are measured: rows replayed during the initial
full scan carry an in-progress marker, so they are excluded.

Fixes: VECTOR-684