### PR TITLE
vector-store: refactor vector_timestamps into values_timestamps

### DIFF
--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -346,7 +346,7 @@ fn fullscan_add(c: &mut Criterion) {
                             let request = (
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
                                 Some(vec![it as f32; DIMENSIONS].into()),
-                                Timestamp::from_unix_timestamp(0),
+                                Timestamp::from_millis(0),
                                 AsyncInProgress::Fullscan(tx_in_progress),
                             );
                             let start = Instant::now();
@@ -416,7 +416,7 @@ fn search(c: &mut Criterion) {
                     tx.send((
                         [(CqlValue::BigInt(it))].into_iter().collect(),
                         Some(vec![it as f32; DIMENSIONS].into()),
-                        Timestamp::from_unix_timestamp(0),
+                        Timestamp::from_millis(0),
                         AsyncInProgress::Fullscan(tx_in_progress.clone()),
                     ))
                     .await
@@ -551,7 +551,7 @@ fn cdc_add(c: &mut Criterion) {
                             let request = (
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
                                 Some(vec![it as f32; DIMENSIONS].into()),
-                                Timestamp::from_unix_timestamp(0),
+                                Timestamp::from_millis(0),
                                 AsyncInProgress::Fullscan(tx_in_progress),
                             );
                             let start = Instant::now();
@@ -628,7 +628,7 @@ fn cdc_update(c: &mut Criterion) {
                         .send((
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
-                            Timestamp::from_unix_timestamp(0),
+                            Timestamp::from_millis(0),
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
@@ -676,7 +676,7 @@ fn cdc_update(c: &mut Criterion) {
                                 .send((
                                     [(CqlValue::BigInt(id))].into_iter().collect(),
                                     Some(vector),
-                                    Timestamp::from_unix_timestamp(timestamp),
+                                    Timestamp::from_millis(timestamp),
                                     AsyncInProgress::Fullscan(tx_in_progress.clone()),
                                 ))
                                 .await
@@ -779,7 +779,7 @@ fn search_while_updating(c: &mut Criterion) {
                         .send((
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
-                            Timestamp::from_unix_timestamp(0),
+                            Timestamp::from_millis(0),
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
@@ -788,7 +788,7 @@ fn search_while_updating(c: &mut Criterion) {
                         .send((
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
-                            Timestamp::from_unix_timestamp(0),
+                            Timestamp::from_millis(0),
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
@@ -821,7 +821,7 @@ fn search_while_updating(c: &mut Criterion) {
                             .send((
                                 [(CqlValue::BigInt(id))].into_iter().collect(),
                                 Some(vector),
-                                Timestamp::from_unix_timestamp(timestamp),
+                                Timestamp::from_millis(timestamp),
                                 AsyncInProgress::Fullscan(tx_in_progress.clone()),
                             ))
                             .await
@@ -849,7 +849,7 @@ fn search_while_updating(c: &mut Criterion) {
                                 .send((
                                     [(CqlValue::BigInt(id))].into_iter().collect(),
                                     Some(vector),
-                                    Timestamp::from_unix_timestamp(timestamp),
+                                    Timestamp::from_millis(timestamp),
                                     AsyncInProgress::Fullscan(tx_in_progress.clone()),
                                 ))
                                 .await
@@ -1006,7 +1006,7 @@ fn search_while_inserting(c: &mut Criterion) {
                     while Arc::clone(&notify_stop).notified().now_or_never().is_none() {
                         let pk = pk.fetch_add(1, Ordering::Relaxed);
                         let vector = vec![pk as f32; DIMENSIONS].into();
-                        let timestamp = Timestamp::from_unix_timestamp(0);
+                        let timestamp = Timestamp::from_millis(0);
                         if tx_cdc
                             .send((
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
@@ -1033,7 +1033,7 @@ fn search_while_inserting(c: &mut Criterion) {
                         while Arc::clone(&stop_bg).notified().now_or_never().is_none() {
                             let pk = pk.fetch_add(1, Ordering::Relaxed);
                             let vector = vec![pk as f32; DIMENSIONS].into();
-                            let timestamp = Timestamp::from_unix_timestamp(0);
+                            let timestamp = Timestamp::from_millis(0);
                             if tx_cdc_bg
                                 .send((
                                     [(CqlValue::BigInt(pk))].into_iter().collect(),

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -17,11 +17,7 @@ use crate::db_index_backend::DbIndexBackend;
 use crate::internals::Internals;
 use crate::internals::InternalsExt;
 use crate::perf;
-use ::time::Date;
-use ::time::Month;
 use ::time::OffsetDateTime;
-use ::time::PrimitiveDateTime;
-use ::time::Time;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -446,7 +442,6 @@ struct CdcConsumerData {
     backend: DbIndexBackend,
     kind: IndexKind,
     tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
-    gregorian_epoch: PrimitiveDateTime,
 }
 
 struct CdcConsumer(Arc<CdcConsumerData>);
@@ -500,17 +495,10 @@ impl Consumer for CdcConsumer {
             return Ok(());
         };
 
-        const HUNDREDS_NANOS_TO_MICROS: u64 = 10;
-        let timestamp = (self.0.gregorian_epoch
-            + Duration::from_micros(
-                row.time
-                    .get_timestamp()
-                    .ok_or(anyhow!("CDC error: time has no timestamp"))?
-                    .to_gregorian()
-                    .0
-                    / HUNDREDS_NANOS_TO_MICROS,
-            ))
-        .into();
+        let timestamp = row
+            .time
+            .try_into()
+            .map_err(|err| anyhow!("CDC error: converting row.time: {err}"))?;
 
         _ = self
             .0
@@ -560,11 +548,6 @@ impl CdcConsumerFactory {
             .collect_nonempty_arc()
             .ok_or_else(|| anyhow!("primary key must have at least one column"))?;
 
-        let gregorian_epoch = PrimitiveDateTime::new(
-            Date::from_calendar_date(1582, Month::October, 15)?,
-            Time::MIDNIGHT,
-        );
-
         let backend = DbIndexBackend::from(metadata);
 
         Ok(Self(Arc::new(CdcConsumerData {
@@ -572,7 +555,6 @@ impl CdcConsumerFactory {
             backend,
             kind: metadata.kind.clone(),
             tx,
-            gregorian_epoch,
         })))
     }
 }

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -609,7 +609,7 @@ impl Statements {
                     debug!("range_scan_stream: bad type of a writetime");
                     return None;
                 };
-                let timestamp = Timestamp::UNIX_EPOCH + Duration::from_micros(timestamp as u64);
+                let timestamp = Timestamp::from_micros(timestamp as u64);
 
                 let Some(column_value) = row.columns.pop().unwrap() else {
                     debug!("range_scan_stream: missing target column");

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -59,6 +59,7 @@ pub use crate::similarity::SimilarityScore;
 pub use crate::table::PartitionId;
 pub use crate::table::PrimaryId;
 pub use crate::timestamp::Timestamp;
+pub use crate::timestamp::Timestamped;
 use db::Db;
 use scylla::cluster::metadata::ColumnType;
 use scylla::serialize::SerializationError;

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -227,10 +227,7 @@ mod tests {
 
         // Create and immediately drop a Cdc marker to trigger observation.
         let histogram = metrics.indexing_lag.with_label_values(&["ks", "idx"]);
-        drop(AsyncInProgress::cdc(
-            histogram.clone(),
-            Timestamp::from_unix_timestamp(0),
-        ));
+        drop(AsyncInProgress::cdc(histogram.clone(), Timestamp::MIN));
 
         assert_eq!(histogram.get_sample_count(), 1);
         assert!(histogram.get_sample_sum() > 0.0);

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -294,7 +294,7 @@ mod tests {
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
             value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_unix_timestamp(10),
+            timestamp: Timestamp::from_millis(10),
         };
         table
             .write()
@@ -332,7 +332,7 @@ mod tests {
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
             value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_unix_timestamp(10),
+            timestamp: Timestamp::from_millis(10),
         };
         let (tx_progress, _rx_progress) = mpsc::channel(1);
         table
@@ -397,7 +397,7 @@ mod tests {
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
             value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_unix_timestamp(10),
+            timestamp: Timestamp::from_millis(10),
         };
         table
             .write()
@@ -462,7 +462,7 @@ mod tests {
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
             value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_unix_timestamp(10),
+            timestamp: Timestamp::from_millis(10),
         };
         table
             .write()
@@ -539,7 +539,7 @@ mod tests {
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
             value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_unix_timestamp(10),
+            timestamp: Timestamp::from_millis(10),
         };
         table
             .write()
@@ -640,7 +640,7 @@ mod tests {
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
             value: None,
-            timestamp: Timestamp::from_unix_timestamp(10),
+            timestamp: Timestamp::from_millis(10),
         };
         table
             .write()
@@ -696,7 +696,7 @@ mod tests {
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
             value: None,
-            timestamp: Timestamp::from_unix_timestamp(10),
+            timestamp: Timestamp::from_millis(10),
         };
         table
             .write()

--- a/crates/vector-store/src/table/chunk_timestamps.rs
+++ b/crates/vector-store/src/table/chunk_timestamps.rs
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::Timestamp;
+use crate::table::Chunk;
+use crate::table::Epoch;
+use crate::timestamp::Timestamped;
+use std::mem;
+use std::num::NonZeroUsize;
+
+const EPOCH_SIZE: usize = mem::size_of::<u8>() * 2;
+const TIMESTAMPED_SIZE: usize = mem::size_of::<u8>() * 8;
+
+const _: () = assert!(Epoch::new().to_ne_bytes().len() == EPOCH_SIZE);
+const _: () =
+    assert!(Timestamped::new_valid(Timestamp::MIN).into_ne_bytes().len() == TIMESTAMPED_SIZE);
+
+/// A chunk of timestamps, which is a fixed-size array of `Timestamped<()>` values, along with an
+/// `Epoch` value.
+#[derive(Debug)]
+pub(super) struct ChunkTimestamps(usize);
+
+impl ChunkTimestamps {
+    /// Create a new `ChunkTimestamps` with the given size.
+    pub(super) fn new(size: NonZeroUsize) -> Self {
+        Self(size.get())
+    }
+}
+
+/// A shared view of a `ChunkTimestamps`, which allows reading the `Epoch` and individual
+/// `Timestamped<()>` values.
+pub(super) struct ChunkTimestampsShared<'a> {
+    bytes: &'a [u8],
+}
+
+impl ChunkTimestampsShared<'_> {
+    /// Get the `Epoch` value from the chunk.
+    pub(super) fn epoch(&self) -> Epoch {
+        epoch(self.bytes)
+    }
+}
+
+/// An exclusive view of a `ChunkTimestamps`, which allows reading and writing the `Epoch` and
+/// individual `Timestamped<()>` values.
+pub(super) struct ChunkTimestampsExclusive<'a> {
+    size: usize,
+    bytes: &'a mut [u8],
+}
+
+impl ChunkTimestampsExclusive<'_> {
+    /// Get the `Epoch` value from the chunk.
+    pub(super) fn epoch(&self) -> Epoch {
+        epoch(self.bytes)
+    }
+
+    /// Set the `Epoch` value in the chunk.
+    pub(super) fn set_epoch(&mut self, epoch: Epoch) {
+        set_epoch(self.bytes, epoch);
+    }
+
+    /// Get the `Timestamped<()>` value at the given index in the chunk.
+    pub(super) fn timestamp(&self, idx: usize) -> Option<Timestamped<()>> {
+        timestamp(self.size, self.bytes, idx)
+    }
+
+    /// Set the `Timestamped<()>` value at the given index in the chunk.
+    pub(super) fn set_timestamp(&mut self, idx: usize, value: Timestamped<()>) -> Option<()> {
+        set_timestamp(self.size, self.bytes, idx, value)
+    }
+}
+
+impl Chunk for ChunkTimestamps {
+    type Shared<'a> = ChunkTimestampsShared<'a>;
+    type Exclusive<'a> = ChunkTimestampsExclusive<'a>;
+
+    fn size(&self) -> NonZeroUsize {
+        chunk_size(self.0).try_into().unwrap()
+    }
+
+    fn fill_default(&self, bytes: &mut [u8]) -> Option<()> {
+        if chunk_size(self.0) != bytes.len() {
+            return None;
+        }
+        set_epoch(bytes, Epoch::new());
+        for idx in 0..self.0 {
+            set_timestamp(
+                self.0,
+                bytes,
+                idx,
+                Timestamped::new_tombstone(Timestamp::MIN),
+            )
+            .expect("chunk size is correct");
+        }
+        Some(())
+    }
+
+    fn get<'a>(&self, bytes: &'a [u8]) -> Option<Self::Shared<'a>> {
+        (chunk_size(self.0) == bytes.len()).then_some(ChunkTimestampsShared { bytes })
+    }
+
+    fn get_mut<'a>(&self, bytes: &'a mut [u8]) -> Option<Self::Exclusive<'a>> {
+        (chunk_size(self.0) == bytes.len()).then_some(ChunkTimestampsExclusive {
+            size: self.0,
+            bytes,
+        })
+    }
+}
+
+fn chunk_size(elements: usize) -> usize {
+    EPOCH_SIZE + elements * TIMESTAMPED_SIZE
+}
+
+fn epoch(bytes: &[u8]) -> Epoch {
+    let mut dst = [0; EPOCH_SIZE];
+    dst.copy_from_slice(&bytes[..EPOCH_SIZE]);
+    Epoch::from_ne_bytes(dst)
+}
+
+fn set_epoch(bytes: &mut [u8], epoch: Epoch) {
+    let src = epoch.to_ne_bytes();
+    bytes[..EPOCH_SIZE].copy_from_slice(&src);
+}
+
+fn timestamp(size: usize, bytes: &[u8], idx: usize) -> Option<Timestamped<()>> {
+    if idx >= size {
+        return None;
+    }
+    let mut dst = [0; TIMESTAMPED_SIZE];
+    let offset = EPOCH_SIZE + idx * TIMESTAMPED_SIZE;
+    dst.copy_from_slice(&bytes[offset..offset + TIMESTAMPED_SIZE]);
+    Some(Timestamped::from_ne_bytes(dst))
+}
+
+fn set_timestamp(size: usize, bytes: &mut [u8], idx: usize, value: Timestamped<()>) -> Option<()> {
+    if idx >= size {
+        return None;
+    }
+    let src = value.into_ne_bytes();
+    let offset = EPOCH_SIZE + idx * TIMESTAMPED_SIZE;
+    bytes[offset..offset + TIMESTAMPED_SIZE].copy_from_slice(&src);
+    Some(())
+}

--- a/crates/vector-store/src/table/column.rs
+++ b/crates/vector-store/src/table/column.rs
@@ -75,7 +75,7 @@ impl Column {
     }
 
     pub(super) fn resize_with(&mut self, size: usize) {
-        let timestamp = Timestamp::UNIX_EPOCH;
+        let timestamp = Timestamp::MIN;
         match self {
             Self::Ascii(vec) => vec.resize_with(size, || TValue::None(timestamp)),
             Self::BigInt(vec) => vec.resize_with(size, || TValue::None(timestamp)),

--- a/crates/vector-store/src/table/column_vec.rs
+++ b/crates/vector-store/src/table/column_vec.rs
@@ -3,10 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::Timestamp;
-use crate::table::ETValue;
 use crate::table::Idx;
-use crate::table::PrimaryId;
 use anyhow::anyhow;
 
 /// ColumnVec is a wrapper around Vec and generic index type. It is used to safely access columns by specific index types.
@@ -41,19 +38,5 @@ impl<I: Idx, T> ColumnVec<I, T> {
             .get_mut(idx)
             .ok_or_else(|| anyhow!("Index out of ColumnVec bounds"))? = value;
         Ok(())
-    }
-}
-
-impl<T> ColumnVec<PrimaryId, ETValue<T>> {
-    pub(super) fn update_epoch_timestamp(
-        &mut self,
-        primary_id: PrimaryId,
-        timestamp: Timestamp,
-    ) -> anyhow::Result<()> {
-        self.get_mut(primary_id)
-            .map(|value| {
-                value.update_epoch_timestamp(primary_id.epoch(), timestamp);
-            })
-            .ok_or_else(|| anyhow!("Index out of ColumnVec bounds"))
     }
 }

--- a/crates/vector-store/src/table/column_vec_chunks.rs
+++ b/crates/vector-store/src/table/column_vec_chunks.rs
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::table::Chunk;
+use crate::table::Idx;
+use crate::table::VecChunks;
+
+/// ColumnVecChunks is a wrapper around VecChunks and generic index type. It is used to safely
+/// access columns by specific index types.
+#[derive(Debug)]
+pub(super) struct ColumnVecChunks<I, T: Chunk> {
+    vec: VecChunks<T>,
+    _index: std::marker::PhantomData<I>,
+}
+
+impl<I: Idx, T: Chunk> ColumnVecChunks<I, T> {
+    /// Create a new ColumnVecChunks with the given chunk.
+    pub(super) fn new(chunk: T) -> Self {
+        Self {
+            vec: VecChunks::new(chunk),
+            _index: std::marker::PhantomData,
+        }
+    }
+
+    /// Resize the underlying VecChunks to the given size.
+    pub(super) fn resize(&mut self, size: usize) {
+        self.vec.resize(size);
+    }
+
+    /// Get the shared reference to the chunk at the given index.
+    pub(super) fn get(&self, idx: I) -> Option<T::Shared<'_>> {
+        self.vec.get(idx.idx())
+    }
+
+    /// Get the exclusive reference to the chunk at the given index.
+    pub(super) fn get_mut(&mut self, idx: I) -> Option<T::Exclusive<'_>> {
+        self.vec.get_mut(idx.idx())
+    }
+}

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -5,6 +5,7 @@
 
 mod column;
 mod column_vec;
+mod column_vec_chunks;
 mod partition_id;
 mod primary_id;
 mod vec_chunks;
@@ -45,6 +46,8 @@ use std::mem;
 use std::sync::Arc;
 use tap::Pipe;
 use tracing::warn;
+use vec_chunks::Chunk;
+use vec_chunks::VecChunks;
 
 /// Idx is a trait for types that can be used as an index in the column vectors.
 trait Idx {

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -21,11 +21,14 @@ use crate::PrimaryKey;
 use crate::Restriction;
 use crate::Timestamp;
 use crate::primary_key::normalize;
+use crate::timestamp::Timestamped;
 use anyhow::anyhow;
 use anyhow::bail;
 use bigdecimal::BigDecimal;
+use chunk_timestamps::ChunkTimestamps;
 use column::Column;
 use column_vec::ColumnVec;
+use column_vec_chunks::ColumnVecChunks;
 use itertools::Itertools;
 use num_bigint::BigInt;
 pub(crate) use partition_id::IndexId;
@@ -43,7 +46,7 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::collections::btree_map::Entry;
-use std::mem;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tap::Pipe;
 use tracing::warn;
@@ -58,30 +61,6 @@ trait Idx {
 /// A newtype for partition size
 #[derive(Clone, Copy, Debug, derive_more::From, derive_more::Into, derive_more::AsRef)]
 struct PartitionSize(usize);
-
-/// An enum that can store Epoch, Timestamp and optionally a value
-#[derive(Debug)]
-enum ETValue<T> {
-    None(Epoch, Timestamp),
-    Some(Epoch, Timestamp, T),
-}
-
-const _: () = assert!(
-    mem::size_of::<ETValue<()>>() <= 2 * mem::size_of::<u64>(),
-    "The impact of Epoch, Timestamp and enum in ColumnValue shouldn't be larger that 2 * u64"
-);
-
-impl<T> ETValue<T> {
-    fn update_epoch_timestamp(&mut self, epoch: Epoch, timestamp: Timestamp) {
-        match self {
-            Self::None(value_epoch, value_timestamp)
-            | Self::Some(value_epoch, value_timestamp, _) => {
-                *value_epoch = epoch;
-                *value_timestamp = timestamp;
-            }
-        }
-    }
-}
 
 /// An enum that can store Timestamp and optionally a value
 #[derive(Debug)]
@@ -196,7 +175,7 @@ struct Index {
     _available_columns: BTreeSet<ColumnName>,
 
     /// Timestamps of the last vector update
-    vector_timestamps: ColumnVec<PrimaryId, ETValue<()>>,
+    values_timestamps: ColumnVecChunks<PrimaryId, ChunkTimestamps>,
 }
 
 impl Index {
@@ -207,6 +186,7 @@ impl Index {
         primary_key_columns: NonemptyArc<ColumnName>,
         filtering_columns: &[ColumnName],
     ) -> Self {
+        let chunk_size = NonZeroUsize::new(1).unwrap();
         Self {
             index_id,
             data: IndexData::Global,
@@ -215,7 +195,7 @@ impl Index {
                 .chain(filtering_columns.iter())
                 .cloned()
                 .collect(),
-            vector_timestamps: ColumnVec::new(),
+            values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(chunk_size)),
         }
     }
 
@@ -224,6 +204,7 @@ impl Index {
         key_columns: NonemptyArc<ColumnName>,
         filtering_columns: &[ColumnName],
     ) -> Self {
+        let chunk_size = NonZeroUsize::new(1).unwrap();
         Self {
             index_id,
             _available_columns: key_columns
@@ -231,7 +212,7 @@ impl Index {
                 .chain(filtering_columns.iter())
                 .cloned()
                 .collect(),
-            vector_timestamps: ColumnVec::new(),
+            values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(chunk_size)),
             data: IndexData::Local {
                 key_columns,
                 map: BTreeMap::new(),
@@ -248,8 +229,7 @@ impl Index {
             IndexData::Global => {}
             IndexData::Local { ids, .. } => ids.resize_with(new_size, || None),
         }
-        self.vector_timestamps
-            .resize_with(new_size, || ETValue::None(Epoch::new(), Timestamp::MIN));
+        self.values_timestamps.resize(new_size);
     }
 
     fn resize_partition_ids(&mut self) -> anyhow::Result<()> {
@@ -507,10 +487,7 @@ impl Table {
     fn is_valid_primary_id(&self, partition_id: PartitionId, primary_id: PrimaryId) -> bool {
         self.indexes
             .get(&partition_id.index_id())
-            .and_then(|index| match index.vector_timestamps.get(primary_id)? {
-                ETValue::Some(epoch, _, _) => Some(*epoch),
-                ETValue::None(_, _) => None,
-            })
+            .and_then(|index| index.values_timestamps.get(primary_id).map(|v| v.epoch()))
             .is_some_and(|epoch| epoch == primary_id.epoch())
     }
 }
@@ -544,29 +521,31 @@ impl TableAdd for Table {
             Entry::Occupied(entry) => {
                 let primary_id = *entry.get();
                 self.indexes.iter_mut().try_for_each(|(index_id, index)| {
-                    let (epoch, timestamp, vector_already_exists) = match index
-                        .vector_timestamps
-                        .get(primary_id)
-                    {
-                        Some(ETValue::Some(epoch, timestamp, _)) => (*epoch, timestamp, true),
-                        Some(ETValue::None(epoch, timestamp)) => (*epoch, timestamp, false),
-                        None => {
-                            bail!(
-                                "Failed to update vector: \
-                                missing vector timestamp for index_id {index_id:?} and primary_id {primary_id:?}"
-                            );
-                        }
-                    };
-                    if *timestamp >= db_row.timestamp {
-                        return Ok(());
-                    }
-                    let primary_id = primary_id.new_epoch(epoch);
                     let partition_id = index.partition_id(primary_id).ok_or_else(|| {
                         anyhow!(
-                            "Failed to update vector: \
-                            missing partition id for index_id {index_id:?} and primary_id {primary_id:?}"
+                            "Failed to update value: missing partition_id \
+                            for index_id {index_id:?}  and primary_id {primary_id:?}"
                         )
                     })?;
+                    let Some(mut values_timestamps) = index.values_timestamps.get_mut(primary_id)
+                    else {
+                        bail!(
+                            "Failed to update value: missing value timestamp \
+                            for index_id {index_id:?} and primary_id {primary_id:?}"
+                        )
+                    };
+                    let epoch = values_timestamps.epoch();
+                    let Some(timestamped) = values_timestamps.timestamp(0) else {
+                        bail!(
+                            "Failed to update value:  missing first timestamped \
+                            for index_id {index_id:?} and primary_id {primary_id:?}"
+                        )
+                    };
+                    if timestamped.timestamp() >= db_row.timestamp {
+                        return Ok(());
+                    }
+                    let vector_already_exists = timestamped.is_valid();
+                    let primary_id = primary_id.new_epoch(epoch);
                     if let Some(value) = &value {
                         if vector_already_exists {
                             operations.push(Operation::RemoveBeforeAddValue {
@@ -576,21 +555,34 @@ impl TableAdd for Table {
                         }
 
                         let primary_id = primary_id.next_epoch();
-                        let timestamp = db_row.timestamp;
                         operations.push(Operation::AddValue {
                             primary_id,
                             partition_id,
                             value: value.clone(),
                             is_update: vector_already_exists,
                         });
-                        index
-                            .vector_timestamps
-                            .update_epoch_timestamp(primary_id, timestamp)?;
+                        values_timestamps.set_epoch(primary_id.epoch());
+                        if values_timestamps
+                            .set_timestamp(0, Timestamped::new_valid(db_row.timestamp))
+                            .is_none()
+                        {
+                            bail!(
+                                "Failed to update value: unable to set first valid timestamped \
+                                for index_id {index_id:?} and primary_id {primary_id:?}"
+                            );
+                        }
                     } else {
                         let epoch = primary_id.epoch().next();
-                        index
-                            .vector_timestamps
-                            .update(primary_id, ETValue::None(epoch, *timestamp))?;
+                        values_timestamps.set_epoch(epoch);
+                        if values_timestamps
+                            .set_timestamp(0, Timestamped::new_tombstone(db_row.timestamp))
+                            .is_none()
+                        {
+                            bail!(
+                                "Failed to update value: unable to set first tombstone timestamped \
+                                for index_id {index_id:?} and primary_id {primary_id:?}"
+                            );
+                        }
                         if vector_already_exists {
                             operations.push(Operation::RemoveValue {
                                 primary_id,
@@ -628,10 +620,24 @@ impl TableAdd for Table {
                                     index.add(primary_id, partition_key)?
                                 }
                             };
-                            index.vector_timestamps.update(
-                                primary_id,
-                                ETValue::Some(primary_id.epoch(), db_row.timestamp, ()),
-                            )?;
+                            let Some(mut values_timestamps) =
+                                index.values_timestamps.get_mut(primary_id)
+                            else {
+                                bail!(
+                                    "Failed to add value:  missing value timestamp \
+                                    for index_id {index_id:?} and primary_id {primary_id:?}"
+                                )
+                            };
+                            values_timestamps.set_epoch(primary_id.epoch());
+                            if values_timestamps
+                                .set_timestamp(0, Timestamped::new_valid(db_row.timestamp))
+                                .is_none()
+                            {
+                                bail!(
+                                    "Failed to add value: unable to add first value timestamped \
+                                    for index_id {index_id:?} and primary_id {primary_id:?}"
+                                )
+                            }
                             operations.push(Operation::AddValue {
                                 primary_id,
                                 partition_id,

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -7,6 +7,7 @@ mod column;
 mod column_vec;
 mod partition_id;
 mod primary_id;
+mod vec_chunks;
 
 use crate::ColumnName;
 use crate::DbIndexedRow;

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod chunk_timestamps;
 mod column;
 mod column_vec;
 mod column_vec_chunks;

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -247,9 +247,8 @@ impl Index {
             IndexData::Global => {}
             IndexData::Local { ids, .. } => ids.resize_with(new_size, || None),
         }
-        self.vector_timestamps.resize_with(new_size, || {
-            ETValue::None(Epoch::new(), Timestamp::UNIX_EPOCH)
-        });
+        self.vector_timestamps
+            .resize_with(new_size, || ETValue::None(Epoch::new(), Timestamp::MIN));
     }
 
     fn resize_partition_ids(&mut self) -> anyhow::Result<()> {
@@ -974,7 +973,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(1)].into(),
                         value: Some(DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_unix_timestamp(100),
+                        timestamp: Timestamp::from_millis(100),
                     },
                 )
                 .unwrap();
@@ -999,7 +998,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
                         value: Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_unix_timestamp(100),
+                        timestamp: Timestamp::from_millis(100),
                     },
                 )
                 .unwrap();
@@ -1026,7 +1025,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(3)].into(),
                         value: Some(DbIndexedValue::Vector(vec![0.3, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_unix_timestamp(100),
+                        timestamp: Timestamp::from_millis(100),
                     },
                 )
                 .unwrap();
@@ -1093,7 +1092,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
                         value: Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_unix_timestamp(50),
+                        timestamp: Timestamp::from_millis(50),
                     },
                 )
                 .unwrap();
@@ -1106,7 +1105,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
                         value: Some(DbIndexedValue::Vector(vec![0.5, 0.5, 0.3].into())),
-                        timestamp: Timestamp::from_unix_timestamp(150),
+                        timestamp: Timestamp::from_millis(150),
                     },
                 )
                 .unwrap();
@@ -1148,7 +1147,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(1)].into(),
                         value: None,
-                        timestamp: Timestamp::from_unix_timestamp(200),
+                        timestamp: Timestamp::from_millis(200),
                     },
                 )
                 .unwrap();
@@ -1171,7 +1170,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
                         value: None,
-                        timestamp: Timestamp::from_unix_timestamp(200),
+                        timestamp: Timestamp::from_millis(200),
                     },
                 )
                 .unwrap();
@@ -1194,7 +1193,7 @@ mod tests {
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(3)].into(),
                         value: None,
-                        timestamp: Timestamp::from_unix_timestamp(200),
+                        timestamp: Timestamp::from_millis(200),
                     },
                 )
                 .unwrap();

--- a/crates/vector-store/src/table/primary_id.rs
+++ b/crates/vector-store/src/table/primary_id.rs
@@ -76,7 +76,7 @@ impl Epoch {
     const MIN: u16 = 0;
     const MAX: u16 = u16::MAX;
 
-    pub(super) fn new() -> Self {
+    pub(super) const fn new() -> Self {
         Self(Self::MIN)
     }
 
@@ -87,5 +87,13 @@ impl Epoch {
         } else {
             Self(self.0 + 1)
         }
+    }
+
+    pub(super) const fn to_ne_bytes(self) -> [u8; 2] {
+        self.0.to_ne_bytes()
+    }
+
+    pub(super) const fn from_ne_bytes(bytes: [u8; 2]) -> Self {
+        Self(u16::from_ne_bytes(bytes))
     }
 }

--- a/crates/vector-store/src/table/vec_chunks.rs
+++ b/crates/vector-store/src/table/vec_chunks.rs
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use std::num::NonZeroUsize;
+
+/// A trait that defines a chunk of data that can be stored in a VecChunks.
+pub(crate) trait Chunk {
+    type Shared<'a>;
+    type Exclusive<'a>;
+
+    fn size(&self) -> NonZeroUsize;
+    fn fill_default(&self, bytes: &mut [u8]) -> Option<()>;
+    fn get<'a>(&self, bytes: &'a [u8]) -> Option<Self::Shared<'a>>;
+    fn get_mut<'a>(&self, bytes: &'a mut [u8]) -> Option<Self::Exclusive<'a>>;
+}
+
+/// VecChunks is a wrapper around Vec<u8> that allows us to store chunks of data in a contiguous
+/// memory layout.
+#[derive(Debug)]
+pub(crate) struct VecChunks<T: Chunk> {
+    vec: Vec<u8>,
+    chunk_size: usize,
+    chunk: T,
+}
+
+impl<T: Chunk> VecChunks<T> {
+    /// Creates a new VecChunks with the given chunk type.
+    pub(crate) fn new(chunk: T) -> Self {
+        let chunk_size = chunk.size().get();
+        Self {
+            vec: Vec::new(),
+            chunk_size,
+            chunk,
+        }
+    }
+
+    /// Returns the number of chunks in the VecChunks.
+    pub(crate) fn len(&self) -> usize {
+        self.vec.len() / self.chunk_size
+    }
+
+    /// Resizes the VecChunks to the given size.
+    ///
+    /// If the new size is larger than the current size, the new chunks will be filled with the
+    /// default value for the chunk type.
+    pub(crate) fn resize(&mut self, size: usize) {
+        let len = self.len();
+        if size <= len {
+            self.vec.truncate(size * self.chunk_size);
+            return;
+        }
+        let mut chunk_bytes = vec![0u8; self.chunk_size];
+        self.chunk
+            .fill_default(&mut chunk_bytes)
+            .expect("chunk_bytes is sized to chunk_size");
+        self.vec.reserve((size - len) * self.chunk_size);
+        for _ in len..size {
+            self.vec.extend_from_slice(&chunk_bytes);
+        }
+    }
+
+    /// Returns a shared reference to the chunk at the given index.
+    pub(crate) fn get(&self, idx: usize) -> Option<T::Shared<'_>> {
+        if idx >= self.len() {
+            return None;
+        }
+        self.chunk
+            .get(&self.vec[idx * self.chunk_size..(idx + 1) * self.chunk_size])
+    }
+
+    /// Returns an exclusive reference to the chunk at the given index.
+    pub(crate) fn get_mut(&mut self, idx: usize) -> Option<T::Exclusive<'_>> {
+        if idx >= self.len() {
+            return None;
+        }
+        self.chunk
+            .get_mut(&mut self.vec[idx * self.chunk_size..(idx + 1) * self.chunk_size])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+
+    struct TestChunk;
+    struct TestChunkShared<'a>(&'a [u8]);
+    struct TestChunkExclusive<'a>(&'a mut [u8]);
+
+    impl TestChunkShared<'_> {
+        fn get(&self) -> u32 {
+            let mut arr = [0u8; 4];
+            arr.copy_from_slice(self.0);
+            u32::from_le_bytes(arr)
+        }
+    }
+
+    impl TestChunkExclusive<'_> {
+        fn set(&mut self, value: u32) {
+            self.0.copy_from_slice(&value.to_le_bytes());
+        }
+    }
+
+    impl Chunk for TestChunk {
+        type Shared<'a> = TestChunkShared<'a>;
+        type Exclusive<'a> = TestChunkExclusive<'a>;
+
+        fn size(&self) -> NonZeroUsize {
+            NonZeroUsize::new(mem::size_of::<u32>()).unwrap()
+        }
+
+        fn fill_default(&self, bytes: &mut [u8]) -> Option<()> {
+            bytes.copy_from_slice(&42u32.to_le_bytes());
+            Some(())
+        }
+
+        fn get<'a>(&self, bytes: &'a [u8]) -> Option<TestChunkShared<'a>> {
+            (bytes.len() == mem::size_of::<u32>()).then_some(TestChunkShared(bytes))
+        }
+
+        fn get_mut<'a>(&self, bytes: &'a mut [u8]) -> Option<TestChunkExclusive<'a>> {
+            (bytes.len() == mem::size_of::<u32>()).then_some(TestChunkExclusive(bytes))
+        }
+    }
+
+    #[test]
+    fn simple_vec_chunks() {
+        let mut vec_chunks = VecChunks::new(TestChunk);
+        assert_eq!(vec_chunks.len(), 0);
+
+        vec_chunks.resize(3);
+        assert_eq!(vec_chunks.len(), 3);
+        assert_eq!(vec_chunks.get(0).unwrap().get(), 42);
+        assert_eq!(vec_chunks.get(1).unwrap().get(), 42);
+        assert_eq!(vec_chunks.get(2).unwrap().get(), 42);
+
+        vec_chunks.get_mut(1).unwrap().set(100);
+        assert_eq!(vec_chunks.get(0).unwrap().get(), 42);
+        assert_eq!(vec_chunks.get(1).unwrap().get(), 100);
+        assert_eq!(vec_chunks.get(2).unwrap().get(), 42);
+
+        vec_chunks.resize(2);
+        assert_eq!(vec_chunks.len(), 2);
+        assert_eq!(vec_chunks.get(0).unwrap().get(), 42);
+        assert_eq!(vec_chunks.get(1).unwrap().get(), 100);
+        assert!(vec_chunks.get(2).is_none());
+    }
+}

--- a/crates/vector-store/src/timestamp.rs
+++ b/crates/vector-store/src/timestamp.rs
@@ -3,33 +3,84 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use std::ops::Add;
+use anyhow::anyhow;
+use std::mem;
+use std::mem::MaybeUninit;
 use std::time::Duration;
-use time::Date;
 use time::OffsetDateTime;
-use time::PrimitiveDateTime;
-use time::Time;
+use uuid::Uuid;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, derive_more::From)]
-pub struct Timestamp(PrimitiveDateTime);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// A type for storing timestamps of values.
+///
+/// Internally it is a number of 100-nanoseconds since the UNIX epoch (January 1, 1970).
+/// The MSB is reserved for internal use, so the maximum timestamp value is 2^63 - 1 nanoseconds,
+/// which corresponds to approximately 29 thousands years.
+pub struct Timestamp(u64);
 
 impl Timestamp {
-    pub const UNIX_EPOCH: Timestamp = Timestamp(PrimitiveDateTime::new(
-        match Date::from_ordinal_date(1970, 1) {
-            Ok(date) => date,
-            Err(_) => panic!("Invalid date for UNIX epoch"),
-        },
-        Time::MIDNIGHT,
-    ));
+    pub const MIN: Timestamp = Timestamp(0);
+    pub const MAX: Timestamp = Timestamp(Self::MAX_100_NANOS);
 
-    pub fn from_unix_timestamp(timestamp: u64) -> Self {
-        Self::UNIX_EPOCH + Duration::from_secs(timestamp)
+    const MAX_100_NANOS: u64 = u64::MAX >> 1;
+
+    const MAX_MICROS: u64 = Self::MAX_100_NANOS / 10;
+
+    const MAX_MILLIS: u64 = Self::MAX_MICROS / 1_000;
+
+    const MAX_SECONDS: u64 = Self::MAX_MILLIS / 1_000;
+
+    /// Creates a new `Timestamp` from a number of 100-nanoseconds since the UNIX epoch.
+    pub const fn from_100_nanos(timestamp: u64) -> Self {
+        let timestamp = if timestamp > Self::MAX_100_NANOS {
+            Self::MAX_100_NANOS
+        } else {
+            timestamp
+        };
+        Timestamp(timestamp)
+    }
+
+    /// Creates a new `Timestamp` from a number of microseconds since the UNIX epoch.
+    pub const fn from_micros(timestamp: u64) -> Self {
+        let timestamp = if timestamp > Self::MAX_MICROS {
+            Self::MAX_MICROS
+        } else {
+            timestamp
+        };
+        Timestamp(timestamp * 10)
+    }
+
+    /// Creates a new `Timestamp` from a number of milliseconds since the UNIX epoch.
+    pub const fn from_millis(timestamp: u64) -> Self {
+        let timestamp = if timestamp > Self::MAX_MILLIS {
+            Self::MAX_MILLIS
+        } else {
+            timestamp
+        };
+        Timestamp(timestamp * 10_000)
+    }
+
+    /// Creates a new `Timestamp` from a number of seconds since the UNIX epoch.
+    pub const fn from_seconds(timestamp: u64) -> Self {
+        let timestamp = if timestamp > Self::MAX_SECONDS {
+            Self::MAX_SECONDS
+        } else {
+            timestamp
+        };
+        Timestamp(timestamp * 10_000_000)
     }
 
     /// Returns the current time in UTC.
     pub fn now() -> Self {
-        let now = OffsetDateTime::now_utc();
-        Timestamp(PrimitiveDateTime::new(now.date(), now.time()))
+        let offset_100_ns =
+            (OffsetDateTime::now_utc() - OffsetDateTime::UNIX_EPOCH).whole_nanoseconds() / 100;
+        if offset_100_ns < 0 {
+            Self::MIN
+        } else if offset_100_ns > Self::MAX_100_NANOS as i128 {
+            Self::MAX
+        } else {
+            Self(offset_100_ns as u64)
+        }
     }
 
     /// Returns the amount of time elapsed from this timestamp until now.
@@ -37,31 +88,310 @@ impl Timestamp {
     /// Returns [`Duration::ZERO`] when this timestamp lies in the future, which
     /// can happen due to clock skew between ScyllaDB and the vector store.
     pub fn elapsed(&self) -> Duration {
-        Duration::try_from(Self::now().0 - self.0).unwrap_or(Duration::ZERO)
+        let now = Self::now();
+        if self.0 > now.0 {
+            Duration::ZERO
+        } else {
+            Duration::from_nanos_u128((now.0 - self.0) as u128 * 100)
+        }
     }
 }
 
-impl Add<Duration> for Timestamp {
-    type Output = Timestamp;
+impl TryFrom<Uuid> for Timestamp {
+    type Error = anyhow::Error;
 
-    fn add(self, rhs: Duration) -> Self::Output {
-        Timestamp(self.0 + rhs)
+    fn try_from(uuid: Uuid) -> anyhow::Result<Self> {
+        let (seconds, nanos) = uuid
+            .get_timestamp()
+            .ok_or(anyhow!("UUID has no timestamp"))?
+            .to_unix();
+        Ok(Timestamp::from_100_nanos(
+            Timestamp::from_seconds(seconds).0 + (nanos / 100) as u64,
+        ))
+    }
+}
+
+#[derive(Debug)]
+/// A value with an associated Timestamp.
+///
+/// It stores the timestamp of the value, a flag indicating whether the value is tombstone, and
+/// the value itself.
+pub struct Timestamped<T> {
+    timestamp: u64,
+    value: MaybeUninit<T>,
+}
+
+impl<T> Timestamped<T> {
+    const DELETED_FLAG: u64 = 1 << 63;
+    const TIMESTAMP_MASK: u64 = !Self::DELETED_FLAG;
+
+    /// Creates a new `Timestamped` value with the given timestamp and optional value.
+    pub fn new(timestamp: Timestamp, value: Option<T>) -> Self {
+        let mut timestamp = timestamp.0;
+
+        let value = if let Some(value) = value {
+            timestamp &= Self::TIMESTAMP_MASK;
+            MaybeUninit::new(value)
+        } else {
+            timestamp |= Self::DELETED_FLAG;
+            MaybeUninit::uninit()
+        };
+
+        Timestamped { timestamp, value }
+    }
+
+    /// Returns true if the value is valid (not a tombstone).
+    pub const fn is_valid(&self) -> bool {
+        (self.timestamp & Self::DELETED_FLAG) == 0
+    }
+
+    /// Returns true if the value is a tombstone (deleted).
+    pub const fn is_tombstone(&self) -> bool {
+        !self.is_valid()
+    }
+
+    /// Returns the timestamp of the value.
+    pub const fn timestamp(&self) -> Timestamp {
+        Timestamp(self.timestamp & Self::TIMESTAMP_MASK)
+    }
+
+    /// Returns a reference to the value if it is valid, or None if it is a tombstone.
+    pub fn value(&self) -> Option<&T> {
+        (self.is_valid()).then_some(
+            // SAFETY: value is initialized if and only if the deleted flag is not set
+            unsafe { self.value.assume_init_ref() },
+        )
+    }
+
+    /// Consumes the `Timestamped` value and returns the inner value if it is valid, or None if it
+    /// is a tombstone.
+    pub fn into_value(mut self) -> Option<T> {
+        if self.is_valid() {
+            // We are moving the value out of self and mark self.value as delete to avoid dropping
+            // uninitialized value in the Drop implementation
+            let value = mem::replace(&mut self.value, MaybeUninit::uninit());
+            self.timestamp |= Self::DELETED_FLAG;
+
+            // SAFETY: value is initialized if and only if the deleted flag is not set.
+            Some(unsafe { value.assume_init() })
+        } else {
+            None
+        }
+    }
+
+    /// Sets the value and timestamp of the `Timestamped` value.
+    pub fn set(&mut self, timestamp: Timestamp, value: Option<T>) {
+        // We are setting a new value, so the old value will be dropped
+        self.drop_if_valid();
+
+        let mut timestamp = timestamp.0;
+
+        let value = if let Some(value) = value {
+            timestamp &= Self::TIMESTAMP_MASK;
+            MaybeUninit::new(value)
+        } else {
+            timestamp |= Self::DELETED_FLAG;
+            MaybeUninit::uninit()
+        };
+
+        self.timestamp = timestamp;
+        self.value = value;
+    }
+
+    fn drop_if_valid(&mut self) {
+        if self.is_valid() {
+            // SAFETY: value is initialized if and only if the deleted flag is not set
+            unsafe { self.value.assume_init_drop() };
+        }
+    }
+}
+
+impl<T: Clone> Clone for Timestamped<T> {
+    fn clone(&self) -> Self {
+        let value = if self.is_valid() {
+            // SAFETY: value is initialized if and only if the deleted flag is not set
+            MaybeUninit::new(unsafe { self.value.assume_init_ref().clone() })
+        } else {
+            MaybeUninit::uninit()
+        };
+        Timestamped {
+            timestamp: self.timestamp,
+            value,
+        }
+    }
+}
+
+impl<T: PartialEq> PartialEq for Timestamped<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp && self.value() == other.value()
+    }
+}
+
+impl<T: PartialEq> Eq for Timestamped<T> {}
+
+impl<T> Drop for Timestamped<T> {
+    fn drop(&mut self) {
+        self.drop_if_valid();
+    }
+}
+
+impl Timestamped<()> {
+    /// Creates a new `Timestamped` value with the given timestamp and no value (tombstone).
+    pub(crate) const fn new_tombstone(timestamp: Timestamp) -> Self {
+        Self::new_valid_or_tombstone(timestamp, false)
+    }
+
+    /// Creates a new `Timestamped` value with the given timestamp and value (valid).
+    pub(crate) const fn new_valid(timestamp: Timestamp) -> Self {
+        Self::new_valid_or_tombstone(timestamp, true)
+    }
+
+    /// Converts the `Timestamped` value into an array of bytes in native endian order.
+    pub(crate) const fn into_ne_bytes(self) -> [u8; 8] {
+        // SAFETY: Timestamped<()> contains only timestamp integer and integers are plain old
+        // datatypes so we can always transmute them to arrays of bytes
+        unsafe { mem::transmute(self) }
+    }
+
+    /// Creates a new `Timestamped` value from an array of bytes in native endian order.
+    pub(crate) const fn from_ne_bytes(bytes: [u8; 8]) -> Self {
+        // SAFETY: Timestamped<()> contains only timestamp integer and integers are plain old
+        // datatypes so we can always transmute them to arrays of bytes
+        unsafe { mem::transmute(bytes) }
+    }
+
+    const fn new_valid_or_tombstone(timestamp: Timestamp, valid: bool) -> Self {
+        let mut timestamp = timestamp.0;
+
+        let value = if valid {
+            timestamp &= Self::TIMESTAMP_MASK;
+            MaybeUninit::new(())
+        } else {
+            timestamp |= Self::DELETED_FLAG;
+            MaybeUninit::uninit()
+        };
+
+        Timestamped { timestamp, value }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use uuid::ContextV1;
+
     use super::*;
 
     #[test]
+    fn timestamp() {
+        let timestamp = Timestamp::from_100_nanos(45);
+        assert_eq!(timestamp.0, 45);
+
+        let timestamp = Timestamp::from_micros(1_000_000);
+        assert_eq!(timestamp.0, 10_000_000);
+
+        let timestamp = Timestamp::from_millis(1_000);
+        assert_eq!(timestamp.0, 10_000_000);
+
+        let timestamp = Timestamp::from_seconds(1);
+        assert_eq!(timestamp.0, 10_000_000);
+
+        let timestamp = Timestamp::from_100_nanos(u64::MAX);
+        assert_eq!(timestamp.0, (1 << 63) - 1);
+
+        let timestamp = Timestamp::from_micros(u64::MAX);
+        assert_eq!(timestamp.0, (((1 << 63) - 1) / 10) * 10);
+
+        let timestamp = Timestamp::from_millis(u64::MAX);
+        assert_eq!(timestamp.0, (((1 << 63) - 1) / 10_000) * 10_000);
+
+        let timestamp = Timestamp::from_seconds(u64::MAX);
+        assert_eq!(timestamp.0, (((1 << 63) - 1) / 10_000_000) * 10_000_000);
+    }
+
+    #[test]
+    fn timestamp_from_uuid() {
+        let context = ContextV1::new_random();
+        assert!(Timestamp::try_from(Uuid::new_v4()).is_err());
+
+        let ts = uuid::timestamp::Timestamp::from_unix(&context, 0, 0);
+        let uuid = Uuid::new_v1(ts, &[0; 6]);
+        let timestamp = Timestamp::try_from(uuid).unwrap();
+        assert_eq!(timestamp, Timestamp::from_micros(0));
+
+        let ts = uuid::timestamp::Timestamp::from_unix(&context, 100, 0);
+        let uuid = Uuid::new_v1(ts, &[0; 6]);
+        let timestamp = Timestamp::try_from(uuid).unwrap();
+        assert_eq!(timestamp, Timestamp::from_seconds(100));
+
+        let ts = uuid::timestamp::Timestamp::from_unix(&context, 200, 100);
+        let uuid = Uuid::new_v1(ts, &[0; 6]);
+        let timestamp = Timestamp::try_from(uuid).unwrap();
+        assert_eq!(timestamp, Timestamp::from_100_nanos(2_000_000_001));
+
+        let ts = uuid::timestamp::Timestamp::from_unix(&context, 200, 1_000);
+        let uuid = Uuid::new_v1(ts, &[0; 6]);
+        let timestamp = Timestamp::try_from(uuid).unwrap();
+        assert_eq!(timestamp, Timestamp::from_100_nanos(2_000_000_010));
+
+        let ts = uuid::timestamp::Timestamp::from_unix(&context, u64::MAX, 0);
+        let uuid = Uuid::new_v1(ts, &[0; 6]);
+        let timestamp = Timestamp::try_from(uuid).unwrap();
+        assert_eq!(timestamp, Timestamp::from_100_nanos(u64::MAX));
+    }
+
+    #[test]
+    fn timestamped() {
+        let timestamped = Timestamped::<()>::new(Timestamp::from_micros(100), None);
+        assert!(!timestamped.is_valid());
+        assert!(timestamped.is_tombstone());
+        assert_eq!(timestamped.timestamp(), Timestamp::from_micros(100));
+        assert_eq!(timestamped.value(), None);
+
+        let mut timestamped = Timestamped::new(Timestamp::from_millis(1_000), Some("value"));
+        assert!(timestamped.is_valid());
+        assert_eq!(timestamped.timestamp(), Timestamp::from_millis(1_000));
+        assert_eq!(timestamped.value(), Some(&"value"));
+
+        timestamped.set(Timestamp::from_millis(2_000), None);
+        assert!(timestamped.is_tombstone());
+        assert_eq!(timestamped.timestamp(), Timestamp::from_millis(2_000));
+        assert_eq!(timestamped.value(), None);
+
+        timestamped.set(Timestamp::from_millis(3_000), Some("new value"));
+        assert!(timestamped.is_valid());
+        assert_eq!(timestamped.timestamp(), Timestamp::from_millis(3_000));
+        assert_eq!(timestamped.value(), Some(&"new value"));
+    }
+
+    #[test]
+    fn timestamped_ne_bytes() {
+        let timestamped = Timestamped::new_tombstone(Timestamp::from_micros(100));
+        let bytes = timestamped.into_ne_bytes();
+        let timestamped = Timestamped::from_ne_bytes(bytes);
+        assert!(!timestamped.is_valid());
+        assert!(timestamped.is_tombstone());
+        assert_eq!(timestamped.timestamp(), Timestamp::from_micros(100));
+        assert_eq!(timestamped.value(), None);
+
+        let timestamped = Timestamped::new_valid(Timestamp::from_millis(1_000));
+        let bytes = timestamped.into_ne_bytes();
+        let timestamped = Timestamped::from_ne_bytes(bytes);
+        assert!(timestamped.is_valid());
+        assert!(!timestamped.is_tombstone());
+        assert_eq!(timestamped.timestamp(), Timestamp::from_millis(1_000));
+        assert_eq!(timestamped.value(), Some(&()));
+    }
+
+    #[test]
     fn elapsed_is_zero_for_future_timestamp() {
-        let future = Timestamp::now() + Duration::from_secs(3600);
+        let future =
+            Timestamp::from_100_nanos(Timestamp::now().0 + Timestamp::from_seconds(3600).0);
         assert_eq!(future.elapsed(), Duration::ZERO);
     }
 
     #[test]
     fn elapsed_is_positive_for_past_timestamp() {
-        let past = Timestamp::from_unix_timestamp(0);
+        let past = Timestamp::MIN;
         assert!(past.elapsed() > Duration::ZERO);
     }
 }

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -114,12 +114,12 @@ async fn fts_index_returns_proper_count() {
             (
                 [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
                 Some("hello world".to_string()),
-                Timestamp::from_unix_timestamp(10),
+                Timestamp::from_millis(10),
             ),
             (
                 [CqlValue::Int(2), CqlValue::Text("two".to_string())].into(),
                 Some("foo bar".to_string()),
-                Timestamp::from_unix_timestamp(20),
+                Timestamp::from_millis(20),
             ),
         ])),
         None,
@@ -158,7 +158,7 @@ async fn setup_fts_and_wait(
             (
                 pk.into_iter().collect(),
                 Some(doc.to_string()),
-                Timestamp::from_unix_timestamp(ts),
+                Timestamp::from_millis(ts),
             )
         })
         .collect();

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -101,7 +101,7 @@ async fn memory_limit_during_index_build() {
                             DbIndexedRow {
                                 primary_key: [CqlValue::Int(pk)].into(),
                                 value: Some(DbIndexedValue::Vector(item)),
-                                timestamp: Timestamp::from_unix_timestamp(10),
+                                timestamp: Timestamp::from_millis(10),
                             },
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))

--- a/crates/vector-store/tests/integration/metrics.rs
+++ b/crates/vector-store/tests/integration/metrics.rs
@@ -34,7 +34,7 @@ async fn setup_single_vector_index() -> (
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
-            Timestamp::from_unix_timestamp(10),
+            Timestamp::from_millis(10),
         )])),
         None,
         Some(1),

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -93,17 +93,17 @@ async fn simple_create_search_delete_index() {
             (
                 [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
                 Some(vec![1., 1., 1.].into()),
-                Timestamp::from_unix_timestamp(10),
+                Timestamp::from_millis(10),
             ),
             (
                 [CqlValue::Int(2), CqlValue::Text("two".to_string())].into(),
                 Some(vec![2., -2., 2.].into()),
-                Timestamp::from_unix_timestamp(20),
+                Timestamp::from_millis(20),
             ),
             (
                 [CqlValue::Int(3), CqlValue::Text("three".to_string())].into(),
                 Some(vec![3., 3., 3.].into()),
-                Timestamp::from_unix_timestamp(30),
+                Timestamp::from_millis(30),
             ),
         ])),
         None,

--- a/crates/vector-store/tests/integration/quantization.rs
+++ b/crates/vector-store/tests/integration/quantization.rs
@@ -47,7 +47,7 @@ async fn quantization_is_effectively_applied() {
         let values = [(
             [CqlValue::Int(1)].into(),
             Some(add_vector.into()),
-            Timestamp::from_unix_timestamp(10),
+            Timestamp::from_millis(10),
         )];
         let values_len = values.len();
         let (run, index, _db, _node_state) = setup_store_with_quantization(
@@ -179,7 +179,7 @@ async fn search_with_quantization(quantization: Quantization, filter: Option<Pos
     let vectors = vec![(
         [CqlValue::Int(pk_value)].into(),
         Some(vector.clone().into()),
-        Timestamp::from_unix_timestamp(10),
+        Timestamp::from_millis(10),
     )];
 
     let (run, index, _db, _node_state) = setup_store_with_quantization(
@@ -298,7 +298,7 @@ async fn binary_quantization_with_non_divisible_by_8_dimensions() {
     let vectors = vec![(
         [CqlValue::Int(pk_value)].into(),
         Some(vector.clone().into()),
-        Timestamp::from_unix_timestamp(10),
+        Timestamp::from_millis(10),
     )];
 
     let (run, index, _db, _node_state) = setup_store_with_quantization(

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -50,7 +50,7 @@ fn single_row_scan(pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'stat
     db_basic::scan_fn_vectors([(
         pks.into_iter().collect::<Vec<_>>().into(),
         Some(vec![1.0, 2.0, 3.0].into()),
-        Timestamp::from_unix_timestamp(10),
+        Timestamp::from_millis(10),
     )])
 }
 

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -224,17 +224,17 @@ async fn simple_create_search_delete_index() {
             (
                 [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
                 Some(vec![1., 1., 1.].into()),
-                Timestamp::from_unix_timestamp(10),
+                Timestamp::from_millis(10),
             ),
             (
                 [CqlValue::Int(2), CqlValue::Text("two".to_string())].into(),
                 Some(vec![2., -2., 2.].into()),
-                Timestamp::from_unix_timestamp(20),
+                Timestamp::from_millis(20),
             ),
             (
                 [CqlValue::Int(3), CqlValue::Text("three".to_string())].into(),
                 Some(vec![3., 3., 3.].into()),
-                Timestamp::from_unix_timestamp(30),
+                Timestamp::from_millis(30),
             ),
         ])),
         None,
@@ -430,7 +430,7 @@ async fn ann_returns_bad_request_when_provided_vector_size_is_not_eq_index_dimen
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
-            Timestamp::from_unix_timestamp(10),
+            Timestamp::from_millis(10),
         )])),
         None,
         Some(1),
@@ -468,7 +468,7 @@ async fn ann_returns_bad_request_when_filtering_required_but_not_allowed() {
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Int(1)].into(),
             Some(vec![1., 1., 1.].into()),
-            Timestamp::from_unix_timestamp(10),
+            Timestamp::from_millis(10),
         )])),
         None,
         Some(1),
@@ -559,7 +559,7 @@ async fn ann_failed_when_wrong_number_of_primary_keys() {
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
-            Timestamp::from_unix_timestamp(10),
+            Timestamp::from_millis(10),
         )])),
         None,
         Some(1),
@@ -911,7 +911,7 @@ async fn setup_int_int_store() -> (
                 (
                     [CqlValue::Int(i / 10), CqlValue::Int(i % 10)].into(),
                     Some(vec![i as f32, i as f32, i as f32].into()),
-                    Timestamp::from_unix_timestamp(10),
+                    Timestamp::from_millis(10),
                 )
             }),
         )),
@@ -1401,7 +1401,7 @@ async fn ann_filter_partition_key_text_gt() {
                 (
                     [CqlValue::Text(pk.to_string()), CqlValue::Int(i as i32)].into(),
                     Some(vec![i as f32, i as f32, i as f32].into()),
-                    Timestamp::from_unix_timestamp(10),
+                    Timestamp::from_millis(10),
                 )
             }),
         )),
@@ -1487,7 +1487,7 @@ async fn http_server_is_responsive_when_index_add_hangs() {
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
-            Timestamp::from_unix_timestamp(10),
+            Timestamp::from_millis(10),
         )])),
         None,
     )
@@ -1516,13 +1516,9 @@ async fn null_vector_is_not_indexed() {
             (
                 [CqlValue::Int(1)].into(),
                 Some(vec![1., 1., 1.].into()),
-                Timestamp::from_unix_timestamp(10),
+                Timestamp::from_millis(10),
             ),
-            (
-                [CqlValue::Int(2)].into(),
-                None,
-                Timestamp::from_unix_timestamp(20),
-            ),
+            ([CqlValue::Int(2)].into(), None, Timestamp::from_millis(20)),
         ])),
         None,
     )
@@ -1607,17 +1603,17 @@ async fn similarity_scores_are_decreasing_and_correctly_converted() {
             (
                 [CqlValue::Int(1)].into(),
                 Some(vec![0.0_f32].into()),
-                Timestamp::from_unix_timestamp(10),
+                Timestamp::from_millis(10),
             ),
             (
                 [CqlValue::Int(2)].into(),
                 Some(vec![1.0_f32].into()),
-                Timestamp::from_unix_timestamp(20),
+                Timestamp::from_millis(20),
             ),
             (
                 [CqlValue::Int(3)].into(),
                 Some(vec![3.0_f32].into()),
-                Timestamp::from_unix_timestamp(30),
+                Timestamp::from_millis(30),
             ),
         ])),
         None,


### PR DESCRIPTION
This PR refactors Table's vector_timestamp to support multi-column targets. It refactors Timestamp to be simpler (to store 100-nanosecons since Unix Epoch) and introduce Timestamped<T> to support better handling Timestamp + Value. It also introduces VecChunks and ColumnVecChunks collections to store runtime-known size of vector elements. Finally, changes allows storing (Epoch + [Timestamp + Value] * N) in a vector in continuous memory.

Fixes: VECTOR-706