### PR TITLE
docs: add minimal Alternator vector search Python examples

### DIFF
--- a/docs/examples/alternator/README.md
+++ b/docs/examples/alternator/README.md
@@ -1,0 +1,46 @@
+# Vector search with ScyllaDB Alternator (Python)
+
+Minimal Python examples that mirror [`../quick-start.cql`](../quick-start.cql)
+using the DynamoDB-compatible
+[Alternator](https://docs.scylladb.com/stable/alternator/) API and the
+[`alternator-client`](https://github.com/scylladb/alternator-client-python)
+load-balancing driver.
+
+Each script creates a `comments` table, inserts two rows, builds a vector
+index over them, then prints the comment whose vector is most similar to the
+query vector.
+
+| Example | Vector data type | ScyllaDB image |
+| --- | --- | --- |
+| [`list_of_numbers.py`](list_of_numbers.py) | standard list of numbers | `scylladb/scylla:2026.2.0-rc3` |
+| [`native_vector.py`](native_vector.py) | native `Vector` type | `scylladb/scylla-nightly:2026.3` |
+
+ScyllaDB 2026.3 adds the native `Vector` type, which is more compact, along
+with a configurable similarity function and similarity scores.
+
+## Run
+
+1. Start single-node ScyllaDB (with Alternator) and Vector Store. Set the
+   `scylla` image in
+   [`../docker/docker-compose-alternator.yml`](../docker/docker-compose-alternator.yml)
+   to the version listed above for the example you want to run, then:
+
+   ```bash
+   docker compose -f ../docker/docker-compose-alternator.yml up -d
+   ```
+
+2. Create a virtual environment and install the driver:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+3. Run an example:
+
+   ```bash
+   python3 list_of_numbers.py
+   # or
+   python3 native_vector.py
+   ```

--- a/docs/examples/alternator/list_of_numbers.py
+++ b/docs/examples/alternator/list_of_numbers.py
@@ -1,0 +1,93 @@
+"""Minimal vector search example using ScyllaDB Alternator (DynamoDB API).
+
+Stores embeddings as a plain list of numbers and finds the most similar one.
+Mirrors ../quick-start.cql and works with ScyllaDB 2026.2.0 or later.
+"""
+
+import time
+from decimal import Decimal
+
+from alternator import AlternatorConfig, AlternatorResource
+
+
+def main():
+    config = AlternatorConfig(seed_hosts=["127.0.0.1"], port=8000)
+    with AlternatorResource(config) as resource:
+        client = resource.meta.client
+        table = resource.Table("comments")
+
+        # Start from a clean table so the example can be re-run.
+        try:
+            table.delete()
+            table.wait_until_not_exists()
+        except client.exceptions.ResourceNotFoundException:
+            pass
+
+        resource.create_table(
+            TableName="comments",
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        table.wait_until_exists()
+
+        # The DynamoDB resource API represents numbers as Decimal.
+        first_vector = [Decimal(str(x)) for x in (0.12, 0.34, 0.56, 0.78, 0.91)]
+        second_vector = [Decimal(str(x)) for x in (0.11, 0.35, 0.55, 0.77, 0.92)]
+        table.put_item(
+            Item={
+                "id": "1",
+                "comment": "I like vector search!",
+                "comment_vector": first_vector,
+            }
+        )
+        table.put_item(
+            Item={
+                "id": "2",
+                "comment": "ScyllaDB is great!",
+                "comment_vector": second_vector,
+            }
+        )
+
+        # Build the vector index. Once the build reaches ACTIVE, every row that
+        # existed when it started is indexed; rows inserted afterwards are picked
+        # up asynchronously (eventual consistency). We insert first and wait for
+        # ACTIVE so the query below deterministically sees all the data.
+        client.update_table(
+            TableName="comments",
+            VectorIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "comment_ann_index",
+                        "VectorAttribute": {
+                            "AttributeName": "comment_vector",
+                            "Dimensions": 5,
+                        },
+                    }
+                }
+            ],
+        )
+
+        # Wait for the vector index to finish building.
+        while True:
+            indexes = client.describe_table(TableName="comments")["Table"].get(
+                "VectorIndexes", []
+            )
+            if indexes and indexes[0]["IndexStatus"] == "ACTIVE":
+                break
+            time.sleep(1)
+
+        # The index projects only the key, so query for the nearest id and then
+        # read the full item to get its text.
+        response = table.query(
+            IndexName="comment_ann_index",
+            VectorSearch={"QueryVector": first_vector},
+            Limit=1,
+        )
+        nearest_id = response["Items"][0]["id"]
+        item = table.get_item(Key={"id": nearest_id})["Item"]
+        print(item["comment"])
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/alternator/native_vector.py
+++ b/docs/examples/alternator/native_vector.py
@@ -1,0 +1,98 @@
+"""Minimal vector search example using ScyllaDB Alternator (DynamoDB API).
+
+Stores embeddings with the native Vector type, which is more compact and
+enables a configurable similarity function and similarity scores. Mirrors
+../quick-start.cql and requires ScyllaDB 2026.3.0-dev or later.
+"""
+
+import time
+
+from alternator import AlternatorConfig, AlternatorResource
+from alternator.vector import Vector
+
+
+def main():
+    config = AlternatorConfig(seed_hosts=["127.0.0.1"], port=8000)
+    with AlternatorResource(config) as resource:
+        client = resource.meta.client
+        table = resource.Table("comments")
+
+        # Start from a clean table so the example can be re-run.
+        try:
+            table.delete()
+            table.wait_until_not_exists()
+        except client.exceptions.ResourceNotFoundException:
+            pass
+
+        resource.create_table(
+            TableName="comments",
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        table.wait_until_exists()
+
+        # The native Vector type accepts plain floats directly.
+        table.put_item(
+            Item={
+                "id": "1",
+                "comment": "I like vector search!",
+                "comment_vector": Vector([0.12, 0.34, 0.56, 0.78, 0.91]),
+            }
+        )
+        table.put_item(
+            Item={
+                "id": "2",
+                "comment": "ScyllaDB is great!",
+                "comment_vector": Vector([0.11, 0.35, 0.55, 0.77, 0.92]),
+            }
+        )
+
+        # Build the vector index, choosing the similarity function used to
+        # compare vectors. Once the build reaches ACTIVE, every row that existed
+        # when it started is indexed; rows inserted afterwards are picked up
+        # asynchronously (eventual consistency). We insert first and wait for
+        # ACTIVE so the query below deterministically sees all the data.
+        client.update_table(
+            TableName="comments",
+            VectorIndexUpdates=[
+                {
+                    "Create": {
+                        "IndexName": "comment_ann_index",
+                        "VectorAttribute": {
+                            "AttributeName": "comment_vector",
+                            "Dimensions": 5,
+                        },
+                        "SimilarityFunction": "COSINE",
+                    }
+                }
+            ],
+        )
+
+        # Wait for the vector index to finish building.
+        while True:
+            indexes = client.describe_table(TableName="comments")["Table"].get(
+                "VectorIndexes", []
+            )
+            if indexes and indexes[0]["IndexStatus"] == "ACTIVE":
+                break
+            time.sleep(1)
+
+        # Query for the nearest comment and its similarity score. The index
+        # projects only the key, so read the full item to get its text.
+        response = table.query(
+            IndexName="comment_ann_index",
+            VectorSearch={
+                "QueryVector": Vector([0.12, 0.34, 0.56, 0.78, 0.91]),
+                "ReturnScores": "SIMILARITY",
+            },
+            Limit=1,
+        )
+        nearest_id = response["Items"][0]["id"]
+        score = response["Scores"][0]
+        item = table.get_item(Key={"id": nearest_id})["Item"]
+        print(f"{item['comment']} (similarity: {score})")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/alternator/requirements.txt
+++ b/docs/examples/alternator/requirements.txt
@@ -1,0 +1,3 @@
+# Vector search support is only available on the alternator-client main branch
+# for now; the 1.0.0 PyPI release does not include it yet.
+alternator-client @ git+https://github.com/scylladb/alternator-client-python.git@main

--- a/docs/examples/docker/docker-compose-alternator.yml
+++ b/docs/examples/docker/docker-compose-alternator.yml
@@ -7,7 +7,7 @@
 
 services:
   scylla:
-    image: scylladb/scylla:2026.1.4
+    image: scylladb/scylla:2026.2.0-rc3
     container_name: scylla-alternator
     command: >
       --smp 2
@@ -28,7 +28,7 @@ services:
       - vector-net
 
   vector-store:
-    image: scylladb/vector-store:1.6.0
+    image: scylladb/vector-store:1.8.0
     container_name: vector-store
     environment:
       VECTOR_STORE_URI: "0.0.0.0:6080"


### PR DESCRIPTION
## What

Adds minimal Python examples that mirror [`docs/examples/quick-start.cql`](docs/examples/quick-start.cql), running vector search through the ScyllaDB Alternator (DynamoDB) API with the [`alternator-client`](https://github.com/scylladb/alternator-client-python) load-balancing driver.

New directory `docs/examples/alternator/`:

| File | Vector data type | ScyllaDB |
| --- | --- | --- |
| `list_of_numbers.py` | plain list of numbers | `scylladb/scylla:2026.2` |
| `native_vector.py` | native `Vector` type (configurable similarity function + similarity scores) | `scylladb/scylla-nightly:2026.3` |

Plus a `README.md` and `requirements.txt`.

Each script creates a `comments` table with a vector index, inserts two rows, waits for the index to build, then prints the most similar comment — the same flow as the CQL quick-start.

The native `Vector` type is more compact and unlocks a configurable `SimilarityFunction` and `ReturnScores`, all of which require ScyllaDB 2026.3 (2026.2 only has partial vector support).

The examples reuse the existing [`docs/examples/docker/docker-compose-alternator.yml`](docs/examples/docker/docker-compose-alternator.yml) to run ScyllaDB + Vector Store.

## Why

VECTOR-661 — provide a minimal Alternator equivalent of the CQL quick-start for the repo, cloud docs, and the cloud UI connect tab.

## Testing

- `python -m py_compile` passes for both scripts.

Fixes VECTOR-661