### PR TITLE
vector-store/validator: fix silently failing tests

### DIFF
--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -38,6 +38,7 @@ use e2etest_vector_store_cluster::VectorStoreClusterExt;
 use std::env;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
@@ -170,7 +171,7 @@ fn validate_different_subnet(dns_ip: Ipv4Addr, base_ip: Ipv4Addr) {
 
 e2etest::group!(name = validator, fixtures = (TestActors));
 
-pub async fn run() {
+pub async fn run() -> ExitCode {
     let args = Args::parse();
     let root = validator();
     let stats = match args.command {
@@ -178,7 +179,7 @@ pub async fn run() {
             root.test_names().into_iter().for_each(|name| {
                 println!("{name}");
             });
-            return;
+            return ExitCode::SUCCESS;
         }
         Command::Run(args) => e2etest::run(init(args), root).await,
     };
@@ -202,7 +203,10 @@ pub async fn run() {
             "{error_list}",
             error_list = format_failed_names(&stats.failed_names())
         );
+        return ExitCode::FAILURE;
     }
+
+    ExitCode::SUCCESS
 }
 
 pub(crate) fn format_failed_names(failed_names: &[String]) -> String {

--- a/crates/validator/src/main.rs
+++ b/crates/validator/src/main.rs
@@ -4,6 +4,6 @@
  */
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() {
+async fn main() -> std::process::ExitCode {
     vector_search_validator::run().await
 }

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -10,6 +10,7 @@ use crate::DbIndexedRow;
 use crate::DbIndexedValue;
 use crate::IndexKind;
 use crate::IndexMetadata;
+use crate::db_index_backend::CdcValueStatus;
 use crate::db_index_backend::DbIndexBackend;
 use crate::internals::Internals;
 use crate::internals::InternalsExt;
@@ -466,14 +467,12 @@ impl Consumer for CdcConsumer {
             OperationType::PartitionDelete | OperationType::RowDelete => None,
 
             OperationType::RowUpdate | OperationType::RowInsert | OperationType::PostImage => {
-                if row.is_value_deleted(column) {
-                    None
-                } else {
-                    let Some(value) = row.take_value(column) else {
-                        // If the column is not deleted but also has no value, skip this row.
-                        return Ok(());
-                    };
-                    extract_indexed_value(source, value, &self.0.kind)?
+                match source.take_cdc_value(&mut row) {
+                    CdcValueStatus::Deleted => None,
+                    CdcValueStatus::Skip => return Ok(()),
+                    CdcValueStatus::NewValue(value) => {
+                        extract_indexed_value(source, value, &self.0.kind)?
+                    }
                 }
             }
 

--- a/crates/vector-store/src/db_index_backend.rs
+++ b/crates/vector-store/src/db_index_backend.rs
@@ -20,8 +20,21 @@ use scylla::client::session::Session;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
 use scylla_cdc::CqlIdentifier;
+use scylla_cdc::consumer::CDCRow;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
+
+/// Alternator tables store all user attributes in a single map column `:attrs`.
+/// Because Alternator (DynamoDB-compatible) is schemaless, different items can
+/// have different types for the same attribute name, so a map is used instead
+/// of dedicated typed columns.
+const ALTERNATOR_ATTRS_COLUMN: &str = ":attrs";
+
+pub(crate) enum CdcValueStatus {
+    NewValue(CqlValue),
+    Deleted,
+    Skip,
+}
 
 pub(crate) struct IndexLocation {
     pub keyspace: KeyspaceName,
@@ -49,7 +62,7 @@ impl DbIndexBackend {
     pub fn target_column_name(&self) -> &str {
         match self {
             Self::Cql { target_column } => target_column.as_ref(),
-            Self::Alternator { .. } => ":attrs",
+            Self::Alternator { .. } => ALTERNATOR_ATTRS_COLUMN,
         }
     }
 
@@ -76,6 +89,42 @@ impl DbIndexBackend {
             }
         }
     }
+
+    pub fn take_cdc_value(&self, row: &mut CDCRow<'_>) -> CdcValueStatus {
+        match self {
+            Self::Cql { target_column } => {
+                let column = target_column.as_ref();
+                if row.is_value_deleted(column) {
+                    return CdcValueStatus::Deleted;
+                }
+                match row.take_value(column) {
+                    Some(value) => CdcValueStatus::NewValue(value),
+                    None => CdcValueStatus::Skip,
+                }
+            }
+            Self::Alternator { target_column } => {
+                // Check take_value before is_value_deleted.
+                // PutItem in Alternator deletes and re-adds :attrs in a single CDC event,
+                // so is_value_deleted can be true even when a new value is present.
+                // We must check for a value first to avoid misreporting it as deleted.
+                let column = ALTERNATOR_ATTRS_COLUMN;
+                match row.take_value(column) {
+                    Some(value) => CdcValueStatus::NewValue(value),
+                    None if row.is_value_deleted(column) => CdcValueStatus::Deleted,
+                    None => {
+                        let target_deleted = row.take_deleted_elements(column).iter().any(|el| {
+                            el.as_text().map(String::as_str) == Some(target_column.as_ref())
+                        });
+                        if target_deleted {
+                            CdcValueStatus::Deleted
+                        } else {
+                            CdcValueStatus::Skip
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Builds the CQL range scan query appropriate for the given keyspace.
@@ -90,7 +139,7 @@ pub(crate) fn range_scan_query(
     partition_key_list: &str,
 ) -> String {
     if keyspace.is_alternator() {
-        let attributes = CqlIdentifier::new(":attrs");
+        let attributes = CqlIdentifier::new(ALTERNATOR_ATTRS_COLUMN);
         let vector = CqlLiteral::new(target_column.as_ref());
         format!(
             "

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -565,6 +565,16 @@ async fn post_index_ann(
                 }
                 (routed_key, index, primary_key_columns, table_columns)
             }
+            indexes::BestIndexState::NoGlobalIndex => {
+                timer.observe_duration();
+
+                let msg = format!(
+                    "Global ANN query is not supported when only a local \
+                    vector index is available for {keyspace}.{index_name}"
+                );
+                debug!("post_index_ann: {msg}");
+                return (StatusCode::BAD_REQUEST, msg).into_response();
+            }
             indexes::BestIndexState::NotServing(progress) => {
                 timer.observe_duration();
 

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -257,6 +257,9 @@ pub(crate) enum BestIndexState {
     NotFound,
     /// The requested index exists but no serving candidate was found.
     NotServing(Progress),
+    /// Serving candidates exist but none can handle a global query
+    /// (all are local-only and the query lacks partition key restrictions).
+    NoGlobalIndex,
     /// A serving candidate was found.
     Serving {
         key: IndexKey,
@@ -394,7 +397,17 @@ impl Indexes {
                     needs_filtering: needs_filtering.clone(),
                 }
             }
-            None => BestIndexState::NotServing(requested_entry.progress),
+            None => {
+                let has_serving = candidates
+                    .iter()
+                    .filter_map(|key| self.vs_entries.get(key))
+                    .any(|entry| entry.status == IndexStatus::Serving);
+                if has_serving {
+                    BestIndexState::NoGlobalIndex
+                } else {
+                    BestIndexState::NotServing(requested_entry.progress)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The validator was returning a success exit code on test failures, which meant failing tests were not noticed in CI. Once the exit code was corrected, the following test cases were revealed to be failing:

- `types::query_with_binary_key`
- `types::query_with_number_key`
- `types::query_with_string_key`
- `types::query_with_optimized_vector_type`
- `lwt::alternator_with_always_use_lwt`
- `update_item::update_item_with_invalid_vector_is_not_indexed`
- `put_item::put_item_updates_index`
- `put_item::put_item_with_invalid_vector_is_not_indexed`
- `batch_write_item::batch_write_item_updates_index`
- `batch_write_item::batch_write_item_with_invalid_vector`
- `query::query_with_large_dimensions`
- `filtering::global_ann_query_on_local_only_index_fails`

This PR fixes the exit code handling and all of the above test cases.