### PR TITLE
vector-store: include FTS indexes in GET /indexes

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "LicenseRef-ScyllaDB-Source-Available-1.0"
     },
-    "version": "1.5.0"
+    "version": "2.0.0"
   },
   "paths": {
     "/api/v1/indexes": {
@@ -14,7 +14,7 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Returns the list of indexes managed by the Vector Store indexing service. The list includes indexes in any state (initializing, available/built, destroying). Due to synchronization delays, it may temporarily differ from the list of vector indexes inside ScyllaDB.",
+        "description": "Returns the list of indexes managed by the Vector Store indexing service. The list includes both vector and fulltext indexes in any state (initializing, available/built, destroying). Due to synchronization delays, it may temporarily differ from the list of indexes inside ScyllaDB.",
         "operationId": "get_indexes",
         "responses": {
           "200": {
@@ -370,24 +370,27 @@
         "description": "A human-readable description of the error that occurred."
       },
       "IndexInfo": {
-        "type": "object",
-        "description": "Information about a vector index, such as keyspace, name and data type.",
-        "required": [
-          "keyspace",
-          "index",
-          "data_type"
-        ],
-        "properties": {
-          "data_type": {
-            "$ref": "#/components/schemas/DataType"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IndexType"
           },
-          "index": {
-            "$ref": "#/components/schemas/IndexName"
-          },
-          "keyspace": {
-            "$ref": "#/components/schemas/KeyspaceName"
+          {
+            "type": "object",
+            "required": [
+              "keyspace",
+              "index"
+            ],
+            "properties": {
+              "index": {
+                "$ref": "#/components/schemas/IndexName"
+              },
+              "keyspace": {
+                "$ref": "#/components/schemas/KeyspaceName"
+              }
+            }
           }
-        }
+        ],
+        "description": "Information about an index, such as keyspace, name and type."
       },
       "IndexName": {
         "type": "string",
@@ -422,6 +425,45 @@
             "$ref": "#/components/schemas/IndexStatus"
           }
         }
+      },
+      "IndexType": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Vector search index with its associated data type.",
+            "required": [
+              "data_type",
+              "type"
+            ],
+            "properties": {
+              "data_type": {
+                "$ref": "#/components/schemas/DataType"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vector"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Fulltext search index.",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "fulltext"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Type of index, distinguishing between vector search and fulltext search indexes."
       },
       "InfoResponse": {
         "type": "object",

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -56,6 +56,16 @@ pub enum DataType {
     B1,
 }
 
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+#[serde(tag = "type", rename_all = "lowercase")]
+/// Type of index, distinguishing between vector search and fulltext search indexes.
+pub enum IndexType {
+    /// Vector search index with its associated data type.
+    Vector { data_type: DataType },
+    /// Fulltext search index.
+    Fulltext,
+}
+
 #[derive(
     Copy,
     Clone,
@@ -82,11 +92,12 @@ impl Serialize for Distance {
 }
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
-/// Information about a vector index, such as keyspace, name and data type.
+/// Information about an index, such as keyspace, name and type.
 pub struct IndexInfo {
     pub keyspace: KeyspaceName,
     pub index: IndexName,
-    pub data_type: DataType,
+    #[serde(flatten)]
+    pub index_type: IndexType,
 }
 
 impl IndexInfo {
@@ -94,7 +105,9 @@ impl IndexInfo {
         IndexInfo {
             keyspace: String::from(keyspace).into(),
             index: String::from(index).into(),
-            data_type: DataType::F32,
+            index_type: IndexType::Vector {
+                data_type: DataType::F32,
+            },
         }
     }
 }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -45,6 +45,7 @@ use axum_server_dual_protocol::Protocol;
 use bigdecimal::BigDecimal;
 use httpapi::DataType;
 use httpapi::IndexInfo;
+use httpapi::IndexType;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use prometheus::Encoder;
@@ -88,7 +89,7 @@ use utoipa_swagger_ui::SwaggerUi;
             name = "LicenseRef-ScyllaDB-Source-Available-1.0"
         ),
         // version should be updated manually when there are changes in API
-        version = "1.5.0"
+        version = "2.0.0"
     ),
     tags(
         (
@@ -239,8 +240,8 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
     path = "/api/v1/indexes",
     tag = "scylla-vector-store-index",
     description = "Returns the list of indexes managed by the Vector Store indexing service. \
-    The list includes indexes in any state (initializing, available/built, destroying). \
-    Due to synchronization delays, it may temporarily differ from the list of vector indexes inside ScyllaDB.",
+    The list includes both vector and fulltext indexes in any state (initializing, available/built, destroying). \
+    Due to synchronization delays, it may temporarily differ from the list of indexes inside ScyllaDB.",
     responses(
         (
             status = 200,
@@ -251,17 +252,25 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
 )]
 
 async fn get_indexes(State(state): State<RoutesInnerState>) -> Response {
-    let indexes: Vec<_> = state
-        .engine
-        .get_vs_index_keys()
-        .await
+    let vs_indexes = state.engine.get_vs_index_keys().await;
+    let fts_guard = state.indexes.read().unwrap();
+
+    let indexes: Vec<_> = vs_indexes
         .iter()
         .map(|(key, vs)| IndexInfo {
             keyspace: key.keyspace().into(),
             index: key.index().into(),
-            data_type: vs.quantization.into(),
+            index_type: IndexType::Vector {
+                data_type: vs.quantization.into(),
+            },
         })
+        .chain(fts_guard.iter_fts().map(|(key, _)| IndexInfo {
+            keyspace: key.keyspace().into(),
+            index: key.index().into(),
+            index_type: IndexType::Fulltext,
+        }))
         .collect();
+
     (StatusCode::OK, response::Json(indexes)).into_response()
 }
 

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -375,3 +375,19 @@ async fn fts_empty_index_returns_empty_bm25_results() {
     assert!(primary_keys.get(&"pk".into()).unwrap().is_empty());
     assert!(scores.is_empty());
 }
+
+#[tokio::test]
+async fn fts_index_appears_in_indexes_list() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
+
+    let indexes = client.indexes().await;
+    let fts_index = indexes
+        .iter()
+        .find(|i| i.keyspace == keyspace_name && i.index == index_name);
+
+    assert!(fts_index.is_some());
+    assert_eq!(fts_index.unwrap().index_type, httpapi::IndexType::Fulltext);
+}

--- a/crates/vector-store/tests/integration/quantization.rs
+++ b/crates/vector-store/tests/integration/quantization.rs
@@ -162,7 +162,12 @@ async fn quantization_is_returned_as_index_data_type() {
         )
         .await;
 
-        assert_eq!(index_info.data_type, expected_data_type);
+        assert_eq!(
+            index_info.index_type,
+            httpapi::IndexType::Vector {
+                data_type: expected_data_type
+            }
+        );
     }
 }
 


### PR DESCRIPTION
Previously GET /api/v1/indexes returned only vector indexes.
This commit extends the endpoint to also return fulltext indexes.

IndexInfo now exposes a discriminator on the index type field:
```
{ "keyspace": "k", "index": "i", "type": "vector", "data_type": "F32" }
{ "keyspace": "k", "index": "i", "type": "fulltext" }
```

The data_type field is now only present for vector indexes.
For this reason the change is **backward incompatible**,
hence the API version is bumped to 2.0.0.
    
VECTOR-611