### PR TITLE
fix: Alternator CDC handling for vector attribute updates

### DIFF
--- a/crates/validator/src/alternator/put_item.rs
+++ b/crates/validator/src/alternator/put_item.rs
@@ -86,80 +86,63 @@ async fn put_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>) {
 
     let ctx = TableContext::create(&actors, shape).await;
 
-    let vec_with_string_elem = AttributeValue::L(vec![
-        AttributeValue::N("1.0".into()),
-        AttributeValue::N("2.0".into()),
-        AttributeValue::S("3.0".into()),
-    ]);
-    let vec_with_null_elem = AttributeValue::L(vec![
-        AttributeValue::N("1.0".into()),
-        AttributeValue::N("2.0".into()),
-        AttributeValue::Null(true),
-    ]);
-
     let no_vec = Item::key(pk, None, "pk", "no-vec");
     ctx.put(&no_vec)
         .send()
         .await
         .expect("PutItem should succeed");
 
-    let wrong_type_string = Item::key(pk, None, "pk", "wrong-type-string")
-        .attr(vec_attr, AttributeValue::S("not-a-vector".into()));
-    alternator::assert_service_error(
-        ctx.put(&wrong_type_string).send().await,
-        "ValidationException",
-    );
-
-    let wrong_type_mostly_float_one_s = Item::key(pk, None, "pk", "wrong-type-mostly-float-one-s")
-        .attr(vec_attr, vec_with_string_elem);
-    alternator::assert_service_error(
-        ctx.put(&wrong_type_mostly_float_one_s).send().await,
-        "ValidationException",
-    );
-
-    let wrong_type_mostly_float_one_null =
-        Item::key(pk, None, "pk", "wrong-type-mostly-float-one-null")
-            .attr(vec_attr, vec_with_null_elem);
-    alternator::assert_service_error(
-        ctx.put(&wrong_type_mostly_float_one_null).send().await,
-        "ValidationException",
-    );
-
-    let wrong_type_too_short = Item::key(pk, None, "pk", "wrong-type-too-short")
-        .attr(vec_attr, alternator::float_list([1.0_f32, 1.0]));
-    alternator::assert_service_error(
-        ctx.put(&wrong_type_too_short).send().await,
-        "ValidationException",
-    );
-
-    let wrong_type_too_long = Item::key(pk, None, "pk", "wrong-type-too-long")
-        .attr(vec_attr, alternator::float_list([1.0_f32, 1.0, 1.0, 1.0]));
-    alternator::assert_service_error(
-        ctx.put(&wrong_type_too_long).send().await,
-        "ValidationException",
-    );
-
-    // valid is put last so that wait_for_ann acts as a sequencing barrier:
-    // when VS has indexed valid it must have already processed the no_vec CDC
-    // event before it (CDC events are ordered), proving that the item without
-    // a vector attribute was correctly ignored.
-    let valid = Item::key(pk, None, "pk", "valid").vec(vec_attr, [1.0, 1.0, 1.0]);
-    ctx.put(&valid)
+    let try_replace_valid =
+        Item::key(pk, None, "pk", "try-replace-valid").vec(vec_attr, [1.0, 1.0, 1.0]);
+    ctx.put(&try_replace_valid)
         .send()
         .await
         .expect("PutItem should succeed");
-    ctx.wait_for_ann([1.0, 1.0, 1.0], &[valid]).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&try_replace_valid))
+        .await;
 
-    let valid_no_vec = Item::key(pk, None, "pk", "valid");
-    ctx.put(&valid_no_vec)
+    let invalid_items = [
+        Item::key(pk, None, "pk", "null-vec").attr(vec_attr, AttributeValue::Null(true)),
+        Item::key(pk, None, "pk", "wrong-type-string")
+            .attr(vec_attr, AttributeValue::S("not-a-vector".into())),
+        Item::key(pk, None, "pk", "wrong-type-mostly-float-one-s").attr(
+            vec_attr,
+            AttributeValue::L(vec![
+                AttributeValue::N("1.0".into()),
+                AttributeValue::N("2.0".into()),
+                AttributeValue::S("3.0".into()),
+            ]),
+        ),
+        Item::key(pk, None, "pk", "wrong-type-mostly-float-one-null").attr(
+            vec_attr,
+            AttributeValue::L(vec![
+                AttributeValue::N("1.0".into()),
+                AttributeValue::N("2.0".into()),
+                AttributeValue::Null(true),
+            ]),
+        ),
+        Item::key(pk, None, "pk", "wrong-type-too-short")
+            .attr(vec_attr, alternator::float_list([1.0_f32, 1.0])),
+        Item::key(pk, None, "pk", "wrong-type-too-long")
+            .attr(vec_attr, alternator::float_list([1.0_f32, 1.0, 1.0, 1.0])),
+        Item::key(pk, None, "pk", "try-replace-valid").attr(vec_attr, AttributeValue::Null(true)),
+        Item::key(pk, None, "pk", "try-replace-valid")
+            .attr(vec_attr, AttributeValue::S("bad".into())),
+    ];
+
+    for invalid_item in &invalid_items {
+        info!(?invalid_item, "expecting invalid PutItem to fail");
+        alternator::assert_service_error(ctx.put(invalid_item).send().await, "ValidationException");
+    }
+    ctx.wait_for_count(1).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&try_replace_valid))
+        .await;
+
+    let try_replace_valid_no_vec = Item::key(pk, None, "pk", "try-replace-valid");
+    ctx.put(&try_replace_valid_no_vec)
         .send()
         .await
         .expect("PutItem should succeed");
-    ctx.wait_for_count(0).await;
-
-    let wrong_type2 =
-        Item::key(pk, None, "pk", "valid").attr(vec_attr, AttributeValue::S("bad".into()));
-    alternator::assert_service_error(ctx.put(&wrong_type2).send().await, "ValidationException");
     ctx.wait_for_count(0).await;
 
     ctx.done().await;

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -13,6 +13,21 @@ use aws_sdk_dynamodb::types::AttributeValue;
 use std::sync::Arc;
 use tracing::info;
 
+/// Builds an `UpdateItem` request with only the key and update expression.
+fn update_item_key(ctx: &TableContext, item: &Item, update_expr: &str) -> UpdateItemFluentBuilder {
+    let mut req = ctx
+        .client
+        .update_item()
+        .table_name(&ctx.table_name)
+        .update_expression(update_expr);
+    for attr_name in std::iter::once(ctx.shape.pk()).chain(ctx.shape.sk()) {
+        if let Some(attr_val) = item.0.get(attr_name) {
+            req = req.key(attr_name, attr_val.clone());
+        }
+    }
+    req
+}
+
 /// Builds an `UpdateItem` request on the vector column of `item`.
 ///
 /// The expression is supplied by the caller and may reference:
@@ -25,17 +40,7 @@ fn update_item_expr(
     value: Option<AttributeValue>,
 ) -> UpdateItemFluentBuilder {
     let va = ctx.shape.vec().expect("TableContext has no vec_attr");
-    let mut req = ctx
-        .client
-        .update_item()
-        .table_name(&ctx.table_name)
-        .update_expression(update_expr)
-        .expression_attribute_names("#vec", va);
-    for attr_name in std::iter::once(ctx.shape.pk()).chain(ctx.shape.sk()) {
-        if let Some(attr_val) = item.0.get(attr_name) {
-            req = req.key(attr_name, attr_val.clone());
-        }
-    }
+    let mut req = update_item_key(ctx, item, update_expr).expression_attribute_names("#vec", va);
     if let Some(val) = value {
         req = req.expression_attribute_values(":val", val);
     }
@@ -194,6 +199,118 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
             "ValidationException",
         );
     }
+
+    ctx.done().await;
+    info!("finished");
+}
+
+/// Tests CDC rows where Alternator's physical `:attrs` map is present because
+/// an unrelated attribute changed, but the logical vector attribute did not.
+#[e2etest::test(group = update_item)]
+async fn update_item_unrelated_attribute_does_not_deindex(actors: Arc<TestActors>) {
+    info!("started");
+
+    let shape = &alternator::name_patterns()[1]; // plain names, HASH+RANGE for same-partition barriers
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[1] always has vec");
+
+    let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 2.0, 4.0]);
+    let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [-1.0, -1.0, -1.0]);
+
+    let ctx = TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone()]).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[a.clone(), b.clone()])
+        .await;
+
+    update_item_key(&ctx, &a, "SET unrelated = :val")
+        .expression_attribute_values(":val", AttributeValue::S("changed".into()))
+        .send()
+        .await
+        .expect("UpdateItem on unrelated attribute should succeed");
+
+    let b_updated = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 1.0, 1.0]);
+    // CDC ordering barrier: ANN result for this update proves the preceding one was processed.
+    update_item_expr(
+        &ctx,
+        &b,
+        "SET #vec = :val",
+        Some(alternator::float_list([1.0_f32, 1.0, 1.0])),
+    )
+    .send()
+    .await
+    .expect("UpdateItem vector barrier should succeed");
+
+    ctx.wait_for_count(2).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[b_updated, a]).await;
+
+    ctx.done().await;
+    info!("finished");
+}
+
+/// Tests a CDC row that deletes the vector attribute and updates another
+/// attribute in the same `:attrs` map delta. The vector deletion must not be
+/// masked by unrelated replacement data.
+#[e2etest::test(group = update_item)]
+async fn update_item_remove_vector_and_set_unrelated_deindexes(actors: Arc<TestActors>) {
+    info!("started");
+
+    let shape = &alternator::name_patterns()[1]; // plain names, HASH+RANGE for same-partition barriers
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[1] always has vec");
+
+    let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [1.0, 1.0, 1.0]);
+    let b = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [4.0, 2.0, 1.0]);
+
+    let ctx = TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone()]).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[a.clone(), b.clone()])
+        .await;
+
+    update_item_expr(
+        &ctx,
+        &a,
+        "SET unrelated = :val REMOVE #vec",
+        Some(AttributeValue::S("kept".into())),
+    )
+    .send()
+    .await
+    .expect("UpdateItem remove vector plus unrelated set should succeed");
+
+    ctx.wait_for_count(1).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[b]).await;
+
+    ctx.done().await;
+    info!("finished");
+}
+
+/// Tests a CDC row that deletes an unrelated attribute while updating the
+/// vector attribute. Unrelated deleted-elements metadata must not de-index the
+/// vector.
+#[e2etest::test(group = update_item)]
+async fn update_item_remove_unrelated_and_set_vector_updates_index(actors: Arc<TestActors>) {
+    info!("started");
+
+    let shape = &alternator::name_patterns()[0]; // plain names, HASH-only
+    let vec_attr = shape.vec().expect("NAME_PATTERNS[0] always has vec");
+
+    let a = Item::key(shape.pk(), shape.sk(), "pk", "a").vec(vec_attr, [4.0, 2.0, 1.0]);
+    let b = Item::key(shape.pk(), shape.sk(), "pk", "b")
+        .vec(vec_attr, [-1.0, -1.0, -1.0])
+        .attr("unrelated", AttributeValue::S("old".into()));
+
+    let ctx = TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone()]).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[a.clone(), b.clone()])
+        .await;
+
+    let b_updated = Item::key(shape.pk(), shape.sk(), "pk", "b").vec(vec_attr, [1.0, 1.0, 1.0]);
+    update_item_expr(
+        &ctx,
+        &b,
+        "SET #vec = :val REMOVE unrelated",
+        Some(alternator::float_list([1.0_f32, 1.0, 1.0])),
+    )
+    .send()
+    .await
+    .expect("UpdateItem remove unrelated plus vector set should succeed");
+
+    ctx.wait_for_count(2).await;
+    ctx.wait_for_ann([1.0, 1.0, 1.0], &[b_updated, a]).await;
 
     ctx.done().await;
     info!("finished");

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -157,17 +157,6 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
 
     let ctx = TableContext::create_with_data(&actors, shape, &[a.clone(), b.clone()]).await;
 
-    let vec_with_string_elem = AttributeValue::L(vec![
-        AttributeValue::N("1.0".into()),
-        AttributeValue::N("2.0".into()),
-        AttributeValue::S("3.0".into()),
-    ]);
-    let vec_with_null_elem = AttributeValue::L(vec![
-        AttributeValue::N("1.0".into()),
-        AttributeValue::N("2.0".into()),
-        AttributeValue::Null(true),
-    ]);
-
     update_item_expr(&ctx, &b, "REMOVE #vec", None)
         .send()
         .await
@@ -176,55 +165,35 @@ async fn update_item_with_invalid_vector_is_not_indexed(actors: Arc<TestActors>)
     ctx.wait_for_ann([1.0, 1.0, 1.0], std::slice::from_ref(&a))
         .await;
 
-    alternator::assert_service_error(
-        update_item_expr(
-            &ctx,
-            &a,
-            "SET #vec = :val",
-            Some(AttributeValue::S("not-a-vector".into())),
-        )
-        .send()
-        .await,
-        "ValidationException",
-    );
+    let invalid_values = [
+        AttributeValue::Null(true),
+        AttributeValue::S("not-a-vector".into()),
+        AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::S("3.0".into()),
+        ]),
+        AttributeValue::L(vec![
+            AttributeValue::N("1.0".into()),
+            AttributeValue::N("2.0".into()),
+            AttributeValue::Null(true),
+        ]),
+        alternator::float_list([1.0_f32, 1.0]),
+        alternator::float_list([1.0_f32, 1.0, 1.0, 1.0]),
+    ];
 
-    alternator::assert_service_error(
-        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_string_elem))
-            .send()
-            .await,
-        "ValidationException",
-    );
-
-    alternator::assert_service_error(
-        update_item_expr(&ctx, &a, "SET #vec = :val", Some(vec_with_null_elem))
-            .send()
-            .await,
-        "ValidationException",
-    );
-
-    alternator::assert_service_error(
-        update_item_expr(
-            &ctx,
-            &a,
-            "SET #vec = :val",
-            Some(alternator::float_list([1.0_f32, 1.0])),
-        )
-        .send()
-        .await,
-        "ValidationException",
-    );
-
-    alternator::assert_service_error(
-        update_item_expr(
-            &ctx,
-            &a,
-            "SET #vec = :val",
-            Some(alternator::float_list([1.0_f32, 1.0, 1.0, 1.0])),
-        )
-        .send()
-        .await,
-        "ValidationException",
-    );
+    for invalid_value in invalid_values {
+        info!(
+            ?invalid_value,
+            "expecting invalid vector UpdateItem to fail"
+        );
+        alternator::assert_service_error(
+            update_item_expr(&ctx, &a, "SET #vec = :val", Some(invalid_value))
+                .send()
+                .await,
+            "ValidationException",
+        );
+    }
 
     ctx.done().await;
     info!("finished");

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -470,7 +470,7 @@ impl Consumer for CdcConsumer {
             OperationType::PartitionDelete | OperationType::RowDelete => None,
 
             OperationType::RowUpdate | OperationType::RowInsert | OperationType::PostImage => {
-                match source.take_cdc_value(&mut row) {
+                match source.take_cdc_value(&mut row)? {
                     CdcValueStatus::Deleted => None,
                     CdcValueStatus::Skip => return Ok(()),
                     CdcValueStatus::NewValue(value) => {

--- a/crates/vector-store/src/db_index_backend.rs
+++ b/crates/vector-store/src/db_index_backend.rs
@@ -14,7 +14,6 @@ use crate::NonemptyArc;
 use crate::TableIdentifier;
 use crate::TableName;
 use crate::Vector;
-use crate::vector;
 use futures::TryStreamExt;
 use regex::Regex;
 use scylla::client::session::Session;
@@ -30,6 +29,9 @@ use std::sync::OnceLock;
 /// Because Alternator (DynamoDB-compatible) is schemaless, different items can
 /// have different types for the same attribute name, so a map is used instead
 /// of dedicated typed columns.
+///
+/// Current Alternator schema stores this as map<utf8, bytes>: attribute names
+/// are text keys and attribute values are serialized blobs.
 const ALTERNATOR_ATTRS_COLUMN: &str = ":attrs";
 
 pub(crate) enum CdcValueStatus {
@@ -79,14 +81,7 @@ impl DbIndexBackend {
     }
 
     pub fn extract_vector(&self, value: CqlValue) -> anyhow::Result<Option<Vector>> {
-        match self {
-            Self::Cql { .. } => Vector::try_from(value).map(Some),
-            Self::Alternator { target_columns } => vector::AlternatorAttrs {
-                attrs: value,
-                target_column: target_columns.first().as_ref(),
-            }
-            .try_into(),
-        }
+        Vector::try_from(value).map(Some)
     }
 
     pub fn extract_document(&self, value: CqlValue) -> anyhow::Result<Option<String>> {
@@ -102,17 +97,17 @@ impl DbIndexBackend {
         }
     }
 
-    pub fn take_cdc_value(&self, row: &mut CDCRow<'_>) -> CdcValueStatus {
+    pub fn take_cdc_value(&self, row: &mut CDCRow<'_>) -> anyhow::Result<CdcValueStatus> {
         match self {
             Self::Cql { target_columns } => {
                 let column = target_columns.first().as_ref();
                 if row.is_value_deleted(column) {
-                    return CdcValueStatus::Deleted;
+                    return Ok(CdcValueStatus::Deleted);
                 }
-                match row.take_value(column) {
+                Ok(match row.take_value(column) {
                     Some(value) => CdcValueStatus::NewValue(value),
                     None => CdcValueStatus::Skip,
-                }
+                })
             }
             Self::Alternator { target_columns } => {
                 // Check take_value before is_value_deleted.
@@ -120,24 +115,44 @@ impl DbIndexBackend {
                 // so is_value_deleted can be true even when a new value is present.
                 // We must check for a value first to avoid misreporting it as deleted.
                 let column = ALTERNATOR_ATTRS_COLUMN;
-                match row.take_value(column) {
-                    Some(value) => CdcValueStatus::NewValue(value),
-                    None if row.is_value_deleted(column) => CdcValueStatus::Deleted,
+                let target = target_columns.first().as_ref();
+                let value = match row.take_value(column) {
+                    Some(attrs) => take_alternator_attr(attrs, target)?,
+                    None => None,
+                };
+
+                match value {
+                    Some(value) => Ok(CdcValueStatus::NewValue(value)),
+                    None if row.is_value_deleted(column) => Ok(CdcValueStatus::Deleted),
                     None => {
-                        let target_deleted = row.take_deleted_elements(column).iter().any(|el| {
-                            el.as_text().map(String::as_str)
-                                == Some(target_columns.first().as_ref())
-                        });
+                        let target_deleted = row
+                            .take_deleted_elements(column)
+                            .iter()
+                            .any(|el| alternator_attr_key_matches_target(el, target));
                         if target_deleted {
-                            CdcValueStatus::Deleted
+                            Ok(CdcValueStatus::Deleted)
                         } else {
-                            CdcValueStatus::Skip
+                            Ok(CdcValueStatus::Skip)
                         }
                     }
                 }
             }
         }
     }
+}
+
+fn alternator_attr_key_matches_target(key: &CqlValue, target: &str) -> bool {
+    key.as_text().map(String::as_str) == Some(target)
+}
+
+fn take_alternator_attr(attrs: CqlValue, target: &str) -> anyhow::Result<Option<CqlValue>> {
+    let CqlValue::Map(entries) = attrs else {
+        anyhow::bail!("expected Map for :attrs column, got {attrs:?}");
+    };
+
+    Ok(entries
+        .into_iter()
+        .find_map(|(key, value)| alternator_attr_key_matches_target(&key, target).then_some(value)))
 }
 
 /// Builds the CQL range scan query appropriate for the given keyspace.
@@ -439,5 +454,49 @@ mod tests {
             query.contains(r#"writetime(":attrs"['it''s a "test"'])"#),
             "writetime must use the same escaped attribute access: {query}"
         );
+    }
+
+    #[test]
+    fn alternator_attr_text_key_matches_target() {
+        assert!(alternator_attr_key_matches_target(
+            &CqlValue::Text("vec".into()),
+            "vec"
+        ));
+    }
+
+    #[test]
+    fn alternator_attr_non_text_key_does_not_match_target() {
+        assert!(!alternator_attr_key_matches_target(
+            &CqlValue::Blob(b"vec".to_vec()),
+            "vec"
+        ));
+    }
+
+    #[test]
+    fn take_alternator_attr_returns_target_value() {
+        let attrs = CqlValue::Map(vec![
+            (CqlValue::Text("unrelated".into()), CqlValue::Blob(vec![1])),
+            (CqlValue::Text("vec".into()), CqlValue::Blob(vec![2])),
+        ]);
+
+        assert_eq!(
+            take_alternator_attr(attrs, "vec").unwrap(),
+            Some(CqlValue::Blob(vec![2]))
+        );
+    }
+
+    #[test]
+    fn take_alternator_attr_skips_unrelated_attrs() {
+        let attrs = CqlValue::Map(vec![(
+            CqlValue::Text("unrelated".into()),
+            CqlValue::Blob(vec![1]),
+        )]);
+
+        assert_eq!(take_alternator_attr(attrs, "vec").unwrap(), None);
+    }
+
+    #[test]
+    fn take_alternator_attr_rejects_non_map() {
+        assert!(take_alternator_attr(CqlValue::Blob(vec![1]), "vec").is_err());
     }
 }

--- a/crates/vector-store/src/vector.rs
+++ b/crates/vector-store/src/vector.rs
@@ -128,44 +128,6 @@ fn parse_alternator_list_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
         .collect()
 }
 
-pub(crate) struct AlternatorAttrs<'a> {
-    pub attrs: CqlValue,
-    pub target_column: &'a str,
-}
-
-/// Extracts a vector from the Alternator `:attrs` map column.
-///
-/// In Alternator, non-key attributes are stored in a `map<bytes, bytes>` column named `:attrs`.
-/// Each entry's key is the attribute name and the value is a serialised attribute prefixed with a 1-byte type tag.
-impl TryFrom<AlternatorAttrs<'_>> for Option<Vector> {
-    type Error = anyhow::Error;
-
-    fn try_from(input: AlternatorAttrs<'_>) -> anyhow::Result<Self> {
-        let AlternatorAttrs {
-            attrs,
-            target_column,
-        } = input;
-        let CqlValue::Map(entries) = attrs else {
-            bail!("expected Map for :attrs column, got {attrs:?}");
-        };
-
-        let target = target_column.as_bytes();
-
-        entries
-            .into_iter()
-            .find_map(|(key, value)| {
-                let matches = match &key {
-                    CqlValue::Blob(b) => b.as_slice() == target,
-                    CqlValue::Text(s) => s.as_bytes() == target,
-                    _ => false,
-                };
-                matches.then_some(value)
-            })
-            .map(Vector::try_from)
-            .transpose()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,68 +209,6 @@ mod tests {
     }
 
     #[test]
-    fn extract_from_attrs_map_with_blob_keys() {
-        let json = r#"{"L": [{"N": "1.0"}, {"N": "2.0"}]}"#;
-        let attrs = CqlValue::Map(vec![
-            (
-                CqlValue::Blob(b"other".to_vec()),
-                CqlValue::Blob(alternator_list_blob(r#"{"S": "ignored"}"#)),
-            ),
-            (
-                CqlValue::Blob(b"v".to_vec()),
-                CqlValue::Blob(alternator_list_blob(json)),
-            ),
-        ]);
-        let result = Option::<Vector>::try_from(AlternatorAttrs {
-            attrs,
-            target_column: "v",
-        })
-        .unwrap();
-        assert_eq!(result, Some(Vector::from(vec![1.0, 2.0])));
-    }
-
-    #[test]
-    fn extract_from_attrs_map_with_text_keys() {
-        let json = r#"{"L": [{"N": "3.0"}]}"#;
-        let attrs = CqlValue::Map(vec![(
-            CqlValue::Text("v".to_string()),
-            CqlValue::Blob(alternator_list_blob(json)),
-        )]);
-        let result = Option::<Vector>::try_from(AlternatorAttrs {
-            attrs,
-            target_column: "v",
-        })
-        .unwrap();
-        assert_eq!(result, Some(Vector::from(vec![3.0])));
-    }
-
-    #[test]
-    fn extract_from_attrs_map_missing_target() {
-        let attrs = CqlValue::Map(vec![(
-            CqlValue::Blob(b"other".to_vec()),
-            CqlValue::Blob(b"data".to_vec()),
-        )]);
-        let result = Option::<Vector>::try_from(AlternatorAttrs {
-            attrs,
-            target_column: "v",
-        })
-        .unwrap();
-        assert_eq!(result, None);
-    }
-
-    #[test]
-    fn extract_from_attrs_non_map() {
-        let attrs = CqlValue::Int(42);
-        assert!(
-            Option::<Vector>::try_from(AlternatorAttrs {
-                attrs,
-                target_column: "v"
-            })
-            .is_err()
-        );
-    }
-
-    #[test]
     fn extract_from_alternator_vector_blob() {
         let value = CqlValue::Blob(alternator_vector_blob(&[1.0, 2.5, 3.0]));
         let result = Vector::try_from(value).unwrap();
@@ -329,25 +229,5 @@ mod tests {
         bytes.extend_from_slice(&[0x00, 0x01, 0x02, 0x03, 0x04]);
         let value = CqlValue::Blob(bytes);
         assert!(Vector::try_from(value).is_err());
-    }
-
-    #[test]
-    fn extract_from_attrs_map_alternator_vector() {
-        let attrs = CqlValue::Map(vec![
-            (
-                CqlValue::Blob(b"other".to_vec()),
-                CqlValue::Blob(alternator_list_blob(r#"{"S": "ignored"}"#)),
-            ),
-            (
-                CqlValue::Blob(b"v".to_vec()),
-                CqlValue::Blob(alternator_vector_blob(&[1.0, 2.0, 3.0])),
-            ),
-        ]);
-        let result = Option::<Vector>::try_from(AlternatorAttrs {
-            attrs,
-            target_column: "v",
-        })
-        .unwrap();
-        assert_eq!(result, Some(Vector::from(vec![1.0, 2.0, 3.0])));
     }
 }


### PR DESCRIPTION
Fix Alternator CDC processing so vector index updates are based on the indexed attribute inside `:attrs`, not on any physical `:attrs` map change.

Alternator stores user attributes in `:attrs` as `map<text, blob>` in CQL terms, represented internally as `map<utf8, bytes>`. Because of that, CDC events for unrelated attributes can still modify the same physical `:attrs` column. The vector-store CDC path now extracts the configured indexed attribute first, then decides whether the event is a new value, deletion, or should be skipped.

This prevents unrelated Alternator `UpdateItem`/`PutItem` changes from de-indexing vectors, while preserving replacement semantics for `PutItem`.

This PR also adds validator coverage for Alternator `PutItem` and `UpdateItem` CDC edge cases, including invalid vector replacements, unrelated attribute updates, mixed target/unrelated attribute deltas, and target attribute deletion. It also removes the obsolete whole-`:attrs` vector extractor so Alternator schema mapping stays in the index backend and vector parsing only handles logical vector values.
