### PR TITLE
Add latte CQL vector-search benchmark workload

### DIFF
--- a/latte/vector-search/README.md
+++ b/latte/vector-search/README.md
@@ -1,0 +1,78 @@
+# latte vector-search workloads
+
+[latte](https://github.com/scylladb/latte) workload scripts that benchmark
+ScyllaDB vector search over the CQL path — measuring throughput, latency and
+**recall@k**. Recall is exported into latte's JSON report via the custom-metrics
+channel, so it can be compared and tracked like QPS and latency.
+
+These are the CQL counterpart to the Rust `vector-search-benchmark`
+(`crates/benchmark`); latte is the load engine, these `.rn` files are the
+workload.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `text_dataset.rn` | dataset/query/ground-truth **text** loaders |
+| `metrics.rn` | quality metrics — the `recall_at_k` definition |
+| `recall.rn` | benchmark over the whole dataset (load → ANN search → recall/QPS/latency) |
+| `recall_buckets.rn` | one upload, queried as the full dataset or per size-stratum, for a recall/QPS-vs-index-size curve |
+
+## Requirements
+
+- `scylladb/latte` **≥ 0.49.0-scylladb** (the custom-metrics support these scripts rely on).
+- A running ScyllaDB + vector-store cluster.
+
+## Quick start (`recall.rn`)
+
+```sh
+# string -P values are parsed as expressions, so quote paths
+latte schema             latte/vector-search/recall.rn <node>
+latte run -f load        latte/vector-search/recall.rn <node> -d <dataset_size> \
+    -P load_data=true -P 'vector_data_dir="<dir>/"' --threads 1 --concurrency 64
+latte run -f build_index latte/vector-search/recall.rn <node> -d 1 -P build_index=true
+latte run -f search      latte/vector-search/recall.rn <node> -d 60s --concurrency 32 \
+    -P 'vector_data_dir="<dir>/"' --generate-report -o report.json
+```
+
+`load` preloads the dataset into memory and inserts one row per cycle (run it
+single-threaded with high async concurrency); `build_index` creates the index and
+blocks until it is fully built; `search` loads only the small query +
+ground-truth files. Key params: `keyspace`, `table`, `dimension`, `ann_limit`
+(k), `index_options`, `index_before_load`, `vector_data_dir`, `dataset_file`,
+`query_vectors_file`, `ground_truth_file`. See each script's header for the rest.
+
+**Index build timing (`index_before_load`):** by default the index is created
+*after* load, in the `build_index` phase, which blocks until the index is fully
+built — so `search` measures a complete index and recall is deterministic. The
+wait works because an ANN query on a not-yet-built index errors, and latte retries
+it (during `build_index`'s warmup) until it succeeds; for a large dataset raise
+`--retry-number` so the retry budget covers the build. Set
+`-P index_before_load=true` to instead create the index in `schema` and skip
+`build_index`; inserts then maintain the index during load (this measures the
+index write path, but the index fills asynchronously, so searching too early sees
+a partial index and you must wait an unbounded delay before `search`).
+
+## Datasets
+
+Inputs are plain text (format documented in `text_dataset.rn`): a base-vector
+file, a query-vector file, and a ground-truth file. They are prepared **offline**
+from the source parquet/fbin datasets (VectorDBBench-style and big-ann formats).
+
+Default filenames — each overridable with the matching `-P` param:
+
+- `dataset_file` — `dataset.txt` for `recall.rn`, `dataset_buckets.txt` for `recall_buckets.rn`
+- `query_vectors_file` — `queries.txt`
+- `ground_truth_file` — `ground_truth.txt`
+
+The `search` phase does not read the dataset file, but it records `dataset_file`
+as the `dataset` field in the report metadata — if you renamed the dataset file,
+pass the same `-P dataset_file=...` to `search` too, or the report will record
+the default name.
+
+`recall_buckets.rn` additionally reads per-stratum files derived from the bucket
+number (not params): `bucket/test_bucket<N>.txt`, `bucket/gt_bucket<N>.txt`.
+
+Text is a stopgap: latte currently reads dataset files into memory and has no
+binary reader, which does not scale to billion-vector datasets (e.g. deep1b).
+Direct streaming reads of the binary formats are the planned enhancement.

--- a/latte/vector-search/metrics.rn
+++ b/latte/vector-search/metrics.rn
@@ -1,0 +1,33 @@
+//! Quality metrics for vector-search workloads (format-agnostic).
+
+/// recall@k — the fraction of a query's true nearest neighbours that the search found.
+///
+///   recall@k = |returned ∩ true_top_k| / min(k, |ground_truth|)
+///
+///   returned       ids the ANN search returned for the query (≤ k)
+///   ground_truth   the query's true neighbours, nearest first (the exact answer)
+///   true_top_k     the first k of ground_truth (the targets to hit)
+///   ∩              set intersection (ids in both — the correct hits)
+///   |x|            size of set x
+///   k              number of neighbours requested
+///
+/// Normally divides by k; falls back to |ground_truth| when a query has fewer
+/// than k true neighbours (e.g. a small stratification bucket), so recall stays
+/// meaningful instead of being capped low.
+pub fn recall_at_k(returned_ids, ground_truth_ids, k) {
+    let limit = if ground_truth_ids.len() < k { ground_truth_ids.len() } else { k };
+    if limit == 0 {
+        return 1.0;
+    }
+    let expected = [];
+    for j in 0..limit {
+        expected.push(ground_truth_ids[j]);
+    }
+    let hits = 0;
+    for id in returned_ids {
+        if expected.iter().any(|e| e == id) {
+            hits = hits + 1;
+        }
+    }
+    hits as f64 / limit as f64
+}

--- a/latte/vector-search/recall.rn
+++ b/latte/vector-search/recall.rn
@@ -1,0 +1,166 @@
+//! Vector-search recall, throughput and latency workload.
+//!
+//! Loads a base-vector dataset into a table, builds an approximate-nearest-
+//! neighbour index on the vector column, then runs ANN queries over the whole
+//! table measuring throughput, latency and recall@k. Recall is computed in the
+//! workload (query results vs. precomputed ground truth) and exported through
+//! the custom-metrics channel, so it appears in the JSON report, `latte show`
+//! and baseline comparison alongside QPS and latency; the dataset, k, dimension
+//! and index options are recorded as report metadata so a report is
+//! self-describing. For a recall/throughput-vs-index-size curve over nested
+//! subsets of a single upload, see `recall_buckets.rn`.
+//!
+//! Note: string `-P` values are parsed as expressions, so quote paths —
+//! `-P 'vector_data_dir="/abs/dir/"'`.
+//!   latte schema             latte/vector-search/recall.rn <node>
+//!   latte run -f load        latte/vector-search/recall.rn <node> -d <dataset_size> \
+//!       -P load_data=true -P 'vector_data_dir="<dir>/"' --threads 1 --concurrency 64
+//!   latte run -f build_index latte/vector-search/recall.rn <node> -d 1 -P build_index=true
+//!   latte run -f search      latte/vector-search/recall.rn <node> -d 60s --concurrency 32 \
+//!       -P 'vector_data_dir="<dir>/"' --generate-report -o report.json
+//!
+//! By default the index is created AFTER load: `schema` builds only the table,
+//! then the `build_index` phase creates the index and blocks (via latte's query
+//! retries) until it is fully built, so `search` measures a complete index and
+//! recall is deterministic. For a large dataset raise `--retry-number` so the
+//! retry budget covers the build. Set `-P index_before_load=true` to instead
+//! build the index in `schema` and skip `build_index`; inserts then maintain the
+//! index during load (measures the write path, but the index fills async — search
+//! too early sees a partial index).
+//!
+//! `load` preloads the dataset into memory and inserts one row per cycle, so run
+//! it single-threaded with high async concurrency to avoid per-thread copies;
+//! pass `-d <dataset_size>`. `search` loads only the small query-vector and
+//! ground-truth files.
+
+use latte::*;
+
+mod text_dataset;
+mod metrics;
+
+// Schema / index
+const KEYSPACE = latte::param!("keyspace", "vector_bench");
+const TABLE = latte::param!("table", "vectors");
+const INDEX = latte::param!("index", "vectors_ann_idx");
+const REPLICATION_FACTOR = latte::param!("replication_factor", 1);
+const DIMENSION = latte::param!("dimension", 1536);
+// Index tuning (e.g. "{'maximum_node_connections': '16'}"); empty => server defaults.
+const INDEX_OPTIONS = latte::param!("index_options", "");
+// Index build timing. false (default): create the index AFTER load via the
+// `build_index` phase, so search runs against a fully-built index (deterministic
+// recall). true: create it in `schema`, so inserts maintain the index during
+// load — measures the index write path, but the index fills asynchronously.
+const INDEX_BEFORE_LOAD = latte::param!("index_before_load", false);
+
+// Search
+const ANN_LIMIT = latte::param!("ann_limit", 10);   // k for recall@k
+
+// Dataset files (text)
+const VECTOR_DATA_DIR = latte::param!("vector_data_dir", "./");
+const DATASET_FILE = latte::param!("dataset_file", "dataset.txt");
+const QUERY_VECTORS_FILE = latte::param!("query_vectors_file", "queries.txt");
+const GROUND_TRUTH_FILE = latte::param!("ground_truth_file", "ground_truth.txt");
+
+// Phase selectors: `load` fills the table (`-P load_data=true`), `build_index`
+// creates the index and waits until it is built (`-P build_index=true`); the
+// default (both false) is the search phase.
+const LOAD_DATA = latte::param!("load_data", false);
+const BUILD_INDEX = latte::param!("build_index", false);
+
+const INSERT = "insert";
+const SEARCH = "search";
+
+// Create the ANN index if absent. Idempotent (IF NOT EXISTS), so it is safe to
+// call from `schema` (before_load) or the `build_index` phase (after_load).
+async fn create_index(db) {
+    let options_clause = if INDEX_OPTIONS == "" { "" } else { `WITH OPTIONS = ${INDEX_OPTIONS}` };
+    db.execute(`CREATE CUSTOM INDEX IF NOT EXISTS ${INDEX} ON ${KEYSPACE}.${TABLE}(vector) \
+        USING 'vector_index' ${options_clause}`).await?;
+    Ok(())
+}
+
+// A constant, non-zero vector for the readiness probe (an all-zero vector can be
+// undefined under cosine distance).
+fn probe_vector() {
+    let v = [];
+    for _ in 0..DIMENSION {
+        v.push(0.1);
+    }
+    v
+}
+
+pub async fn schema(db) {
+    db.execute(`CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE} WITH REPLICATION = \
+        {'class': 'NetworkTopologyStrategy', 'replication_factor': '${REPLICATION_FACTOR}'}`).await?;
+    db.execute(`DROP TABLE IF EXISTS ${KEYSPACE}.${TABLE}`).await?;
+    db.execute(`CREATE TABLE ${KEYSPACE}.${TABLE} (
+        id bigint PRIMARY KEY,
+        vector vector<float, ${DIMENSION}>
+    )`).await?;
+    if INDEX_BEFORE_LOAD {
+        create_index(db).await?;
+    }
+}
+
+pub async fn erase(db) {
+    db.execute(`TRUNCATE TABLE ${KEYSPACE}.${TABLE}`).await?;
+}
+
+pub async fn prepare(db) {
+    if LOAD_DATA {
+        db.prepare(INSERT, `INSERT INTO ${KEYSPACE}.${TABLE} (id, vector) VALUES (:id, :vector)`).await?;
+        db.data.dataset = text_dataset::load_base_vectors(text_dataset::join_path(VECTOR_DATA_DIR, DATASET_FILE), false).await?;
+        db.load_cycle_count = db.data.dataset.len();
+        println!("Loaded {} dataset rows for insert", db.data.dataset.len());
+    } else if BUILD_INDEX {
+        // after_load: create the index now that the table is full; before_load:
+        // a no-op create. The `build_index` probe below waits until it is built.
+        create_index(db).await?;
+        db.prepare(SEARCH, `SELECT id FROM ${KEYSPACE}.${TABLE} ORDER BY vector ANN OF :vector LIMIT ${ANN_LIMIT}`).await?;
+        db.data.probe = probe_vector();
+    } else {
+        db.prepare(SEARCH, `SELECT id FROM ${KEYSPACE}.${TABLE} ORDER BY vector ANN OF :vector LIMIT ${ANN_LIMIT}`).await?;
+        db.data.query_vectors = text_dataset::load_query_vectors(text_dataset::join_path(VECTOR_DATA_DIR, QUERY_VECTORS_FILE)).await?;
+        db.data.ground_truth = text_dataset::load_ground_truth(text_dataset::join_path(VECTOR_DATA_DIR, GROUND_TRUTH_FILE)).await?;
+        println!("Loaded {} query vectors / {} ground-truth rows",
+                 db.data.query_vectors.len(), db.data.ground_truth.len());
+
+        // recall is better when higher; record run context so the report is self-describing.
+        db.declare_metric("recall", "higher");
+        db.set_report_field("dataset", DATASET_FILE);
+        db.set_report_field("k", `${ANN_LIMIT}`);
+        db.set_report_field("dimension", `${DIMENSION}`);
+        db.set_report_field("query_path", "cql");
+        db.set_report_field("index_options", if INDEX_OPTIONS == "" { "server_defaults" } else { INDEX_OPTIONS });
+        db.set_report_field("index_timing", if INDEX_BEFORE_LOAD { "before_load" } else { "after_load" });
+    }
+}
+
+pub async fn load(db, i) {
+    // Map the cycle index into the dataset; modulo keeps it in bounds regardless
+    // of the exact `-d` count (inserts are idempotent on the primary key).
+    let row = db.data.dataset[i % db.data.dataset.len()];
+    db.execute_prepared(INSERT, #{ "id": row.id, "vector": row.vector }).await?;
+}
+
+pub async fn build_index(db, i) {
+    // A single ANN probe. latte retries execution errors, so the "index not built
+    // yet" error is retried (absorbed by warmup) until the async build completes;
+    // the index is fully built by the time this returns.
+    db.execute_prepared_with_result(SEARCH, #{ "vector": db.data.probe }).await?;
+}
+
+pub async fn search(db, i) {
+    let idx = latte::hash(i) % db.data.query_vectors.len();
+    let vector = db.data.query_vectors[idx];
+    let ground_truth_ids = db.data.ground_truth[idx];
+
+    let rows = db.execute_prepared_with_result(SEARCH, #{ "vector": vector }).await?;
+
+    let returned_ids = [];
+    for row in rows {
+        returned_ids.push(row.id);
+    }
+
+    db.record_metric("recall", metrics::recall_at_k(returned_ids, ground_truth_ids, ANN_LIMIT));
+}

--- a/latte/vector-search/recall_buckets.rn
+++ b/latte/vector-search/recall_buckets.rn
@@ -1,0 +1,201 @@
+//! Vector-search recall, throughput and latency workload — stratified one-upload scaling curve.
+//!
+//! One table partition-keyed on `bucket`, loaded ONCE, then queried either as
+//! the full dataset (a global index, no filter) or one stratum at a time (a
+//! local per-bucket index plus `WHERE bucket = ?`). Each bucket is a disjoint
+//! subset of decreasing size, so a single upload yields a recall/QPS/latency
+//! curve against index size with no re-upload — querying a stratum searches only
+//! its own smaller index. Bucket assignments and the matching per-bucket ground
+//! truth are precomputed offline (bucketed dataset format documented in
+//! `text_dataset.rn`), so the script only reads them. Recall reaches the report
+//! through the custom-metrics channel, as in `recall.rn`.
+//!
+//! Note: string `-P` values are parsed as expressions, so quote paths —
+//! `-P 'vector_data_dir="/abs/dir/"'`.
+//!   # one upload (table is PK((bucket, id)); index built AFTER load):
+//!   latte schema             latte/vector-search/recall_buckets.rn <node>
+//!   latte run -f load        latte/vector-search/recall_buckets.rn <node> -d <dataset_size> \
+//!       -P load_data=true -P 'vector_data_dir="<dir>/"' --threads 1 --concurrency 64
+//!   # full-dataset point — build the global index, then search it (default bucket=-1):
+//!   latte run -f build_index latte/vector-search/recall_buckets.rn <node> -d 1 -P build_index=true
+//!   latte run -f search      latte/vector-search/recall_buckets.rn <node> -d 60s --concurrency 32 \
+//!       -P 'vector_data_dir="<dir>/"' --generate-report -o full.json
+//!   # per-stratum sweep off the SAME data: drop the global index, build a local
+//!   # per-bucket index, then query strata (defaults: vector_bench.vectors_bucketed_ann_idx):
+//!   cqlsh -e "DROP INDEX vector_bench.vectors_bucketed_ann_idx"
+//!   latte run -f build_index latte/vector-search/recall_buckets.rn <node> -d 1 \
+//!       -P build_index=true -P local_index=true
+//!   latte run -f search      latte/vector-search/recall_buckets.rn <node> -d 30s --concurrency 32 -P bucket=0 \
+//!       -P 'vector_data_dir="<dir>/"' --generate-report -o bucket0.json
+//!
+//! Index build timing works as in `recall.rn`: by default the index is built
+//! after load in the `build_index` phase (which blocks until it is ready), so
+//! search measures a complete index; `-P index_before_load=true` builds it in
+//! `schema` instead. What is bucket-specific is that global vs. local is an
+//! index-build choice (`local_index`), so switching between them off one upload
+//! means dropping the index and re-running `build_index`, as shown above.
+
+use latte::*;
+
+mod text_dataset;
+mod metrics;
+
+// Schema / index
+const KEYSPACE = latte::param!("keyspace", "vector_bench");
+const TABLE = latte::param!("table", "vectors_bucketed");
+const INDEX = latte::param!("index", "vectors_bucketed_ann_idx");
+const REPLICATION_FACTOR = latte::param!("replication_factor", 1);
+const DIMENSION = latte::param!("dimension", 1536);
+// Index tuning (e.g. "{'maximum_node_connections': '16'}"); empty => server defaults.
+const INDEX_OPTIONS = latte::param!("index_options", "");
+// Index build timing. false (default): create the index AFTER load via the
+// `build_index` phase, so search runs against a fully-built index (deterministic
+// recall). true: create it in `schema`, so inserts maintain the index during
+// load — measures the index write path, but the index fills asynchronously.
+const INDEX_BEFORE_LOAD = latte::param!("index_before_load", false);
+
+// Search / stratification
+const ANN_LIMIT = latte::param!("ann_limit", 10);   // k for recall@k
+// -1 => full dataset via the global index; 0..8 => one stratum via the local per-bucket index.
+const BUCKET = latte::param!("bucket", -1);
+// Build the local per-bucket index in `schema` instead of the global one.
+const LOCAL_INDEX = latte::param!("local_index", false);
+
+// Dataset files (text)
+const VECTOR_DATA_DIR = latte::param!("vector_data_dir", "./");
+const DATASET_FILE = latte::param!("dataset_file", "dataset_buckets.txt");
+const QUERY_VECTORS_FILE = latte::param!("query_vectors_file", "queries.txt");
+const GROUND_TRUTH_FILE = latte::param!("ground_truth_file", "ground_truth.txt");
+
+// Phase selectors: `load` fills the table (`-P load_data=true`), `build_index`
+// creates the index and waits until it is built (`-P build_index=true`); the
+// default (both false) is the search phase.
+const LOAD_DATA = latte::param!("load_data", false);
+const BUILD_INDEX = latte::param!("build_index", false);
+
+const INSERT = "insert";
+const SEARCH = "search";
+
+// Create the ANN index if absent. Idempotent (IF NOT EXISTS), so it is safe to
+// call from `schema` (before_load) or the `build_index` phase (after_load). The
+// target is the whole `vector` column (global index) or `(bucket), vector` for a
+// local per-bucket index, selected by `local_index`.
+async fn create_index(db) {
+    let options_clause = if INDEX_OPTIONS == "" { "" } else { `WITH OPTIONS = ${INDEX_OPTIONS}` };
+    let target = if LOCAL_INDEX { "(bucket), vector" } else { "vector" };
+    db.execute(`CREATE CUSTOM INDEX IF NOT EXISTS ${INDEX} ON ${KEYSPACE}.${TABLE}(${target}) \
+        USING 'vector_index' ${options_clause}`).await?;
+    Ok(())
+}
+
+// A constant, non-zero vector for the readiness probe (an all-zero vector can be
+// undefined under cosine distance).
+fn probe_vector() {
+    let v = [];
+    for _ in 0..DIMENSION {
+        v.push(0.1);
+    }
+    v
+}
+
+pub async fn schema(db) {
+    db.execute(`CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE} WITH REPLICATION = \
+        {'class': 'NetworkTopologyStrategy', 'replication_factor': '${REPLICATION_FACTOR}'}`).await?;
+    db.execute(`DROP TABLE IF EXISTS ${KEYSPACE}.${TABLE}`).await?;
+    db.execute(`CREATE TABLE ${KEYSPACE}.${TABLE} (
+        bucket bigint,
+        id bigint,
+        vector vector<float, ${DIMENSION}>,
+        PRIMARY KEY ((bucket, id))
+    )`).await?;
+    if INDEX_BEFORE_LOAD {
+        create_index(db).await?;
+    }
+}
+
+pub async fn erase(db) {
+    db.execute(`TRUNCATE TABLE ${KEYSPACE}.${TABLE}`).await?;
+}
+
+pub async fn prepare(db) {
+    if LOAD_DATA {
+        db.prepare(INSERT, `INSERT INTO ${KEYSPACE}.${TABLE} (bucket, id, vector) VALUES (:bucket, :id, :vector)`).await?;
+        db.data.dataset = text_dataset::load_base_vectors(text_dataset::join_path(VECTOR_DATA_DIR, DATASET_FILE), true).await?;
+        db.load_cycle_count = db.data.dataset.len();
+        println!("Loaded {} bucketed dataset rows for insert", db.data.dataset.len());
+    } else if BUILD_INDEX {
+        // after_load: create the index now that the table is full; before_load:
+        // a no-op create. The `build_index` probe below waits until it is built.
+        create_index(db).await?;
+        if LOCAL_INDEX {
+            db.prepare(SEARCH, `SELECT id FROM ${KEYSPACE}.${TABLE} WHERE bucket = :bucket ORDER BY vector ANN OF :vector LIMIT ${ANN_LIMIT}`).await?;
+        } else {
+            db.prepare(SEARCH, `SELECT id FROM ${KEYSPACE}.${TABLE} ORDER BY vector ANN OF :vector LIMIT ${ANN_LIMIT}`).await?;
+        }
+        db.data.probe = probe_vector();
+    } else {
+        if BUCKET >= 0 {
+            db.prepare(SEARCH, `SELECT id FROM ${KEYSPACE}.${TABLE} WHERE bucket = :bucket ORDER BY vector ANN OF :vector LIMIT ${ANN_LIMIT}`).await?;
+            let test_path = text_dataset::join_path(VECTOR_DATA_DIR, `bucket/test_bucket${BUCKET}.txt`);
+            let gt_path = text_dataset::join_path(VECTOR_DATA_DIR, `bucket/gt_bucket${BUCKET}.txt`);
+            db.data.query_vectors = text_dataset::load_query_vectors(test_path).await?;
+            db.data.ground_truth = text_dataset::load_ground_truth(gt_path).await?;
+        } else {
+            db.prepare(SEARCH, `SELECT id FROM ${KEYSPACE}.${TABLE} ORDER BY vector ANN OF :vector LIMIT ${ANN_LIMIT}`).await?;
+            db.data.query_vectors = text_dataset::load_query_vectors(text_dataset::join_path(VECTOR_DATA_DIR, QUERY_VECTORS_FILE)).await?;
+            db.data.ground_truth = text_dataset::load_ground_truth(text_dataset::join_path(VECTOR_DATA_DIR, GROUND_TRUTH_FILE)).await?;
+        }
+        println!("Loaded {} query vectors / {} ground-truth rows (bucket={})",
+                 db.data.query_vectors.len(), db.data.ground_truth.len(), BUCKET);
+
+        // recall is better when higher; record run context so the report is self-describing.
+        db.declare_metric("recall", "higher");
+        db.set_report_field("dataset", DATASET_FILE);
+        db.set_report_field("k", `${ANN_LIMIT}`);
+        db.set_report_field("dimension", `${DIMENSION}`);
+        db.set_report_field("query_path", "cql");
+        db.set_report_field("bucket", if BUCKET >= 0 { `${BUCKET}` } else { "global" });
+        db.set_report_field("index_options", if INDEX_OPTIONS == "" { "server_defaults" } else { INDEX_OPTIONS });
+        db.set_report_field("index_timing", if INDEX_BEFORE_LOAD { "before_load" } else { "after_load" });
+    }
+}
+
+pub async fn load(db, i) {
+    // Map the cycle index into the dataset; modulo keeps it in bounds regardless
+    // of the exact `-d` count (inserts are idempotent on the primary key).
+    let row = db.data.dataset[i % db.data.dataset.len()];
+    db.execute_prepared(INSERT, #{ "bucket": row.bucket, "id": row.id, "vector": row.vector }).await?;
+}
+
+pub async fn build_index(db, i) {
+    // A single ANN probe. latte retries execution errors, so the "index not built
+    // yet" error is retried (absorbed by warmup) until the async build completes;
+    // the index is fully built by the time this returns. For a local per-bucket
+    // index, probe one populated stratum (bucket 0) — one build covers all buckets.
+    let params = if LOCAL_INDEX {
+        #{ "bucket": 0, "vector": db.data.probe }
+    } else {
+        #{ "vector": db.data.probe }
+    };
+    db.execute_prepared_with_result(SEARCH, params).await?;
+}
+
+pub async fn search(db, i) {
+    let idx = latte::hash(i) % db.data.query_vectors.len();
+    let vector = db.data.query_vectors[idx];
+    let ground_truth_ids = db.data.ground_truth[idx];
+
+    let params = if BUCKET >= 0 {
+        #{ "bucket": BUCKET, "vector": vector }
+    } else {
+        #{ "vector": vector }
+    };
+    let rows = db.execute_prepared_with_result(SEARCH, params).await?;
+
+    let returned_ids = [];
+    for row in rows {
+        returned_ids.push(row.id);
+    }
+
+    db.record_metric("recall", metrics::recall_at_k(returned_ids, ground_truth_ids, ANN_LIMIT));
+}

--- a/latte/vector-search/text_dataset.rn
+++ b/latte/vector-search/text_dataset.rn
@@ -1,0 +1,85 @@
+//! Text dataset loaders for vector-search workloads.
+//!
+//! A benchmark dataset is three plain-text files (fields separated by ", ").
+//! This layout is the workload's own convention, not a latte requirement —
+//! latte only provides generic line/field reading. A binary reader (e.g. fbin)
+//! would be a sibling module exposing the same loader functions.
+//!
+//!   base vectors  — the corpus: loaded into the table and indexed; ANN search
+//!                   returns these.         `id, [v1, v2, ...]`
+//!   query vectors — the vectors you search *with*, one ANN query each.
+//!                   `v1, v2, ...`
+//!   ground truth  — per query (aligned by line), the ids of its true nearest
+//!                   neighbours (nearest first, from an exact search); recall
+//!                   compares the ANN result against these.    `id1, id2, ...`
+
+const PARSING_DELIMITER = ", ";
+
+/// Join a directory prefix and a file name, tolerating a missing trailing
+/// slash: `join_path("/data", "x.txt")` and `join_path("/data/", "x.txt")` both
+/// give `/data/x.txt`; an empty dir yields the bare name.
+pub fn join_path(dir, name) {
+    if dir == "" || dir.ends_with("/") { dir + name } else { dir + "/" + name }
+}
+
+/// Parse a `[v1, v2, ...]` field into a Vec of f64 (the components of one
+/// vector). The line reader already stripped surrounding whitespace and the
+/// components are ", "-separated, so only the brackets are removed here.
+fn parse_vector(field) {
+    let body = field;
+    if body.starts_with("[") && body.ends_with("]") {
+        body = body[1..body.len() - 1];
+    }
+    let vector = [];
+    for component in body.split(PARSING_DELIMITER) {
+        vector.push(f64::parse(component)?);
+    }
+    Ok(vector)
+}
+
+/// Read a file whose every line is a ", "-separated list of values, parsing each
+/// value with `parse`. Returns a Vec of per-line Vecs; empty lines are skipped.
+async fn load_value_lines(path, parse) {
+    let it = fs::read_split_lines_iter(path, [PARSING_DELIMITER])?;
+    let lines = [];
+    while let Some(line) = it.next() {
+        let raw = line?;
+        if !raw.is_empty() {
+            let values = [];
+            for field in raw {
+                values.push(parse(field)?);
+            }
+            lines.push(values);
+        }
+    }
+    Ok(lines)
+}
+
+/// Load a base-vector file into a Vec of `#{ id, bucket, vector }`.
+///
+/// `bucketed` selects the line format: `id, [v...]` (bucket defaults to 0) when
+/// false; `id, bucket, [v...]` (bucket read from the line) when true.
+pub async fn load_base_vectors(path, bucketed) {
+    let maxsplit = if bucketed { 2 } else { 1 };
+    let it = fs::read_split_lines_iter(path, [PARSING_DELIMITER, maxsplit])?;
+    let rows = [];
+    while let Some(entry) = it.next() {
+        let raw = entry?;
+        if !raw.is_empty() {
+            let bucket = if bucketed { raw[1].parse::<i64>()? } else { 0 };
+            let vector_field = if bucketed { raw[2] } else { raw[1] };
+            rows.push(#{ "id": raw[0].parse::<i64>()?, "bucket": bucket, "vector": parse_vector(vector_field)? });
+        }
+    }
+    Ok(rows)
+}
+
+/// Load a query-vector file (`v1, v2, ...` per line) into a Vec of Vec<f64>.
+pub async fn load_query_vectors(path) {
+    load_value_lines(path, |field| f64::parse(field)).await
+}
+
+/// Load a ground-truth file (`id1, id2, ...` per line) into a Vec of Vec<i64>.
+pub async fn load_ground_truth(path) {
+    load_value_lines(path, |field| field.parse::<i64>()).await
+}


### PR DESCRIPTION
Adds a latte workload that benchmarks ScyllaDB vector search over CQL. This is the latte counterpart to the Rust vector-search-benchmark's CQL path (`crates/benchmark`). Lives in `latte/vector-search/`.

`recall.rn` - load a vector dataset -> build the HNSW index -> run ANN queries, measuring throughput, latency and recall@k. Recall is exported into latte's JSON report via the custom-metrics channel (so it's tracked/compared like QPS and latency); dataset/k/dimension/index-options are recorded as report metadata.

`recall_buckets.rn` - same, but the table is partition-keyed on a bucket column. One upload can be queried as the full dataset or per size-stratum (local per-bucket index), a recall/throughput-vs-index-size curve with no re-upload.

`text_dataset.rn` / `metrics.rn` - shared text loaders and the recall@k definition. Datasets are plain text (format documented in `text_dataset.rn`), prepared offline. Requires scylladb/latte >= 0.49.0-scylladb (custom-metrics support).

Validated on `openai_small_50k` (1536-dim, k=10): recall 0.98 at server defaults / 0.99 with a tuned index, matching the Rust benchmark.

Scope: CQL path only.

Fixes: VECTOR-694