### PR TITLE
vector-store: refactor DbIndexedRow::value into values

### DIFF
--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -57,11 +57,13 @@ use vector_store::IndexKind;
 use vector_store::IndexMetadata;
 use vector_store::IndexOptionsVs;
 use vector_store::NonemptyArc;
+use vector_store::NonemptyBox;
 use vector_store::NonemptyIteratorExt;
 use vector_store::PrimaryKey;
 use vector_store::Quantization;
 use vector_store::SpaceType;
 use vector_store::Timestamp;
+use vector_store::Timestamped;
 use vector_store::Vector;
 use vector_store::db::Db;
 use vector_store::node_state::NodeState;
@@ -277,8 +279,11 @@ fn scan_fn_mpsc(
                     .send((
                         DbIndexedRow {
                             primary_key,
-                            value: embedding.map(DbIndexedValue::Vector),
-                            timestamp,
+                            values: NonemptyBox::new([Timestamped::new(
+                                timestamp,
+                                embedding.map(DbIndexedValue::Vector),
+                            )])
+                            .unwrap(),
                         },
                         in_progress,
                     ))

--- a/crates/vector-store/src/async_in_progress.rs
+++ b/crates/vector-store/src/async_in_progress.rs
@@ -7,11 +7,13 @@ use crate::Timestamp;
 use prometheus::Histogram;
 use tokio::sync::mpsc;
 
+#[derive(Debug)]
 pub struct CdcInProgress {
     histogram: Histogram,
     timestamp: Timestamp,
 }
 
+#[derive(Debug)]
 pub enum AsyncInProgress {
     None,
     Fullscan(mpsc::Sender<()>),

--- a/crates/vector-store/src/db_cdc/actor.rs
+++ b/crates/vector-store/src/db_cdc/actor.rs
@@ -122,7 +122,7 @@ pub(crate) fn new(
     let mut reader = CdcReaderState::new(
         name,
         params_fn,
-        metrics,
+        Arc::clone(&metrics),
         metadata.keyspace_name.clone(),
         metadata.index_name.clone(),
     );
@@ -439,7 +439,12 @@ async fn create_cdc_reader(
     scylla_cdc::log_reader::CDCLogReader,
     impl std::future::Future<Output = anyhow::Result<()>>,
 )> {
-    let consumer_factory = CdcConsumerFactory::new(Arc::clone(&session), &metadata, tx_embeddings)?;
+    let consumer_factory = CdcConsumerFactory::new(
+        Arc::clone(&session),
+        &metadata,
+        Arc::clone(&metrics),
+        tx_embeddings,
+    )?;
 
     let cdc_start = start - CHECKPOINT_TIMESTAMP_OFFSET;
     info!(

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -7,8 +7,10 @@ use crate::AsyncInProgress;
 use crate::ColumnName;
 use crate::DbIndexedRow;
 use crate::DbIndexedValue;
+use crate::IndexKey;
 use crate::IndexKind;
 use crate::IndexMetadata;
+use crate::Metrics;
 use crate::NonemptyArc;
 use crate::NonemptyIteratorExt;
 use crate::db_index_backend::CdcValueStatus;
@@ -41,10 +43,12 @@ fn extract_indexed_value(
 }
 
 struct CdcConsumerData {
+    index_key: IndexKey,
     primary_key_columns: NonemptyArc<ColumnName>,
     backend: DbIndexBackend,
     kind: IndexKind,
     tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+    metrics: Arc<Metrics>,
 }
 
 struct CdcConsumer(Arc<CdcConsumerData>);
@@ -112,7 +116,13 @@ impl Consumer for CdcConsumer {
                     value,
                     timestamp,
                 },
-                AsyncInProgress::None,
+                AsyncInProgress::cdc(
+                    self.0.metrics.indexing_lag.with_label_values(&[
+                        self.0.index_key.keyspace().as_ref(),
+                        self.0.index_key.index().as_ref(),
+                    ]),
+                    timestamp,
+                ),
             ))
             .await;
         Ok(())
@@ -132,6 +142,7 @@ impl CdcConsumerFactory {
     pub(super) fn new(
         session: Arc<Session>,
         metadata: &IndexMetadata,
+        metrics: Arc<Metrics>,
         tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     ) -> anyhow::Result<Self> {
         let cluster_state = session.get_cluster_state();
@@ -154,10 +165,12 @@ impl CdcConsumerFactory {
         let backend = DbIndexBackend::from(metadata);
 
         Ok(Self(Arc::new(CdcConsumerData {
+            index_key: metadata.key(),
             primary_key_columns,
             backend,
             kind: metadata.kind.clone(),
             tx,
+            metrics,
         })))
     }
 }

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -12,7 +12,9 @@ use crate::IndexKind;
 use crate::IndexMetadata;
 use crate::Metrics;
 use crate::NonemptyArc;
+use crate::NonemptyBox;
 use crate::NonemptyIteratorExt;
+use crate::Timestamped;
 use crate::db_index_backend::CdcValueStatus;
 use crate::db_index_backend::DbIndexBackend;
 use anyhow::anyhow;
@@ -113,8 +115,7 @@ impl Consumer for CdcConsumer {
             .send((
                 DbIndexedRow {
                     primary_key,
-                    value,
-                    timestamp,
+                    values: NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
                 },
                 AsyncInProgress::cdc(
                     self.0.metrics.indexing_lag.with_label_values(&[

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -13,6 +13,7 @@ use crate::IndexMetadata;
 use crate::KeyspaceIdentifier;
 use crate::Metrics;
 use crate::NonemptyArc;
+use crate::NonemptyBox;
 use crate::NonemptyIteratorExt;
 use crate::Percentage;
 use crate::Progress;
@@ -28,6 +29,7 @@ use crate::node_state::Event;
 use crate::node_state::NodeState;
 use crate::node_state::NodeStateExt;
 use crate::perf;
+use crate::timestamp::Timestamped;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -639,8 +641,7 @@ impl Statements {
 
                 Some(DbIndexedRow {
                     primary_key,
-                    value,
-                    timestamp,
+                    values: NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
                 })
             })
             .filter_map(|value| async move {

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -232,6 +232,7 @@ async fn add_index(
         primary_key_columns.clone(),
         partition_key_count,
         partition_key_columns,
+        metadata.target_columns.len(),
         &metadata.filtering_columns,
         table_columns,
     ) {

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -660,11 +660,10 @@ pub enum DbIndexedValue {
     Document(String),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbIndexedRow {
     pub primary_key: PrimaryKey,
-    pub value: Option<DbIndexedValue>,
-    pub timestamp: Timestamp,
+    pub values: NonemptyBox<Timestamped<DbIndexedValue>>,
 }
 
 pub use async_in_progress::AsyncInProgress;

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -5,9 +5,9 @@
 
 use crate::AsyncInProgress;
 use crate::DbIndexedRow;
-use crate::DbIndexedValue;
 use crate::IndexKey;
 use crate::Metrics;
+use crate::Vector;
 use crate::fts_index::FtsIndex;
 use crate::fts_index::FtsIndexExt;
 use crate::metrics::OP_INSERT;
@@ -32,13 +32,29 @@ use tracing::error;
 use tracing::error_span;
 
 pub(crate) trait IndexDispatch {
-    fn add_value(
+    fn add_vector(
         &self,
-        partition_id: PartitionId,
-        primary_id: PrimaryId,
-        value: DbIndexedValue,
-        in_progress: AsyncInProgress,
-    ) -> impl Future<Output = ()> + Send;
+        _partition_id: PartitionId,
+        _primary_id: PrimaryId,
+        _vector: Vector,
+        _in_progress: AsyncInProgress,
+    ) -> impl Future<Output = ()> + Send {
+        async move {
+            error!("ignoring add vector for an index that does not support it");
+        }
+    }
+
+    fn add_document(
+        &self,
+        _partition_id: PartitionId,
+        _primary_id: PrimaryId,
+        _document: String,
+        _in_progress: AsyncInProgress,
+    ) -> impl Future<Output = ()> + Send {
+        async move {
+            error!("ignoring add document for an index that does not support it");
+        }
+    }
 
     fn remove_value(
         &self,
@@ -51,22 +67,14 @@ pub(crate) trait IndexDispatch {
 }
 
 impl IndexDispatch for mpsc::Sender<VsIndex> {
-    async fn add_value(
+    async fn add_vector(
         &self,
         partition_id: PartitionId,
         primary_id: PrimaryId,
-        value: DbIndexedValue,
+        vector: Vector,
         in_progress: AsyncInProgress,
     ) {
-        match value {
-            DbIndexedValue::Vector(vector) => {
-                self.add_vector(partition_id, primary_id, vector, in_progress)
-                    .await;
-            }
-            DbIndexedValue::Document(_) => {
-                error!("received document for vector-search index, ignoring");
-            }
-        }
+        VsIndexExt::add_vector(self, partition_id, primary_id, vector, in_progress).await;
     }
 
     async fn remove_value(
@@ -85,21 +93,14 @@ impl IndexDispatch for mpsc::Sender<VsIndex> {
 }
 
 impl IndexDispatch for mpsc::Sender<FtsIndex> {
-    async fn add_value(
+    async fn add_document(
         &self,
         _partition_id: PartitionId,
         primary_id: PrimaryId,
-        value: DbIndexedValue,
+        document: String,
         in_progress: AsyncInProgress,
     ) {
-        match value {
-            DbIndexedValue::Document(document) => {
-                self.add_document(primary_id, document, in_progress).await;
-            }
-            DbIndexedValue::Vector(_) => {
-                error!("received vector for full-text-search index, ignoring");
-            }
-        }
+        FtsIndexExt::add_document(self, primary_id, document, in_progress).await;
     }
 
     async fn remove_value(
@@ -174,15 +175,30 @@ async fn add<I: IndexDispatch>(
     let in_progress = &mut in_progress;
     for operation in operations.into_iter() {
         match operation {
-            Operation::AddValue {
+            Operation::AddVector {
                 primary_id,
                 partition_id,
-                value,
+                vector,
                 is_update,
             } => {
                 let op_label = if is_update { OP_UPDATE } else { OP_INSERT };
                 index
-                    .add_value(partition_id, primary_id, value, in_progress.take())
+                    .add_vector(partition_id, primary_id, vector, in_progress.take())
+                    .await;
+                metrics
+                    .modified
+                    .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref(), op_label])
+                    .inc();
+            }
+            Operation::AddDocument {
+                primary_id,
+                partition_id,
+                document,
+                is_update,
+            } => {
+                let op_label = if is_update { OP_UPDATE } else { OP_INSERT };
+                index
+                    .add_document(partition_id, primary_id, document, in_progress.take())
                     .await;
                 metrics
                     .modified
@@ -222,7 +238,9 @@ async fn add<I: IndexDispatch>(
 mod tests {
     use super::*;
     use crate::DbIndexedValue;
+    use crate::NonemptyBox;
     use crate::Timestamp;
+    use crate::Timestamped;
     use crate::metrics::Metrics;
     use crate::table::MockTableAdd;
     use crate::vs_index::VsIndex;
@@ -281,8 +299,11 @@ mod tests {
 
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
-            value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_millis(10),
+            values: NonemptyBox::new([Timestamped::new(
+                Timestamp::from_millis(10),
+                Some(DbIndexedValue::Vector(vec![1.].into())),
+            )])
+            .unwrap(),
         };
         table
             .write()
@@ -319,8 +340,11 @@ mod tests {
 
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
-            value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_millis(10),
+            values: NonemptyBox::new([Timestamped::new(
+                Timestamp::from_millis(10),
+                Some(DbIndexedValue::Vector(vec![1.].into())),
+            )])
+            .unwrap(),
         };
         let (tx_progress, _rx_progress) = mpsc::channel(1);
         table
@@ -330,10 +354,10 @@ mod tests {
             .with(eq(index_key), eq(embedding.clone()))
             .once()
             .returning(|_, _| {
-                Ok(vec![Operation::AddValue {
+                Ok(vec![Operation::AddVector {
                     primary_id: 2.into(),
                     partition_id: 3.into(),
-                    value: DbIndexedValue::Vector(vec![4.].into()),
+                    vector: vec![4.].into(),
                     is_update: false,
                 }])
             });
@@ -384,8 +408,11 @@ mod tests {
 
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
-            value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_millis(10),
+            values: NonemptyBox::new([Timestamped::new(
+                Timestamp::from_millis(10),
+                Some(DbIndexedValue::Vector(vec![1.].into())),
+            )])
+            .unwrap(),
         };
         table
             .write()
@@ -394,10 +421,10 @@ mod tests {
             .with(eq(index_key), eq(embedding.clone()))
             .once()
             .returning(|_, _| {
-                Ok(vec![Operation::AddValue {
+                Ok(vec![Operation::AddVector {
                     primary_id: 2.into(),
                     partition_id: 3.into(),
-                    value: DbIndexedValue::Vector(vec![4.].into()),
+                    vector: vec![4.].into(),
                     is_update: false,
                 }])
             });
@@ -454,8 +481,11 @@ mod tests {
 
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
-            value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_millis(10),
+            values: NonemptyBox::new([Timestamped::new(
+                Timestamp::from_millis(10),
+                Some(DbIndexedValue::Vector(vec![1.].into())),
+            )])
+            .unwrap(),
         };
         table
             .write()
@@ -469,10 +499,10 @@ mod tests {
                         primary_id: 2.into(),
                         partition_id: 3.into(),
                     },
-                    Operation::AddValue {
+                    Operation::AddVector {
                         primary_id: 3.into(),
                         partition_id: 3.into(),
-                        value: DbIndexedValue::Vector(vec![4.].into()),
+                        vector: vec![4.].into(),
                         is_update: true,
                     },
                 ])
@@ -530,8 +560,11 @@ mod tests {
 
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
-            value: Some(DbIndexedValue::Vector(vec![1.].into())),
-            timestamp: Timestamp::from_millis(10),
+            values: NonemptyBox::new([Timestamped::new(
+                Timestamp::from_millis(10),
+                Some(DbIndexedValue::Vector(vec![1.].into())),
+            )])
+            .unwrap(),
         };
         table
             .write()
@@ -542,10 +575,10 @@ mod tests {
             .returning(|_, _| {
                 Ok(vec![
                     // Plain insert
-                    Operation::AddValue {
+                    Operation::AddVector {
                         primary_id: 1.into(),
                         partition_id: 2.into(),
-                        value: DbIndexedValue::Vector(vec![10.].into()),
+                        vector: vec![10.].into(),
                         is_update: false,
                     },
                     // Update (remove + add)
@@ -553,10 +586,10 @@ mod tests {
                         primary_id: 3.into(),
                         partition_id: 4.into(),
                     },
-                    Operation::AddValue {
+                    Operation::AddVector {
                         primary_id: 5.into(),
                         partition_id: 4.into(),
-                        value: DbIndexedValue::Vector(vec![20.].into()),
+                        vector: vec![20.].into(),
                         is_update: true,
                     },
                 ])
@@ -630,8 +663,7 @@ mod tests {
 
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
-            value: None,
-            timestamp: Timestamp::from_millis(10),
+            values: NonemptyBox::new([Timestamped::new(Timestamp::from_millis(10), None)]).unwrap(),
         };
         table
             .write()
@@ -685,8 +717,7 @@ mod tests {
 
         let embedding = DbIndexedRow {
             primary_key: [CqlValue::Int(1)].into(),
-            value: None,
-            timestamp: Timestamp::from_millis(10),
+            values: NonemptyBox::new([Timestamped::new(Timestamp::from_millis(10), None)]).unwrap(),
         };
         table
             .write()

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -161,18 +161,6 @@ async fn add<I: IndexDispatch>(
     metrics: &Metrics,
     key: &IndexKey,
 ) {
-    // Rows arriving without a progress marker come from CDC. Wrap them in a
-    // Cdc marker so that the indexing-lag metric is observed when the marker
-    // is dropped (i.e. when the index actor finishes processing the row).
-    if matches!(in_progress, AsyncInProgress::None) {
-        in_progress = AsyncInProgress::cdc(
-            metrics
-                .indexing_lag
-                .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref()]),
-            embedding.timestamp,
-        );
-    }
-
     let Ok(operations) = table
         .write()
         .unwrap()
@@ -378,7 +366,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn add_vector_without_progress() {
+    async fn add_vector_with_cdc_progress() {
         let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
@@ -414,7 +402,13 @@ mod tests {
                 }])
             });
         tx_embeddings
-            .send((embedding, AsyncInProgress::None))
+            .send((
+                embedding,
+                AsyncInProgress::cdc(
+                    metrics.indexing_lag.with_label_values(&["vector", "store"]),
+                    Timestamp::now(),
+                ),
+            ))
             .await
             .unwrap();
         let Some(VsIndex::AddVector {
@@ -429,7 +423,6 @@ mod tests {
         assert_eq!(primary_id, 2.into());
         assert_eq!(partition_id, 3.into());
         assert_eq!(embedding, vec![4.].into());
-        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
         drop(in_progress);
 
         drop(tx_embeddings);
@@ -504,7 +497,7 @@ mod tests {
             partition_id,
             primary_id,
             embedding,
-            in_progress,
+            ..
         }) = rx_index.recv().await
         else {
             unreachable!();
@@ -512,7 +505,6 @@ mod tests {
         assert_eq!(primary_id, 3.into());
         assert_eq!(partition_id, 3.into());
         assert_eq!(embedding, vec![4.].into());
-        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());
@@ -579,7 +571,7 @@ mod tests {
             partition_id,
             primary_id,
             embedding,
-            in_progress,
+            ..
         }) = rx_index.recv().await
         else {
             unreachable!();
@@ -587,7 +579,6 @@ mod tests {
         assert_eq!(primary_id, 1.into());
         assert_eq!(partition_id, 2.into());
         assert_eq!(embedding, vec![10.].into());
-        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
 
         // Second: remove half of the update
         let Some(VsIndex::RemoveVector {
@@ -662,14 +653,13 @@ mod tests {
         let Some(VsIndex::RemoveVector {
             partition_id,
             primary_id,
-            in_progress,
+            ..
         }) = rx_index.recv().await
         else {
             unreachable!();
         };
         assert_eq!(primary_id, 5.into());
         assert_eq!(partition_id, 6.into());
-        assert!(matches!(in_progress, AsyncInProgress::Cdc(_)));
 
         drop(tx_embeddings);
         assert!(rx_index.recv().await.is_none());

--- a/crates/vector-store/src/table/column.rs
+++ b/crates/vector-store/src/table/column.rs
@@ -7,7 +7,7 @@ use crate::PrimaryKey;
 use crate::Timestamp;
 use crate::table::ColumnVec;
 use crate::table::PrimaryId;
-use crate::table::TValue;
+use crate::timestamp::Timestamped;
 use anyhow::bail;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlDate;
@@ -28,24 +28,24 @@ pub(super) struct KeyOffset(usize);
 /// type or a primary key column (as an offset in the primary key columns).
 #[derive(Debug)]
 pub(super) enum Column {
-    Ascii(ColumnVec<PrimaryId, TValue<String>>),
-    BigInt(ColumnVec<PrimaryId, TValue<i64>>),
-    Blob(ColumnVec<PrimaryId, TValue<Vec<u8>>>),
-    Boolean(ColumnVec<PrimaryId, TValue<bool>>),
-    Date(ColumnVec<PrimaryId, TValue<CqlDate>>),
-    Decimal(ColumnVec<PrimaryId, TValue<CqlDecimal>>),
-    Double(ColumnVec<PrimaryId, TValue<f64>>),
-    Float(ColumnVec<PrimaryId, TValue<f32>>),
-    Inet(ColumnVec<PrimaryId, TValue<IpAddr>>),
-    Int(ColumnVec<PrimaryId, TValue<i32>>),
-    SmallInt(ColumnVec<PrimaryId, TValue<i16>>),
-    Text(ColumnVec<PrimaryId, TValue<String>>),
-    Time(ColumnVec<PrimaryId, TValue<CqlTime>>),
-    Timestamp(ColumnVec<PrimaryId, TValue<CqlTimestamp>>),
-    Timeuuid(ColumnVec<PrimaryId, TValue<CqlTimeuuid>>),
-    TinyInt(ColumnVec<PrimaryId, TValue<i8>>),
-    Uuid(ColumnVec<PrimaryId, TValue<Uuid>>),
-    Varint(ColumnVec<PrimaryId, TValue<CqlVarint>>),
+    Ascii(ColumnVec<PrimaryId, Timestamped<String>>),
+    BigInt(ColumnVec<PrimaryId, Timestamped<i64>>),
+    Blob(ColumnVec<PrimaryId, Timestamped<Vec<u8>>>),
+    Boolean(ColumnVec<PrimaryId, Timestamped<bool>>),
+    Date(ColumnVec<PrimaryId, Timestamped<CqlDate>>),
+    Decimal(ColumnVec<PrimaryId, Timestamped<CqlDecimal>>),
+    Double(ColumnVec<PrimaryId, Timestamped<f64>>),
+    Float(ColumnVec<PrimaryId, Timestamped<f32>>),
+    Inet(ColumnVec<PrimaryId, Timestamped<IpAddr>>),
+    Int(ColumnVec<PrimaryId, Timestamped<i32>>),
+    SmallInt(ColumnVec<PrimaryId, Timestamped<i16>>),
+    Text(ColumnVec<PrimaryId, Timestamped<String>>),
+    Time(ColumnVec<PrimaryId, Timestamped<CqlTime>>),
+    Timestamp(ColumnVec<PrimaryId, Timestamped<CqlTimestamp>>),
+    Timeuuid(ColumnVec<PrimaryId, Timestamped<CqlTimeuuid>>),
+    TinyInt(ColumnVec<PrimaryId, Timestamped<i8>>),
+    Uuid(ColumnVec<PrimaryId, Timestamped<Uuid>>),
+    Varint(ColumnVec<PrimaryId, Timestamped<CqlVarint>>),
     PrimaryKey(KeyOffset),
 }
 
@@ -77,24 +77,24 @@ impl Column {
     pub(super) fn resize_with(&mut self, size: usize) {
         let timestamp = Timestamp::MIN;
         match self {
-            Self::Ascii(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::BigInt(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Blob(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Boolean(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Date(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Decimal(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Double(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Float(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Inet(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Int(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::SmallInt(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Text(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Time(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Timestamp(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Timeuuid(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::TinyInt(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Uuid(vec) => vec.resize_with(size, || TValue::None(timestamp)),
-            Self::Varint(vec) => vec.resize_with(size, || TValue::None(timestamp)),
+            Self::Ascii(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::BigInt(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Blob(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Boolean(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Date(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Decimal(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Double(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Float(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Inet(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Int(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::SmallInt(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Text(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Time(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Timestamp(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Timeuuid(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::TinyInt(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Uuid(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
+            Self::Varint(vec) => vec.resize_with(size, || Timestamped::new(timestamp, None)),
             Self::PrimaryKey(_) => {}
         }
     }
@@ -111,109 +111,109 @@ impl Column {
                 let CqlValue::Ascii(value) = value else {
                     bail!("Failed to convert value to Ascii");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::BigInt(vec) => {
                 let CqlValue::BigInt(value) = value else {
                     bail!("Failed to convert value to BigInt");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Blob(vec) => {
                 let CqlValue::Blob(value) = value else {
                     bail!("Failed to convert value to Blob");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Boolean(vec) => {
                 let CqlValue::Boolean(value) = value else {
                     bail!("Failed to convert value to Boolean");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Date(vec) => {
                 let CqlValue::Date(value) = value else {
                     bail!("Failed to convert value to Date");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Decimal(vec) => {
                 let CqlValue::Decimal(value) = value else {
                     bail!("Failed to convert value to Decimal");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Double(vec) => {
                 let CqlValue::Double(value) = value else {
                     bail!("Failed to convert value to Double");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Float(vec) => {
                 let CqlValue::Float(value) = value else {
                     bail!("Failed to convert value to Float");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Inet(vec) => {
                 let CqlValue::Inet(value) = value else {
                     bail!("Failed to convert value to Inet");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Int(vec) => {
                 let CqlValue::Int(value) = value else {
                     bail!("Failed to convert value to Int");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::SmallInt(vec) => {
                 let CqlValue::SmallInt(value) = value else {
                     bail!("Failed to convert value to SmallInt");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Text(vec) => {
                 let CqlValue::Text(value) = value else {
                     bail!("Failed to convert value to Text");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Time(vec) => {
                 let CqlValue::Time(value) = value else {
                     bail!("Failed to convert value to Time");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Timestamp(vec) => {
                 let CqlValue::Timestamp(value) = value else {
                     bail!("Failed to convert value to Timestamp");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Timeuuid(vec) => {
                 let CqlValue::Timeuuid(value) = value else {
                     bail!("Failed to convert value to Timeuuid");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::TinyInt(vec) => {
                 let CqlValue::TinyInt(value) = value else {
                     bail!("Failed to convert value to TinyInt");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Uuid(vec) => {
                 let CqlValue::Uuid(value) = value else {
                     bail!("Failed to convert value to Uuid");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::Varint(vec) => {
                 let CqlValue::Varint(value) = value else {
                     bail!("Failed to convert value to Varint");
                 };
-                vec.update(primary_id, TValue::Some(timestamp, value))
+                vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::PrimaryKey(_) => bail!("Cannot insert value into PrimaryKey column"),
         }
@@ -227,92 +227,92 @@ impl Column {
         match self {
             Self::Ascii(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Ascii),
             Self::BigInt(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::BigInt),
             Self::Blob(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Blob),
             Self::Boolean(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Boolean),
             Self::Date(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Date),
             Self::Decimal(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Decimal),
             Self::Double(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Double),
             Self::Float(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Float),
             Self::Inet(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Inet),
             Self::Int(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Int),
             Self::SmallInt(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::SmallInt),
             Self::Text(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Text),
             Self::Time(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Time),
             Self::Timestamp(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Timestamp),
             Self::Timeuuid(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Timeuuid),
             Self::TinyInt(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::TinyInt),
             Self::Uuid(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Uuid),
             Self::Varint(vec) => vec
                 .get(primary_id)
-                .and_then(|val| val.get())
+                .and_then(|timestamped| timestamped.value())
                 .cloned()
                 .map(CqlValue::Varint),
             Self::PrimaryKey(key_offset) => primary_keys

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -19,7 +19,6 @@ use crate::NonemptyArc;
 use crate::PartitionKey;
 use crate::PrimaryKey;
 use crate::Restriction;
-use crate::Timestamp;
 use crate::primary_key::normalize;
 use crate::timestamp::Timestamped;
 use anyhow::anyhow;
@@ -61,23 +60,6 @@ trait Idx {
 /// A newtype for partition size
 #[derive(Clone, Copy, Debug, derive_more::From, derive_more::Into, derive_more::AsRef)]
 struct PartitionSize(usize);
-
-/// An enum that can store Timestamp and optionally a value
-#[derive(Debug)]
-enum TValue<T> {
-    #[allow(dead_code)]
-    None(Timestamp),
-    #[allow(dead_code)]
-    Some(Timestamp, T),
-}
-impl<T> TValue<T> {
-    fn get(&self) -> Option<&T> {
-        match self {
-            Self::None(_) => None,
-            Self::Some(_, value) => Some(value),
-        }
-    }
-}
 
 /// A struct that stores free PrimaryIds. It is used to efficiently use ids of preallocated or
 /// deleted rows.
@@ -950,6 +932,7 @@ pub(crate) enum Operation {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Timestamp;
     use scylla::value::CqlDecimal;
 
     #[test]

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -16,9 +16,11 @@ use crate::DbIndexedRow;
 use crate::DbIndexedValue;
 use crate::IndexKey;
 use crate::NonemptyArc;
+use crate::NonemptyBox;
 use crate::PartitionKey;
 use crate::PrimaryKey;
 use crate::Restriction;
+use crate::Vector;
 use crate::primary_key::normalize;
 use crate::table::chunk_timestamps::ChunkTimestampsExclusive;
 use crate::timestamp::Timestamped;
@@ -166,9 +168,9 @@ impl Index {
     fn new_global(
         index_id: IndexId,
         primary_key_columns: NonemptyArc<ColumnName>,
+        column_targets_count: NonZeroUsize,
         filtering_columns: &[ColumnName],
     ) -> Self {
-        let chunk_size = NonZeroUsize::new(1).unwrap();
         Self {
             index_id,
             data: IndexData::Global,
@@ -177,16 +179,16 @@ impl Index {
                 .chain(filtering_columns.iter())
                 .cloned()
                 .collect(),
-            values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(chunk_size)),
+            values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(column_targets_count)),
         }
     }
 
     fn new_local(
         index_id: IndexId,
         key_columns: NonemptyArc<ColumnName>,
+        column_targets_count: NonZeroUsize,
         filtering_columns: &[ColumnName],
     ) -> Self {
-        let chunk_size = NonZeroUsize::new(1).unwrap();
         Self {
             index_id,
             _available_columns: key_columns
@@ -194,7 +196,7 @@ impl Index {
                 .chain(filtering_columns.iter())
                 .cloned()
                 .collect(),
-            values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(chunk_size)),
+            values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(column_targets_count)),
             data: IndexData::Local {
                 key_columns,
                 map: BTreeMap::new(),
@@ -349,6 +351,7 @@ impl Table {
         primary_key_columns: NonemptyArc<ColumnName>,
         partition_key_count: usize,
         partition_key_columns: Option<NonemptyArc<ColumnName>>,
+        column_targets_count: NonZeroUsize,
         filtering_columns: &[ColumnName],
         table_columns: Arc<HashMap<ColumnName, NativeType>>,
     ) -> anyhow::Result<Self> {
@@ -358,9 +361,19 @@ impl Table {
         let mut index_ids = BTreeMap::new();
         let index_id = index_id_generator.next(partition_key_columns.is_none())?;
         let index = if let Some(partition_key_columns) = partition_key_columns.as_ref() {
-            Index::new_local(index_id, partition_key_columns.clone(), filtering_columns)
+            Index::new_local(
+                index_id,
+                partition_key_columns.clone(),
+                column_targets_count,
+                filtering_columns,
+            )
         } else {
-            Index::new_global(index_id, primary_key_columns.clone(), filtering_columns)
+            Index::new_global(
+                index_id,
+                primary_key_columns.clone(),
+                column_targets_count,
+                filtering_columns,
+            )
         };
         indexes.insert(index_id, index);
         index_ids.insert(index_key, index_id);
@@ -502,36 +515,86 @@ struct CompareTimestamps {
 
 fn compare_timestamps(
     values_timestamps: &ChunkTimestampsExclusive,
-    db_row: &DbIndexedRow,
+    timestamps: &[Timestamped<()>],
 ) -> anyhow::Result<CompareTimestamps> {
-    if let Some(timestamped) = values_timestamps.timestamp(0) {
-        let is_cur_tombstone = timestamped.is_tombstone();
-        let is_new_tombstone = db_row.value.is_none();
-        let is_newer = timestamped.timestamp() < db_row.timestamp;
-        Ok(CompareTimestamps {
-            is_cur_tombstone,
-            is_new_tombstone,
-            is_newer,
+    timestamps
+        .iter()
+        .enumerate()
+        .map(|(idx, new)| {
+            values_timestamps
+                .timestamp(idx)
+                .ok_or_else(|| anyhow!("Failed to compare timestamp:  missing timestamped({idx})"))
+                .map(|cur| (cur, new))
         })
-    } else {
-        Err(anyhow!("Missing first timestamped for comparing"))
-    }
+        .fold_ok(
+            CompareTimestamps {
+                is_cur_tombstone: false,
+                is_new_tombstone: true,
+                is_newer: false,
+            },
+            |mut comparision, (cur, new)| {
+                if cur.is_tombstone() {
+                    comparision.is_cur_tombstone = true;
+                }
+                if new.is_valid() {
+                    comparision.is_new_tombstone = false;
+                }
+                if cur.timestamp() < new.timestamp() {
+                    comparision.is_newer = true;
+                }
+                comparision
+            },
+        )
 }
 
 fn update_timestamps(
     mut values_timestamps: ChunkTimestampsExclusive,
-    db_row: &DbIndexedRow,
+    timestamps: NonemptyBox<Timestamped<()>>,
 ) -> anyhow::Result<()> {
-    values_timestamps
-        .set_timestamp(
-            0,
-            if db_row.value.is_some() {
-                Timestamped::new_valid(db_row.timestamp)
-            } else {
-                Timestamped::new_tombstone(db_row.timestamp)
-            },
-        )
-        .ok_or_else(|| anyhow!("Missing first timestamped for updating"))
+    timestamps
+        .into_iter()
+        .enumerate()
+        .try_for_each(|(idx, timestamped)| {
+            values_timestamps
+                .set_timestamp(idx, timestamped)
+                .ok_or_else(|| anyhow!("Failed to update timestamp: missing timestamped({idx})"))
+        })
+}
+
+enum SplittingValues {
+    Vector(Vector),
+    Document(String),
+}
+
+struct SplitValuesFiltering {
+    values: Option<SplittingValues>,
+    timestamps: NonemptyBox<Timestamped<()>>,
+}
+
+fn split_values_filtering(db_row: DbIndexedRow) -> anyhow::Result<SplitValuesFiltering> {
+    let mut row_values = db_row.values.into_iter();
+
+    let (values, timestamps) = {
+        let Some(value) = row_values.next() else {
+            bail!("Expected vector or document value for first column, got None");
+        };
+
+        let timestamp = value.timestamp();
+        let timestamped = if value.is_valid() {
+            Timestamped::new_valid(timestamp)
+        } else {
+            Timestamped::new_tombstone(timestamp)
+        };
+        let timestamps = NonemptyBox::new([timestamped]).unwrap();
+
+        let values = value.into_value().map(|value| match value {
+            DbIndexedValue::Vector(vector) => SplittingValues::Vector(vector),
+            DbIndexedValue::Document(document) => SplittingValues::Document(document),
+        });
+        (values, timestamps)
+    };
+
+    Ok(SplitValuesFiltering { values, timestamps })
 }
 
 /// A trait that defines the add operation for the table.
@@ -579,18 +642,23 @@ impl TableAdd for Table {
                 for index_id {index_id:?} and primary_id {primary_id:?}"
             )
         };
+
+        let SplitValuesFiltering { values, timestamps } = split_values_filtering(db_row)?;
         let epoch = values_timestamps.epoch();
         let CompareTimestamps {
             is_cur_tombstone,
             is_new_tombstone,
             is_newer,
-        } = compare_timestamps(&values_timestamps, &db_row)?;
+        } = compare_timestamps(&values_timestamps, timestamps.as_slice())?;
         if !is_newer {
             return Ok(operations);
         }
 
         let primary_id = primary_id.new_epoch(epoch);
         if !is_new_tombstone {
+            let values = values.ok_or_else(|| {
+                anyhow!("Expected vector or document value for first column, got None")
+            })?;
             if !is_cur_tombstone {
                 operations.push(Operation::RemoveBeforeAddValue {
                     primary_id,
@@ -600,18 +668,28 @@ impl TableAdd for Table {
 
             let primary_id = primary_id.next_epoch();
             values_timestamps.set_epoch(primary_id.epoch());
-            update_timestamps(values_timestamps, &db_row)?;
+            update_timestamps(values_timestamps, timestamps)?;
 
-            operations.push(Operation::AddValue {
-                primary_id,
-                partition_id,
-                value: db_row.value.unwrap(),
-                is_update: !is_cur_tombstone,
-            });
+            let is_update = !is_cur_tombstone;
+            let operation = match values {
+                SplittingValues::Vector(vector) => Operation::AddVector {
+                    primary_id,
+                    partition_id,
+                    vector,
+                    is_update,
+                },
+                SplittingValues::Document(document) => Operation::AddDocument {
+                    primary_id,
+                    partition_id,
+                    document,
+                    is_update,
+                },
+            };
+            operations.push(operation);
         } else {
             let epoch = primary_id.epoch().next();
             values_timestamps.set_epoch(epoch);
-            update_timestamps(values_timestamps, &db_row)?;
+            update_timestamps(values_timestamps, timestamps)?;
 
             if !is_cur_tombstone {
                 operations.push(Operation::RemoveValue {
@@ -899,10 +977,16 @@ fn cql_cmp_tuple(
 
 #[derive(Clone, Debug)]
 pub(crate) enum Operation {
-    AddValue {
+    AddVector {
         primary_id: PrimaryId,
         partition_id: PartitionId,
-        value: DbIndexedValue,
+        vector: Vector,
+        is_update: bool,
+    },
+    AddDocument {
+        primary_id: PrimaryId,
+        partition_id: PartitionId,
+        document: String,
         is_update: bool,
     },
     RemoveBeforeAddValue {
@@ -933,6 +1017,7 @@ mod tests {
                 NonemptyArc::new(["pk", "ck"]).unwrap(),
                 1,
                 partition_key_columns.clone(),
+                NonZeroUsize::new(1).unwrap(),
                 &[],
                 Arc::new(
                     [
@@ -951,20 +1036,23 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(1)].into(),
-                        value: Some(DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_millis(100),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(100),
+                            Some(DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into())),
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
             let (primary_id11, partition_id11) = match operations.first().unwrap() {
-                Operation::AddValue {
+                Operation::AddVector {
                     primary_id,
                     partition_id,
-                    value,
+                    vector,
                     is_update: false,
                 } => {
-                    assert_eq!(value, &DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into()));
+                    assert_eq!(vector, &vec![0.1, 0.2, 0.3].into());
                     (*primary_id, *partition_id)
                 }
                 _ => panic!("Expected AddValue operation"),
@@ -976,20 +1064,23 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        value: Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_millis(100),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(100),
+                            Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
             let (primary_id21, partition_id21) = match operations.first().unwrap() {
-                Operation::AddValue {
+                Operation::AddVector {
                     primary_id,
                     partition_id,
-                    value,
+                    vector,
                     is_update: false,
                 } => {
-                    assert_eq!(value, &DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into()));
+                    assert_eq!(vector, &vec![0.2, 0.2, 0.3].into());
                     (*primary_id, *partition_id)
                 }
                 _ => panic!("Expected AddValue operation"),
@@ -1003,20 +1094,23 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(3)].into(),
-                        value: Some(DbIndexedValue::Vector(vec![0.3, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_millis(100),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(100),
+                            Some(DbIndexedValue::Vector(vec![0.3, 0.2, 0.3].into())),
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
             let (primary_id31, partition_id31) = match operations.first().unwrap() {
-                Operation::AddValue {
+                Operation::AddVector {
                     primary_id,
                     partition_id,
-                    value,
+                    vector,
                     is_update: false,
                 } => {
-                    assert_eq!(value, &DbIndexedValue::Vector(vec![0.3, 0.2, 0.3].into()));
+                    assert_eq!(vector, &vec![0.3, 0.2, 0.3].into());
                     (*primary_id, *partition_id)
                 }
                 _ => panic!("Expected AddValue operation"),
@@ -1070,8 +1164,11 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        value: Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
-                        timestamp: Timestamp::from_millis(50),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(50),
+                            Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();
@@ -1083,8 +1180,11 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        value: Some(DbIndexedValue::Vector(vec![0.5, 0.5, 0.3].into())),
-                        timestamp: Timestamp::from_millis(150),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(150),
+                            Some(DbIndexedValue::Vector(vec![0.5, 0.5, 0.3].into())),
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();
@@ -1099,13 +1199,13 @@ mod tests {
             assert_eq!(primary_id22, primary_id21);
             assert_eq!(partition_id22, partition_id21);
             let (primary_id22, partition_id22) = match operations.get(1).unwrap() {
-                Operation::AddValue {
+                Operation::AddVector {
                     primary_id,
                     partition_id,
-                    value,
+                    vector,
                     is_update: true,
                 } => {
-                    assert_eq!(value, &DbIndexedValue::Vector(vec![0.5, 0.5, 0.3].into()));
+                    assert_eq!(vector, &vec![0.5, 0.5, 0.3].into());
                     (*primary_id, *partition_id)
                 }
                 _ => panic!("Expected AddValue operation"),
@@ -1125,8 +1225,11 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(1)].into(),
-                        value: None,
-                        timestamp: Timestamp::from_millis(200),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(200),
+                            None,
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();
@@ -1148,8 +1251,11 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        value: None,
-                        timestamp: Timestamp::from_millis(200),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(200),
+                            None,
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();
@@ -1171,8 +1277,11 @@ mod tests {
                     &index_key,
                     DbIndexedRow {
                         primary_key: [CqlValue::Int(1), CqlValue::Int(3)].into(),
-                        value: None,
-                        timestamp: Timestamp::from_millis(200),
+                        values: NonemptyBox::new([Timestamped::new(
+                            Timestamp::from_millis(200),
+                            None,
+                        )])
+                        .unwrap(),
                     },
                 )
                 .unwrap();

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -48,7 +48,6 @@ use std::collections::btree_map::Entry;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tap::Pipe;
-use tracing::warn;
 use vec_chunks::Chunk;
 use vec_chunks::VecChunks;
 
@@ -243,82 +242,85 @@ impl Index {
         Ok(())
     }
 
-    fn partition_id(&self, primary_id: PrimaryId) -> Option<PartitionId> {
-        match &self.data {
-            IndexData::Global => Some(PartitionId::global(self.index_id)),
-            IndexData::Local { ids, .. } => ids.get(primary_id).copied().flatten(),
-        }
-    }
-
-    fn partition_key(
-        &self,
-        primary_key_columns: &[ColumnName],
-        primary_key: &PrimaryKey,
-    ) -> Option<PartitionKey> {
-        match &self.data {
-            IndexData::Global => None,
-            IndexData::Local { key_columns, .. } => key_columns
-                .iter()
-                .map(|name| {
-                    primary_key_columns
-                        .iter()
-                        .position(|col_name| col_name == name)
-                        .and_then(|idx| primary_key.get(idx))
-                })
-                .collect::<Option<PartitionKey>>(),
-        }
-    }
-
-    fn add(
+    fn add_partition_key(
         &mut self,
+        index_id: IndexId,
         primary_id: PrimaryId,
-        partition_key: PartitionKey,
+        primary_key: &PrimaryKey,
+        primary_key_columns: &[ColumnName],
     ) -> anyhow::Result<PartitionId> {
         match &mut self.data {
-            IndexData::Global => bail!("Cannot add partition key to global index"),
+            IndexData::Global => Ok(PartitionId::global(index_id)),
             IndexData::Local {
                 map,
                 free_ids,
                 keys,
                 ids,
                 sizes,
-                ..
-            } => match map.entry(partition_key.clone()) {
-                Entry::Occupied(entry) => {
-                    let partition_id = *entry.get();
-                    let id = ids
-                        .get_mut(primary_id)
-                        .ok_or_else(|| anyhow!("PrimaryId index out of partition ids bounds"))?;
-                    if let Some(current_id) = &id {
-                        bail!(
-                            "Partition key {partition_key:?} already exists for primary id {current_id:?}",
-                        );
+                key_columns,
+            } => {
+                let partition_id_storage = ids
+                    .get_mut(primary_id)
+                    .ok_or_else(|| anyhow!("PrimaryId index out of partition ids bounds"))?;
+                if let Some(partition_id) = &partition_id_storage {
+                    return Ok(*partition_id);
+                }
+                let partition_key =
+                    partition_key(primary_key, primary_key_columns, key_columns.as_slice())?;
+                match map.entry(partition_key.clone()) {
+                    Entry::Occupied(entry) => {
+                        let partition_id = *entry.get();
+                        partition_id_storage.replace(partition_id);
+                        sizes
+                            .get_mut(partition_id)
+                            .ok_or_else(|| {
+                                anyhow!("PartitionId index out of partition sizes bounds")
+                            })?
+                            .0 += 1;
+                        Ok(partition_id)
                     }
-                    id.replace(partition_id);
-                    sizes
-                        .get_mut(partition_id)
-                        .ok_or_else(|| anyhow!("PartitionId index out of partition sizes bounds"))?
-                        .0 += 1;
-                    Ok(partition_id)
+                    Entry::Vacant(entry) => {
+                        let partition_id = free_ids.take_id()?;
+                        entry.insert(partition_id);
+                        keys.get_mut(partition_id)
+                            .ok_or_else(|| {
+                                anyhow!("PartitionId index out of partition keys bounds")
+                            })?
+                            .replace(partition_key);
+                        partition_id_storage.replace(partition_id);
+                        sizes
+                            .get_mut(partition_id)
+                            .ok_or_else(|| {
+                                anyhow!("PartitionId index out of partition sizes bounds")
+                            })?
+                            .0 = 1;
+                        Ok(partition_id)
+                    }
                 }
-                Entry::Vacant(entry) => {
-                    let partition_id = free_ids.take_id()?;
-                    entry.insert(partition_id);
-                    keys.get_mut(partition_id)
-                        .ok_or_else(|| anyhow!("PartitionId index out of partition keys bounds"))?
-                        .replace(partition_key);
-                    ids.get_mut(primary_id)
-                        .ok_or_else(|| anyhow!("PrimaryId index out of partition ids bounds"))?
-                        .replace(partition_id);
-                    sizes
-                        .get_mut(partition_id)
-                        .ok_or_else(|| anyhow!("PartitionId index out of partition sizes bounds"))?
-                        .0 = 1;
-                    Ok(partition_id)
-                }
-            },
+            }
         }
     }
+}
+
+fn partition_key(
+    primary_key: &PrimaryKey,
+    primary_key_columns: &[ColumnName],
+    partition_key_columns: &[ColumnName],
+) -> anyhow::Result<PartitionKey> {
+    partition_key_columns
+        .iter()
+        .map(|name| {
+            primary_key_columns
+                .iter()
+                .position(|col_name| col_name == name)
+                .and_then(|idx| primary_key.get(idx))
+        })
+        .collect::<Option<PartitionKey>>()
+        .ok_or_else(|| {
+            anyhow!(
+                "Failed to construct partition key: missing partition key column in primary key"
+            )
+        })
 }
 
 /// A struct that represents a table in the database.
@@ -472,6 +474,23 @@ impl Table {
             .and_then(|index| index.values_timestamps.get(primary_id).map(|v| v.epoch()))
             .is_some_and(|epoch| epoch == primary_id.epoch())
     }
+
+    fn add_primary_key(&mut self, primary_key: &PrimaryKey) -> anyhow::Result<PrimaryId> {
+        let normalized_key = self.normalize_primary_key(primary_key);
+
+        match self.primary_ids.entry(normalized_key) {
+            Entry::Occupied(entry) => Ok(*entry.get()),
+            Entry::Vacant(entry) => {
+                let primary_id = self.free_primary_ids.take_id()?;
+                entry.insert(primary_id);
+                self.primary_keys
+                    .get_mut(primary_id)
+                    .ok_or_else(|| anyhow!("PrimaryId index out of primary keys bounds"))?
+                    .replace(primary_key.clone());
+                Ok(primary_id)
+            }
+        }
+    }
 }
 
 /// A trait that defines the add operation for the table.
@@ -485,7 +504,7 @@ impl TableAdd for Table {
     #[hotpath::measure]
     fn add(
         &mut self,
-        _index_key: &IndexKey,
+        index_key: &IndexKey,
         db_row: DbIndexedRow,
     ) -> anyhow::Result<Vec<Operation>> {
         self.reserve_primary_ids()?;
@@ -493,148 +512,95 @@ impl TableAdd for Table {
 
         let mut operations = vec![];
 
-        let primary_key = db_row.primary_key;
+        let index_id = self
+            .index_ids
+            .get(index_key)
+            .copied()
+            .ok_or_else(|| anyhow!("Index key {index_key:?} not found"))?;
+
+        let primary_id = self.add_primary_key(&db_row.primary_key)?;
+
+        let index = self
+            .indexes
+            .get_mut(&index_id)
+            .ok_or_else(|| anyhow!("Index id {index_id:?} not found"))?;
+
+        let partition_id = index.add_partition_key(
+            index_id,
+            primary_id,
+            &db_row.primary_key,
+            self.primary_key_columns.as_slice(),
+        )?;
+
         let value = db_row.value;
 
-        let normalized_key = self.normalize_primary_key(&primary_key);
-        let row_map = &mut self.primary_ids;
+        let Some(mut values_timestamps) = index.values_timestamps.get_mut(primary_id) else {
+            bail!(
+                "Failed to update value: missing value timestamp \
+                for index_id {index_id:?} and primary_id {primary_id:?}"
+            )
+        };
+        let epoch = values_timestamps.epoch();
+        let Some(timestamped) = values_timestamps.timestamp(0) else {
+            bail!(
+                "Failed to update value: missing first timestamped \
+                for index_id {index_id:?} and primary_id {primary_id:?}"
+            )
+        };
+        if timestamped.timestamp() >= db_row.timestamp {
+            return Ok(operations);
+        }
 
-        match row_map.entry(normalized_key) {
-            Entry::Occupied(entry) => {
-                let primary_id = *entry.get();
-                self.indexes.iter_mut().try_for_each(|(index_id, index)| {
-                    let partition_id = index.partition_id(primary_id).ok_or_else(|| {
-                        anyhow!(
-                            "Failed to update value: missing partition_id \
-                            for index_id {index_id:?}  and primary_id {primary_id:?}"
-                        )
-                    })?;
-                    let Some(mut values_timestamps) = index.values_timestamps.get_mut(primary_id)
-                    else {
-                        bail!(
-                            "Failed to update value: missing value timestamp \
-                            for index_id {index_id:?} and primary_id {primary_id:?}"
-                        )
-                    };
-                    let epoch = values_timestamps.epoch();
-                    let Some(timestamped) = values_timestamps.timestamp(0) else {
-                        bail!(
-                            "Failed to update value:  missing first timestamped \
-                            for index_id {index_id:?} and primary_id {primary_id:?}"
-                        )
-                    };
-                    if timestamped.timestamp() >= db_row.timestamp {
-                        return Ok(());
-                    }
-                    let vector_already_exists = timestamped.is_valid();
-                    let primary_id = primary_id.new_epoch(epoch);
-                    if let Some(value) = &value {
-                        if vector_already_exists {
-                            operations.push(Operation::RemoveBeforeAddValue {
-                                primary_id,
-                                partition_id,
-                            });
-                        }
-
-                        let primary_id = primary_id.next_epoch();
-                        operations.push(Operation::AddValue {
-                            primary_id,
-                            partition_id,
-                            value: value.clone(),
-                            is_update: vector_already_exists,
-                        });
-                        values_timestamps.set_epoch(primary_id.epoch());
-                        if values_timestamps
-                            .set_timestamp(0, Timestamped::new_valid(db_row.timestamp))
-                            .is_none()
-                        {
-                            bail!(
-                                "Failed to update value: unable to set first valid timestamped \
-                                for index_id {index_id:?} and primary_id {primary_id:?}"
-                            );
-                        }
-                    } else {
-                        let epoch = primary_id.epoch().next();
-                        values_timestamps.set_epoch(epoch);
-                        if values_timestamps
-                            .set_timestamp(0, Timestamped::new_tombstone(db_row.timestamp))
-                            .is_none()
-                        {
-                            bail!(
-                                "Failed to update value: unable to set first tombstone timestamped \
-                                for index_id {index_id:?} and primary_id {primary_id:?}"
-                            );
-                        }
-                        if vector_already_exists {
-                            operations.push(Operation::RemoveValue {
-                                primary_id,
-                                partition_id,
-                            });
-                            if index.data.remove_row(primary_id) {
-                                operations.push(Operation::RemovePartition { partition_id });
-                            }
-                        }
-                    }
-                    Ok(())
-                })?;
-                Ok(operations)
+        let vector_already_exists = timestamped.is_valid();
+        let primary_id = primary_id.new_epoch(epoch);
+        if let Some(value) = &value {
+            if vector_already_exists {
+                operations.push(Operation::RemoveBeforeAddValue {
+                    primary_id,
+                    partition_id,
+                });
             }
 
-            Entry::Vacant(entry) => {
-                if let Some(value) = &value {
-                    let primary_id = self.free_primary_ids.take_id()?;
-                    entry.insert(primary_id);
-                    self.primary_keys
-                        .get_mut(primary_id)
-                        .ok_or_else(|| anyhow!("PrimaryId index out of primary keys bounds"))?
-                        .replace(primary_key.clone());
-                    self.indexes.iter_mut().try_for_each(
-                        |(index_id, index)| -> anyhow::Result<()> {
-                            let partition_id = match index.data {
-                                IndexData::Global => PartitionId::global(*index_id),
-                                IndexData::Local { .. } => {
-                                    let Some(partition_key) = index.partition_key(
-                                        self.primary_key_columns.as_slice(),
-                                        &primary_key,
-                                    ) else {
-                                        return Ok(());
-                                    };
-                                    index.add(primary_id, partition_key)?
-                                }
-                            };
-                            let Some(mut values_timestamps) =
-                                index.values_timestamps.get_mut(primary_id)
-                            else {
-                                bail!(
-                                    "Failed to add value:  missing value timestamp \
-                                    for index_id {index_id:?} and primary_id {primary_id:?}"
-                                )
-                            };
-                            values_timestamps.set_epoch(primary_id.epoch());
-                            if values_timestamps
-                                .set_timestamp(0, Timestamped::new_valid(db_row.timestamp))
-                                .is_none()
-                            {
-                                bail!(
-                                    "Failed to add value: unable to add first value timestamped \
-                                    for index_id {index_id:?} and primary_id {primary_id:?}"
-                                )
-                            }
-                            operations.push(Operation::AddValue {
-                                primary_id,
-                                partition_id,
-                                value: value.clone(),
-                                is_update: false,
-                            });
-                            Ok(())
-                        },
-                    )?;
-                } else {
-                    warn!("Added row with no vector, skipping vector addition");
+            let primary_id = primary_id.next_epoch();
+            operations.push(Operation::AddValue {
+                primary_id,
+                partition_id,
+                value: value.clone(),
+                is_update: vector_already_exists,
+            });
+            values_timestamps.set_epoch(primary_id.epoch());
+            if values_timestamps
+                .set_timestamp(0, Timestamped::new_valid(db_row.timestamp))
+                .is_none()
+            {
+                bail!(
+                    "Failed to update value: unable to set first valid timestamped \
+                    for index_id {index_id:?} and primary_id {primary_id:?}"
+                );
+            }
+        } else {
+            let epoch = primary_id.epoch().next();
+            values_timestamps.set_epoch(epoch);
+            if values_timestamps
+                .set_timestamp(0, Timestamped::new_tombstone(db_row.timestamp))
+                .is_none()
+            {
+                bail!(
+                    "Failed to update value:  unable to set first tombstone timestamped \
+                    for index_id {index_id:?} and primary_id {primary_id:?}"
+                );
+            }
+            if vector_already_exists {
+                operations.push(Operation::RemoveValue {
+                    primary_id,
+                    partition_id,
+                });
+                if index.data.remove_row(primary_id) {
+                    operations.push(Operation::RemovePartition { partition_id });
                 }
-                Ok(operations)
             }
         }
+        Ok(operations)
     }
 }
 

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -20,6 +20,7 @@ use crate::PartitionKey;
 use crate::PrimaryKey;
 use crate::Restriction;
 use crate::primary_key::normalize;
+use crate::table::chunk_timestamps::ChunkTimestampsExclusive;
 use crate::timestamp::Timestamped;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -493,6 +494,46 @@ impl Table {
     }
 }
 
+struct CompareTimestamps {
+    is_cur_tombstone: bool,
+    is_new_tombstone: bool,
+    is_newer: bool,
+}
+
+fn compare_timestamps(
+    values_timestamps: &ChunkTimestampsExclusive,
+    db_row: &DbIndexedRow,
+) -> anyhow::Result<CompareTimestamps> {
+    if let Some(timestamped) = values_timestamps.timestamp(0) {
+        let is_cur_tombstone = timestamped.is_tombstone();
+        let is_new_tombstone = db_row.value.is_none();
+        let is_newer = timestamped.timestamp() < db_row.timestamp;
+        Ok(CompareTimestamps {
+            is_cur_tombstone,
+            is_new_tombstone,
+            is_newer,
+        })
+    } else {
+        Err(anyhow!("Missing first timestamped for comparing"))
+    }
+}
+
+fn update_timestamps(
+    mut values_timestamps: ChunkTimestampsExclusive,
+    db_row: &DbIndexedRow,
+) -> anyhow::Result<()> {
+    values_timestamps
+        .set_timestamp(
+            0,
+            if db_row.value.is_some() {
+                Timestamped::new_valid(db_row.timestamp)
+            } else {
+                Timestamped::new_tombstone(db_row.timestamp)
+            },
+        )
+        .ok_or_else(|| anyhow!("Missing first timestamped for updating"))
+}
+
 /// A trait that defines the add operation for the table.
 #[cfg_attr(test, mockall::automock)]
 pub(crate) trait TableAdd {
@@ -532,8 +573,6 @@ impl TableAdd for Table {
             self.primary_key_columns.as_slice(),
         )?;
 
-        let value = db_row.value;
-
         let Some(mut values_timestamps) = index.values_timestamps.get_mut(primary_id) else {
             bail!(
                 "Failed to update value: missing value timestamp \
@@ -541,20 +580,18 @@ impl TableAdd for Table {
             )
         };
         let epoch = values_timestamps.epoch();
-        let Some(timestamped) = values_timestamps.timestamp(0) else {
-            bail!(
-                "Failed to update value: missing first timestamped \
-                for index_id {index_id:?} and primary_id {primary_id:?}"
-            )
-        };
-        if timestamped.timestamp() >= db_row.timestamp {
+        let CompareTimestamps {
+            is_cur_tombstone,
+            is_new_tombstone,
+            is_newer,
+        } = compare_timestamps(&values_timestamps, &db_row)?;
+        if !is_newer {
             return Ok(operations);
         }
 
-        let vector_already_exists = timestamped.is_valid();
         let primary_id = primary_id.new_epoch(epoch);
-        if let Some(value) = &value {
-            if vector_already_exists {
+        if !is_new_tombstone {
+            if !is_cur_tombstone {
                 operations.push(Operation::RemoveBeforeAddValue {
                     primary_id,
                     partition_id,
@@ -562,35 +599,21 @@ impl TableAdd for Table {
             }
 
             let primary_id = primary_id.next_epoch();
+            values_timestamps.set_epoch(primary_id.epoch());
+            update_timestamps(values_timestamps, &db_row)?;
+
             operations.push(Operation::AddValue {
                 primary_id,
                 partition_id,
-                value: value.clone(),
-                is_update: vector_already_exists,
+                value: db_row.value.unwrap(),
+                is_update: !is_cur_tombstone,
             });
-            values_timestamps.set_epoch(primary_id.epoch());
-            if values_timestamps
-                .set_timestamp(0, Timestamped::new_valid(db_row.timestamp))
-                .is_none()
-            {
-                bail!(
-                    "Failed to update value: unable to set first valid timestamped \
-                    for index_id {index_id:?} and primary_id {primary_id:?}"
-                );
-            }
         } else {
             let epoch = primary_id.epoch().next();
             values_timestamps.set_epoch(epoch);
-            if values_timestamps
-                .set_timestamp(0, Timestamped::new_tombstone(db_row.timestamp))
-                .is_none()
-            {
-                bail!(
-                    "Failed to update value:  unable to set first tombstone timestamped \
-                    for index_id {index_id:?} and primary_id {primary_id:?}"
-                );
-            }
-            if vector_already_exists {
+            update_timestamps(values_timestamps, &db_row)?;
+
+            if !is_cur_tombstone {
                 operations.push(Operation::RemoveValue {
                     primary_id,
                     partition_id,

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -30,11 +30,13 @@ use vector_store::IndexName;
 use vector_store::IndexVersion;
 use vector_store::KeyspaceName;
 use vector_store::NonemptyArc;
+use vector_store::NonemptyBox;
 use vector_store::Percentage;
 use vector_store::PrimaryKey;
 use vector_store::Progress;
 use vector_store::TableName;
 use vector_store::Timestamp;
+use vector_store::Timestamped;
 use vector_store::Vector;
 use vector_store::db::Db;
 use vector_store::db_index::DbIndex;
@@ -73,8 +75,11 @@ where
             .into_iter()
             .map(|(primary_key, embedding, timestamp)| DbIndexedRow {
                 primary_key,
-                value: embedding.map(DbIndexedValue::Vector),
-                timestamp,
+                values: NonemptyBox::new([Timestamped::new(
+                    timestamp,
+                    embedding.map(DbIndexedValue::Vector),
+                )])
+                .unwrap(),
             }),
     )
 }
@@ -84,15 +89,16 @@ where
     I: IntoIterator<Item = (PrimaryKey, Option<String>, Timestamp)>,
     I::IntoIter: Send + Sync + 'static,
 {
-    make_scan_fn(
-        items
-            .into_iter()
-            .map(|(primary_key, document, timestamp)| DbIndexedRow {
-                primary_key,
-                value: document.map(DbIndexedValue::Document),
+    make_scan_fn(items.into_iter().map(|(primary_key, document, timestamp)| {
+        DbIndexedRow {
+            primary_key,
+            values: NonemptyBox::new([Timestamped::new(
                 timestamp,
-            }),
-    )
+                document.map(DbIndexedValue::Document),
+            )])
+            .unwrap(),
+        }
+    }))
 }
 
 #[derive(Clone, derive_more::Debug)]

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -31,9 +31,11 @@ use vector_store::IndexKind;
 use vector_store::IndexMetadata;
 use vector_store::IndexOptionsVs;
 use vector_store::NonemptyArc;
+use vector_store::NonemptyBox;
 use vector_store::Quantization;
 use vector_store::SpaceType;
 use vector_store::Timestamp;
+use vector_store::Timestamped;
 
 #[tokio::test]
 /// The test case scenario:
@@ -100,8 +102,11 @@ async fn memory_limit_during_index_build() {
                         .send((
                             DbIndexedRow {
                                 primary_key: [CqlValue::Int(pk)].into(),
-                                value: Some(DbIndexedValue::Vector(item)),
-                                timestamp: Timestamp::from_millis(10),
+                                values: NonemptyBox::new([Timestamped::new(
+                                    Timestamp::from_millis(10),
+                                    Some(DbIndexedValue::Vector(item)),
+                                )])
+                                .unwrap(),
                             },
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))


### PR DESCRIPTION
This PR refactors several component to finally provide possibility to pass multi-column target values and filtering column values in a single type - DbIndexedRow. To limit refactors now the code assumes single-column target and no filtering-columns passed in DbIndexedRow. 

This PR refactors Column::TValue<T> using Timestamped<T> to prepare better storing column values and allow refactoring process of adding new values to the Table.

This PR refactors Table::add - it simplify it, it provides more linear process of adding primary_id, partition_id, updating timestamps.

Additionally this PR move creating AsyncInProgress into cdc (to simplify management of them and simplify monitor_items).

It also refactor table::Operation::AddValue into two types: AddVector and AddDocument to simplify Table::add processing.

Fixes: VECTOR-690