### PR TITLE
vector-store: refactor DbIndexedRow::values into Upsert/Delete operation

### DIFF
--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -47,6 +47,7 @@ use vector_store::Config;
 use vector_store::ConfigReceivers;
 use vector_store::Connectivity;
 use vector_store::DbIndexPartitioning;
+use vector_store::DbIndexedOperation;
 use vector_store::DbIndexedRow;
 use vector_store::DbIndexedValue;
 use vector_store::ExpansionAdd;
@@ -279,11 +280,13 @@ fn scan_fn_mpsc(
                     .send((
                         DbIndexedRow {
                             primary_key,
-                            values: NonemptyBox::new([Timestamped::new(
-                                timestamp,
-                                embedding.map(DbIndexedValue::Vector),
-                            )])
-                            .unwrap(),
+                            operation: DbIndexedOperation::Upsert(
+                                NonemptyBox::new([Timestamped::new(
+                                    timestamp,
+                                    embedding.map(DbIndexedValue::Vector),
+                                )])
+                                .unwrap(),
+                            ),
                         },
                         in_progress,
                     ))

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -5,6 +5,7 @@
 
 use crate::AsyncInProgress;
 use crate::ColumnName;
+use crate::DbIndexedOperation;
 use crate::DbIndexedRow;
 use crate::DbIndexedValue;
 use crate::IndexKey;
@@ -70,17 +71,27 @@ impl Consumer for CdcConsumer {
             bail!("CDC error: column {column} should be deletable");
         }
 
-        let value = match row.operation {
-            OperationType::PartitionDelete | OperationType::RowDelete => None,
+        let timestamp = row
+            .time
+            .try_into()
+            .map_err(|err| anyhow!("CDC error: converting row.time: {err}"))?;
+
+        let operation = match row.operation {
+            OperationType::PartitionDelete | OperationType::RowDelete => {
+                DbIndexedOperation::Delete(timestamp)
+            }
 
             OperationType::RowUpdate | OperationType::RowInsert | OperationType::PostImage => {
-                match source.take_cdc_value(&mut row)? {
+                let value = match source.take_cdc_value(&mut row)? {
                     CdcValueStatus::Deleted => None,
                     CdcValueStatus::Skip => return Ok(()),
                     CdcValueStatus::NewValue(value) => {
                         extract_indexed_value(source, value, &self.0.kind)?
                     }
-                }
+                };
+                DbIndexedOperation::Upsert(
+                    NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
+                )
             }
 
             OperationType::PreImage
@@ -104,18 +115,13 @@ impl Consumer for CdcConsumer {
             return Ok(());
         };
 
-        let timestamp = row
-            .time
-            .try_into()
-            .map_err(|err| anyhow!("CDC error: converting row.time: {err}"))?;
-
         _ = self
             .0
             .tx
             .send((
                 DbIndexedRow {
                     primary_key,
-                    values: NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
+                    operation,
                 },
                 AsyncInProgress::cdc(
                     self.0.metrics.indexing_lag.with_label_values(&[

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -6,6 +6,7 @@
 use crate::AsyncInProgress;
 use crate::ColumnName;
 use crate::Config;
+use crate::DbIndexedOperation;
 use crate::DbIndexedRow;
 use crate::DbIndexedValue;
 use crate::IndexKind;
@@ -641,7 +642,9 @@ impl Statements {
 
                 Some(DbIndexedRow {
                     primary_key,
-                    values: NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
+                    operation: DbIndexedOperation::Upsert(
+                        NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
+                    ),
                 })
             })
             .filter_map(|value| async move {

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -253,7 +253,7 @@ async fn add_index(
         partition_key_count,
         partition_key_columns,
         metadata.target_columns.len(),
-        &metadata.filtering_columns,
+        Arc::clone(&metadata.filtering_columns),
         table_columns,
     ) {
         Ok(table) => Arc::new(RwLock::new(table)),

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -661,10 +661,18 @@ pub enum DbIndexedValue {
     Filtering(CqlValue),
 }
 
+/// The operation read from a CDC row or full scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DbIndexedOperation {
+    Upsert(NonemptyBox<Timestamped<DbIndexedValue>>),
+    Delete(Timestamp),
+}
+
+/// A row read from a CDC row or full scan, containing the primary key and the operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbIndexedRow {
     pub primary_key: PrimaryKey,
-    pub values: NonemptyBox<Timestamped<DbIndexedValue>>,
+    pub operation: DbIndexedOperation,
 }
 
 pub use async_in_progress::AsyncInProgress;

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -658,6 +658,7 @@ impl DbCustomIndex {
 pub enum DbIndexedValue {
     Vector(Vector),
     Document(String),
+    Filtering(CqlValue),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -722,7 +722,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remove_vector() {
+    async fn remove_vector_with_none_value() {
         let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
@@ -758,6 +758,67 @@ mod tests {
                 DbIndexedRow {
                     primary_key,
                     operation: DbIndexedOperation::Upsert(values),
+                },
+                AsyncInProgress::None,
+            ))
+            .await
+            .unwrap();
+
+        let Some(VsIndex::RemoveVector {
+            partition_id,
+            primary_id,
+            ..
+        }) = rx_index.recv().await
+        else {
+            unreachable!();
+        };
+        assert_eq!(primary_id, 5.into());
+        assert_eq!(partition_id, 6.into());
+
+        drop(tx_db_rows);
+        assert!(rx_index.recv().await.is_none());
+        assert_modified_metric_counts(&metrics, 0., 0., 1.);
+    }
+
+    #[tokio::test]
+    async fn remove_vector_with_delete() {
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
+        let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
+        let metrics: Arc<Metrics> = Arc::new(Metrics::new());
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
+        let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
+        let _actor = new(
+            index_key.clone(),
+            Arc::clone(&table),
+            rx_db_rows,
+            tx_index,
+            Arc::clone(&metrics),
+        )
+        .await
+        .unwrap();
+
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        table
+            .write()
+            .unwrap()
+            .expect_delete()
+            .with(
+                eq(index_key),
+                eq(primary_key.clone()),
+                eq(Timestamp::from_millis(10)),
+            )
+            .once()
+            .returning(|_, _, _| {
+                Ok(vec![Operation::RemoveValue {
+                    primary_id: 5.into(),
+                    partition_id: 6.into(),
+                }])
+            });
+        tx_db_rows
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Delete(Timestamp::from_millis(10)),
                 },
                 AsyncInProgress::None,
             ))

--- a/crates/vector-store/src/monitor_items.rs
+++ b/crates/vector-store/src/monitor_items.rs
@@ -4,9 +4,15 @@
  */
 
 use crate::AsyncInProgress;
+use crate::DbIndexedOperation;
 use crate::DbIndexedRow;
+use crate::DbIndexedValue;
 use crate::IndexKey;
 use crate::Metrics;
+use crate::NonemptyBox;
+use crate::PrimaryKey;
+use crate::Timestamp;
+use crate::Timestamped;
 use crate::Vector;
 use crate::fts_index::FtsIndex;
 use crate::fts_index::FtsIndexExt;
@@ -17,7 +23,7 @@ use crate::perf;
 use crate::table::Operation;
 use crate::table::PartitionId;
 use crate::table::PrimaryId;
-use crate::table::TableAdd;
+use crate::table::TableModify;
 use crate::vs_index::VsIndex;
 use crate::vs_index::VsIndexExt;
 use std::future::Future;
@@ -119,8 +125,8 @@ pub(crate) enum MonitorItems {}
 
 pub(crate) async fn new<T>(
     key: IndexKey,
-    table: Arc<RwLock<impl TableAdd + Send + Sync + 'static>>,
-    mut embeddings: Receiver<(DbIndexedRow, AsyncInProgress)>,
+    table: Arc<RwLock<impl TableModify + Send + Sync + 'static>>,
+    mut db_rows: Receiver<(DbIndexedRow, AsyncInProgress)>,
     index: mpsc::Sender<T>,
     metrics: Arc<Metrics>,
 ) -> anyhow::Result<Sender<MonitorItems>>
@@ -137,11 +143,19 @@ where
 
             while !rx.is_closed() {
                 tokio::select! {
-                    embedding = embeddings.recv() => {
-                        let Some((embedding, in_progress)) = embedding else {
+                    db_row = db_rows.recv() => {
+                        let Some((db_row, in_progress)) = db_row else {
                             break;
                         };
-                        add(&table, &index, embedding, in_progress, &metrics, &key).await;
+                        let primary_key = db_row.primary_key;
+                        match db_row.operation {
+                            DbIndexedOperation::Upsert(values) => {
+                                upsert(&table, &index, primary_key, values, in_progress, &metrics, &key).await;
+                            }
+                            DbIndexedOperation::Delete(timestamp) => {
+                                delete(&table, &index, primary_key, timestamp, in_progress, &metrics, &key).await;
+                            }
+                        }
                     }
                     _ = rx.recv() => { }
                 }
@@ -154,24 +168,57 @@ where
     Ok(tx)
 }
 
-async fn add<I: IndexDispatch>(
-    table: &Arc<RwLock<impl TableAdd>>,
+async fn upsert<I: IndexDispatch>(
+    table: &Arc<RwLock<impl TableModify>>,
     index: &I,
-    embedding: DbIndexedRow,
-    mut in_progress: AsyncInProgress,
+    primary_key: PrimaryKey,
+    values: NonemptyBox<Timestamped<DbIndexedValue>>,
+    in_progress: AsyncInProgress,
     metrics: &Metrics,
-    key: &IndexKey,
+    index_key: &IndexKey,
 ) {
     let Ok(operations) = table
         .write()
         .unwrap()
-        .add(key, embedding)
+        .upsert(index_key, primary_key, values)
         .inspect_err(|err| {
-            error!("failed to add embedding to table: {err}");
+            error!("failed to upsert values to a table: {err}");
         })
     else {
         return;
     };
+    process_operations(operations, index, in_progress, metrics, index_key).await;
+}
+
+async fn delete<I: IndexDispatch>(
+    table: &Arc<RwLock<impl TableModify>>,
+    index: &I,
+    primary_key: PrimaryKey,
+    timestamp: Timestamp,
+    in_progress: AsyncInProgress,
+    metrics: &Metrics,
+    index_key: &IndexKey,
+) {
+    let Ok(operations) = table
+        .write()
+        .unwrap()
+        .delete(index_key, primary_key, timestamp)
+        .inspect_err(|err| {
+            error!("failed to delete row from a table: {err}");
+        })
+    else {
+        return;
+    };
+    process_operations(operations, index, in_progress, metrics, index_key).await;
+}
+
+async fn process_operations<I: IndexDispatch>(
+    operations: Vec<Operation>,
+    index: &I,
+    mut in_progress: AsyncInProgress,
+    metrics: &Metrics,
+    index_key: &IndexKey,
+) {
     let in_progress = &mut in_progress;
     for operation in operations.into_iter() {
         match operation {
@@ -187,7 +234,11 @@ async fn add<I: IndexDispatch>(
                     .await;
                 metrics
                     .modified
-                    .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref(), op_label])
+                    .with_label_values(&[
+                        index_key.keyspace().as_ref(),
+                        index_key.index().as_ref(),
+                        op_label,
+                    ])
                     .inc();
             }
             Operation::AddDocument {
@@ -202,7 +253,11 @@ async fn add<I: IndexDispatch>(
                     .await;
                 metrics
                     .modified
-                    .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref(), op_label])
+                    .with_label_values(&[
+                        index_key.keyspace().as_ref(),
+                        index_key.index().as_ref(),
+                        op_label,
+                    ])
                     .inc();
             }
             Operation::RemoveBeforeAddValue {
@@ -222,7 +277,11 @@ async fn add<I: IndexDispatch>(
                     .await;
                 metrics
                     .modified
-                    .with_label_values(&[key.keyspace().as_ref(), key.index().as_ref(), OP_REMOVE])
+                    .with_label_values(&[
+                        index_key.keyspace().as_ref(),
+                        index_key.index().as_ref(),
+                        OP_REMOVE,
+                    ])
                     .inc();
             }
             Operation::RemovePartition { partition_id } => {
@@ -231,18 +290,19 @@ async fn add<I: IndexDispatch>(
         }
     }
 
-    metrics.mark_dirty(key.keyspace().as_ref(), key.index().as_ref());
+    metrics.mark_dirty(index_key.keyspace().as_ref(), index_key.index().as_ref());
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::DbIndexedOperation;
     use crate::DbIndexedValue;
     use crate::NonemptyBox;
     use crate::Timestamp;
     use crate::Timestamped;
     use crate::metrics::Metrics;
-    use crate::table::MockTableAdd;
+    use crate::table::MockTableModify;
     use crate::vs_index::VsIndex;
     use anyhow::anyhow;
     use mockall::predicate::*;
@@ -282,78 +342,80 @@ mod tests {
 
     #[tokio::test]
     async fn do_nothing_on_error() {
-        let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
-        let table = Arc::new(RwLock::new(MockTableAdd::new()));
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
         let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
         let _actor = new(
             index_key.clone(),
             Arc::clone(&table),
-            rx_embeddings,
+            rx_db_rows,
             tx_index,
             metrics,
         )
         .await
         .unwrap();
 
-        let embedding = DbIndexedRow {
-            primary_key: [CqlValue::Int(1)].into(),
-            values: NonemptyBox::new([Timestamped::new(
-                Timestamp::from_millis(10),
-                Some(DbIndexedValue::Vector(vec![1.].into())),
-            )])
-            .unwrap(),
-        };
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        let values = NonemptyBox::new([Timestamped::new(
+            Timestamp::from_millis(10),
+            Some(DbIndexedValue::Vector(vec![1.].into())),
+        )])
+        .unwrap();
         table
             .write()
             .unwrap()
-            .expect_add()
-            .with(eq(index_key), eq(embedding.clone()))
+            .expect_upsert()
+            .with(eq(index_key), eq(primary_key.clone()), eq(values.clone()))
             .once()
-            .returning(|_, _| Err(anyhow!("some error")));
-        tx_embeddings
-            .send((embedding, AsyncInProgress::None))
+            .returning(|_, _, _| Err(anyhow!("some error")));
+        tx_db_rows
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
+                AsyncInProgress::None,
+            ))
             .await
             .unwrap();
 
-        drop(tx_embeddings);
+        drop(tx_db_rows);
         assert!(rx_index.recv().await.is_none());
     }
 
     #[tokio::test]
     async fn add_vector_with_progress() {
-        let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
-        let table = Arc::new(RwLock::new(MockTableAdd::new()));
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
         let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
         let _actor = new(
             index_key.clone(),
             Arc::clone(&table),
-            rx_embeddings,
+            rx_db_rows,
             tx_index,
             Arc::clone(&metrics),
         )
         .await
         .unwrap();
 
-        let embedding = DbIndexedRow {
-            primary_key: [CqlValue::Int(1)].into(),
-            values: NonemptyBox::new([Timestamped::new(
-                Timestamp::from_millis(10),
-                Some(DbIndexedValue::Vector(vec![1.].into())),
-            )])
-            .unwrap(),
-        };
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        let values = NonemptyBox::new([Timestamped::new(
+            Timestamp::from_millis(10),
+            Some(DbIndexedValue::Vector(vec![1.].into())),
+        )])
+        .unwrap();
         let (tx_progress, _rx_progress) = mpsc::channel(1);
         table
             .write()
             .unwrap()
-            .expect_add()
-            .with(eq(index_key), eq(embedding.clone()))
+            .expect_upsert()
+            .with(eq(index_key), eq(primary_key.clone()), eq(values.clone()))
             .once()
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 Ok(vec![Operation::AddVector {
                     primary_id: 2.into(),
                     partition_id: 3.into(),
@@ -361,8 +423,14 @@ mod tests {
                     is_update: false,
                 }])
             });
-        tx_embeddings
-            .send((embedding, AsyncInProgress::Fullscan(tx_progress)))
+        tx_db_rows
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
+                AsyncInProgress::Fullscan(tx_progress),
+            ))
             .await
             .unwrap();
         let VsIndex::AddVector {
@@ -379,7 +447,7 @@ mod tests {
         assert_eq!(embedding, vec![4.].into());
         assert!(matches!(in_progress, AsyncInProgress::Fullscan(_)));
 
-        drop(tx_embeddings);
+        drop(tx_db_rows);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 1., 0., 0.);
         assert_eq!(
@@ -391,36 +459,34 @@ mod tests {
 
     #[tokio::test]
     async fn add_vector_with_cdc_progress() {
-        let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
-        let table = Arc::new(RwLock::new(MockTableAdd::new()));
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
         let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
         let _actor = new(
             index_key.clone(),
             Arc::clone(&table),
-            rx_embeddings,
+            rx_db_rows,
             tx_index,
             Arc::clone(&metrics),
         )
         .await
         .unwrap();
 
-        let embedding = DbIndexedRow {
-            primary_key: [CqlValue::Int(1)].into(),
-            values: NonemptyBox::new([Timestamped::new(
-                Timestamp::from_millis(10),
-                Some(DbIndexedValue::Vector(vec![1.].into())),
-            )])
-            .unwrap(),
-        };
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        let values = NonemptyBox::new([Timestamped::new(
+            Timestamp::from_millis(10),
+            Some(DbIndexedValue::Vector(vec![1.].into())),
+        )])
+        .unwrap();
         table
             .write()
             .unwrap()
-            .expect_add()
-            .with(eq(index_key), eq(embedding.clone()))
+            .expect_upsert()
+            .with(eq(index_key), eq(primary_key.clone()), eq(values.clone()))
             .once()
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 Ok(vec![Operation::AddVector {
                     primary_id: 2.into(),
                     partition_id: 3.into(),
@@ -428,9 +494,12 @@ mod tests {
                     is_update: false,
                 }])
             });
-        tx_embeddings
+        tx_db_rows
             .send((
-                embedding,
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
                 AsyncInProgress::cdc(
                     metrics.indexing_lag.with_label_values(&["vector", "store"]),
                     Timestamp::now(),
@@ -452,7 +521,7 @@ mod tests {
         assert_eq!(embedding, vec![4.].into());
         drop(in_progress);
 
-        drop(tx_embeddings);
+        drop(tx_db_rows);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 1., 0., 0.);
         assert_eq!(
@@ -464,36 +533,34 @@ mod tests {
 
     #[tokio::test]
     async fn update_vector() {
-        let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
-        let table = Arc::new(RwLock::new(MockTableAdd::new()));
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
         let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
         let _actor = new(
             index_key.clone(),
             Arc::clone(&table),
-            rx_embeddings,
+            rx_db_rows,
             tx_index,
             Arc::clone(&metrics),
         )
         .await
         .unwrap();
 
-        let embedding = DbIndexedRow {
-            primary_key: [CqlValue::Int(1)].into(),
-            values: NonemptyBox::new([Timestamped::new(
-                Timestamp::from_millis(10),
-                Some(DbIndexedValue::Vector(vec![1.].into())),
-            )])
-            .unwrap(),
-        };
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        let values = NonemptyBox::new([Timestamped::new(
+            Timestamp::from_millis(10),
+            Some(DbIndexedValue::Vector(vec![1.].into())),
+        )])
+        .unwrap();
         table
             .write()
             .unwrap()
-            .expect_add()
-            .with(eq(index_key), eq(embedding.clone()))
+            .expect_upsert()
+            .with(eq(index_key), eq(primary_key.clone()), eq(values.clone()))
             .once()
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 Ok(vec![
                     Operation::RemoveBeforeAddValue {
                         primary_id: 2.into(),
@@ -507,8 +574,14 @@ mod tests {
                     },
                 ])
             });
-        tx_embeddings
-            .send((embedding, AsyncInProgress::None))
+        tx_db_rows
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
+                AsyncInProgress::None,
+            ))
             .await
             .unwrap();
 
@@ -536,43 +609,41 @@ mod tests {
         assert_eq!(partition_id, 3.into());
         assert_eq!(embedding, vec![4.].into());
 
-        drop(tx_embeddings);
+        drop(tx_db_rows);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 0., 1., 0.);
     }
 
     #[tokio::test]
     async fn insert_and_update_in_single_batch() {
-        let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
-        let table = Arc::new(RwLock::new(MockTableAdd::new()));
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
         let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
         let _actor = new(
             index_key.clone(),
             Arc::clone(&table),
-            rx_embeddings,
+            rx_db_rows,
             tx_index,
             Arc::clone(&metrics),
         )
         .await
         .unwrap();
 
-        let embedding = DbIndexedRow {
-            primary_key: [CqlValue::Int(1)].into(),
-            values: NonemptyBox::new([Timestamped::new(
-                Timestamp::from_millis(10),
-                Some(DbIndexedValue::Vector(vec![1.].into())),
-            )])
-            .unwrap(),
-        };
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        let values = NonemptyBox::new([Timestamped::new(
+            Timestamp::from_millis(10),
+            Some(DbIndexedValue::Vector(vec![1.].into())),
+        )])
+        .unwrap();
         table
             .write()
             .unwrap()
-            .expect_add()
-            .with(eq(index_key), eq(embedding.clone()))
+            .expect_upsert()
+            .with(eq(index_key), eq(primary_key.clone()), eq(values.clone()))
             .once()
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 Ok(vec![
                     // Plain insert
                     Operation::AddVector {
@@ -594,8 +665,14 @@ mod tests {
                     },
                 ])
             });
-        tx_embeddings
-            .send((embedding, AsyncInProgress::None))
+        tx_db_rows
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
+                AsyncInProgress::None,
+            ))
             .await
             .unwrap();
 
@@ -639,46 +716,51 @@ mod tests {
         assert_eq!(partition_id, 4.into());
         assert_eq!(embedding, vec![20.].into());
 
-        drop(tx_embeddings);
+        drop(tx_db_rows);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 1., 1., 0.);
     }
 
     #[tokio::test]
     async fn remove_vector() {
-        let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
-        let table = Arc::new(RwLock::new(MockTableAdd::new()));
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
         let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
         let _actor = new(
             index_key.clone(),
             Arc::clone(&table),
-            rx_embeddings,
+            rx_db_rows,
             tx_index,
             Arc::clone(&metrics),
         )
         .await
         .unwrap();
 
-        let embedding = DbIndexedRow {
-            primary_key: [CqlValue::Int(1)].into(),
-            values: NonemptyBox::new([Timestamped::new(Timestamp::from_millis(10), None)]).unwrap(),
-        };
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        let values =
+            NonemptyBox::new([Timestamped::new(Timestamp::from_millis(10), None)]).unwrap();
         table
             .write()
             .unwrap()
-            .expect_add()
-            .with(eq(index_key), eq(embedding.clone()))
+            .expect_upsert()
+            .with(eq(index_key), eq(primary_key.clone()), eq(values.clone()))
             .once()
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 Ok(vec![Operation::RemoveValue {
                     primary_id: 5.into(),
                     partition_id: 6.into(),
                 }])
             });
-        tx_embeddings
-            .send((embedding, AsyncInProgress::None))
+        tx_db_rows
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
+                AsyncInProgress::None,
+            ))
             .await
             .unwrap();
 
@@ -693,45 +775,53 @@ mod tests {
         assert_eq!(primary_id, 5.into());
         assert_eq!(partition_id, 6.into());
 
-        drop(tx_embeddings);
+        drop(tx_db_rows);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 0., 0., 1.);
     }
 
     #[tokio::test]
     async fn remove_partition() {
-        let (tx_embeddings, rx_embeddings) = mpsc::channel(10);
+        let (tx_db_rows, rx_db_rows) = mpsc::channel(10);
         let (tx_index, mut rx_index) = mpsc::channel::<VsIndex>(10);
         let metrics: Arc<Metrics> = Arc::new(Metrics::new());
-        let table = Arc::new(RwLock::new(MockTableAdd::new()));
+        let table = Arc::new(RwLock::new(MockTableModify::new()));
         let index_key = IndexKey::new(&"vector".to_string().into(), &"store".to_string().into());
         let _actor = new(
             index_key.clone(),
             Arc::clone(&table),
-            rx_embeddings,
+            rx_db_rows,
             tx_index,
             Arc::clone(&metrics),
         )
         .await
         .unwrap();
 
-        let embedding = DbIndexedRow {
-            primary_key: [CqlValue::Int(1)].into(),
-            values: NonemptyBox::new([Timestamped::new(Timestamp::from_millis(10), None)]).unwrap(),
-        };
+        let primary_key: PrimaryKey = [CqlValue::Int(1)].into();
+        let values = NonemptyBox::new([Timestamped::<DbIndexedValue>::new(
+            Timestamp::from_millis(10),
+            None,
+        )])
+        .unwrap();
         table
             .write()
             .unwrap()
-            .expect_add()
-            .with(eq(index_key), eq(embedding.clone()))
+            .expect_upsert()
+            .with(eq(index_key), eq(primary_key.clone()), eq(values.clone()))
             .once()
-            .returning(|_, _| {
+            .returning(|_, _, _| {
                 Ok(vec![Operation::RemovePartition {
                     partition_id: 6.into(),
                 }])
             });
-        tx_embeddings
-            .send((embedding, AsyncInProgress::None))
+        tx_db_rows
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
+                AsyncInProgress::None,
+            ))
             .await
             .unwrap();
 
@@ -740,7 +830,7 @@ mod tests {
         };
         assert_eq!(partition_id, 6.into());
 
-        drop(tx_embeddings);
+        drop(tx_db_rows);
         assert!(rx_index.recv().await.is_none());
         assert_modified_metric_counts(&metrics, 0., 0., 0.);
     }

--- a/crates/vector-store/src/table/column.rs
+++ b/crates/vector-store/src/table/column.rs
@@ -99,8 +99,7 @@ impl Column {
         }
     }
 
-    #[allow(dead_code)]
-    fn insert_cqlvalue(
+    pub(super) fn insert(
         &mut self,
         primary_id: PrimaryId,
         timestamp: Timestamp,
@@ -216,6 +215,34 @@ impl Column {
                 vec.update(primary_id, Timestamped::new(timestamp, Some(value)))
             }
             Self::PrimaryKey(_) => bail!("Cannot insert value into PrimaryKey column"),
+        }
+    }
+
+    pub(super) fn remove(
+        &mut self,
+        primary_id: PrimaryId,
+        timestamp: Timestamp,
+    ) -> anyhow::Result<()> {
+        match self {
+            Self::Ascii(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::BigInt(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Blob(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Boolean(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Date(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Decimal(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Double(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Float(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Inet(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Int(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::SmallInt(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Text(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Time(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Timestamp(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Timeuuid(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::TinyInt(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Uuid(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::Varint(vec) => vec.update(primary_id, Timestamped::new(timestamp, None)),
+            Self::PrimaryKey(_) => bail!("Cannot remove value from PrimaryKey column"),
         }
     }
 

--- a/crates/vector-store/src/table/column_vec.rs
+++ b/crates/vector-store/src/table/column_vec.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::Timestamped;
 use crate::table::Idx;
 use anyhow::anyhow;
 
@@ -32,11 +33,16 @@ impl<I: Idx, T> ColumnVec<I, T> {
     pub(super) fn get_mut(&mut self, idx: I) -> Option<&mut T> {
         self.vec.get_mut(idx.idx())
     }
+}
 
-    pub(super) fn update(&mut self, idx: I, value: T) -> anyhow::Result<()> {
-        *self
+impl<I: Idx, T> ColumnVec<I, Timestamped<T>> {
+    pub(super) fn update(&mut self, idx: I, value: Timestamped<T>) -> anyhow::Result<()> {
+        let it = self
             .get_mut(idx)
-            .ok_or_else(|| anyhow!("Index out of ColumnVec bounds"))? = value;
+            .ok_or_else(|| anyhow!("Index out of ColumnVec bounds"))?;
+        if value.timestamp() > it.timestamp() {
+            *it = value;
+        }
         Ok(())
     }
 }

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -20,6 +20,7 @@ use crate::NonemptyBox;
 use crate::PartitionKey;
 use crate::PrimaryKey;
 use crate::Restriction;
+use crate::Timestamp;
 use crate::Vector;
 use crate::primary_key::normalize;
 use crate::table::chunk_timestamps::ChunkTimestampsExclusive;
@@ -155,6 +156,8 @@ struct Index {
 
     data: IndexData,
 
+    filtering_columns: Arc<[ColumnName]>,
+
     /// All column names that are used in this index (key columns + filtering columns)
     _available_columns: BTreeSet<ColumnName>,
 
@@ -169,7 +172,7 @@ impl Index {
         index_id: IndexId,
         primary_key_columns: NonemptyArc<ColumnName>,
         column_targets_count: NonZeroUsize,
-        filtering_columns: &[ColumnName],
+        filtering_columns: Arc<[ColumnName]>,
     ) -> Self {
         Self {
             index_id,
@@ -179,6 +182,7 @@ impl Index {
                 .chain(filtering_columns.iter())
                 .cloned()
                 .collect(),
+            filtering_columns,
             values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(column_targets_count)),
         }
     }
@@ -187,7 +191,7 @@ impl Index {
         index_id: IndexId,
         key_columns: NonemptyArc<ColumnName>,
         column_targets_count: NonZeroUsize,
-        filtering_columns: &[ColumnName],
+        filtering_columns: Arc<[ColumnName]>,
     ) -> Self {
         Self {
             index_id,
@@ -196,6 +200,7 @@ impl Index {
                 .chain(filtering_columns.iter())
                 .cloned()
                 .collect(),
+            filtering_columns,
             values_timestamps: ColumnVecChunks::new(ChunkTimestamps::new(column_targets_count)),
             data: IndexData::Local {
                 key_columns,
@@ -352,7 +357,7 @@ impl Table {
         partition_primary_key_count: usize,
         partition_key_columns: Option<NonemptyArc<ColumnName>>,
         column_targets_count: NonZeroUsize,
-        filtering_columns: &[ColumnName],
+        filtering_columns: Arc<[ColumnName]>,
         table_columns: Arc<HashMap<ColumnName, NativeType>>,
     ) -> anyhow::Result<Self> {
         let partition_primary_key_count =
@@ -366,14 +371,14 @@ impl Table {
                 index_id,
                 partition_key_columns.clone(),
                 column_targets_count,
-                filtering_columns,
+                Arc::clone(&filtering_columns),
             )
         } else {
             Index::new_global(
                 index_id,
                 primary_key_columns.clone(),
                 column_targets_count,
-                filtering_columns,
+                Arc::clone(&filtering_columns),
             )
         };
         indexes.insert(index_id, index);
@@ -562,6 +567,27 @@ fn update_timestamps(
         })
 }
 
+fn update_filtering_columns(
+    columns: &mut BTreeMap<ColumnName, Column>,
+    primary_id: PrimaryId,
+    filtering_columns: &[ColumnName],
+    filtering: Box<[(Timestamp, Option<CqlValue>)]>,
+) -> anyhow::Result<()> {
+    filtering
+        .into_iter()
+        .zip(filtering_columns.iter())
+        .try_for_each(|((timestamp, value), column_name)| {
+            let column = columns
+                .get_mut(column_name)
+                .ok_or_else(|| anyhow!("Column {column_name} not found in table columns"))?;
+            if let Some(value) = value {
+                column.insert(primary_id, timestamp, value)
+            } else {
+                column.remove(primary_id, timestamp)
+            }
+        })
+}
+
 enum SplittingValues {
     Vector(Vector),
     Document(String),
@@ -570,6 +596,7 @@ enum SplittingValues {
 struct SplitValuesFiltering {
     values: Option<SplittingValues>,
     timestamps: NonemptyBox<Timestamped<()>>,
+    filtering: Box<[(Timestamp, Option<CqlValue>)]>,
 }
 
 fn split_values_filtering(db_row: DbIndexedRow) -> anyhow::Result<SplitValuesFiltering> {
@@ -588,14 +615,35 @@ fn split_values_filtering(db_row: DbIndexedRow) -> anyhow::Result<SplitValuesFil
         };
         let timestamps = NonemptyBox::new([timestamped]).unwrap();
 
-        let values = value.into_value().map(|value| match value {
+        let values = value.into_value().map(|value| Ok(match value {
             DbIndexedValue::Vector(vector) => SplittingValues::Vector(vector),
             DbIndexedValue::Document(document) => SplittingValues::Document(document),
-        });
+            DbIndexedValue::Filtering(_) => {
+                bail!("Expected vector or document value for first column, got filtering value")
+            }
+        })).transpose()?;
         (values, timestamps)
     };
 
-    Ok(SplitValuesFiltering { values, timestamps })
+    let filtering = row_values
+        .map(|value| (value.timestamp(), value.into_value()))
+        .map(|(timestamp, value)| {
+            let filtering_value = match value {
+                Some(DbIndexedValue::Filtering(filtering_value)) => Some(filtering_value),
+                Some(DbIndexedValue::Vector(_)) | Some(DbIndexedValue::Document(_)) => {
+                    bail!("Expected filtering value for column, got vector or document value");
+                }
+                None => None,
+            };
+            Ok((timestamp, filtering_value))
+        })
+        .collect::<Result<Box<_>, _>>()?;
+
+    Ok(SplitValuesFiltering {
+        values,
+        timestamps,
+        filtering,
+    })
 }
 
 /// A trait that defines the add operation for the table.
@@ -644,7 +692,14 @@ impl TableAdd for Table {
             )
         };
 
-        let SplitValuesFiltering { values, timestamps } = split_values_filtering(db_row)?;
+        let SplitValuesFiltering {
+            values,
+            timestamps,
+            filtering,
+        } = split_values_filtering(db_row)?;
+
+        let filtering_columns = Arc::clone(&index.filtering_columns);
+        update_filtering_columns(&mut self.columns, primary_id, &filtering_columns, filtering)?;
         let epoch = values_timestamps.epoch();
         let CompareTimestamps {
             is_cur_tombstone,
@@ -1019,7 +1074,7 @@ mod tests {
                 1,
                 partition_key_columns.clone(),
                 NonZeroUsize::new(1).unwrap(),
-                &[],
+                Arc::new([]),
                 Arc::new(
                     [
                         ("pk".into(), NativeType::Int),
@@ -1336,7 +1391,7 @@ mod tests {
             1,
             None,
             NonZeroUsize::new(1).unwrap(),
-            &[],
+            Arc::new([]),
             Arc::new([("p".into(), NativeType::Int)].into_iter().collect()),
         )
         .unwrap();

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -587,6 +587,7 @@ fn update_filtering_columns(
         })
 }
 
+#[derive(Debug, PartialEq)]
 enum SplittingValues {
     Vector(Vector),
     Document(String),
@@ -1561,6 +1562,287 @@ mod tests {
             );
             primary_id_prev = primary_id4;
         }
+    }
+
+    #[test]
+    fn upsert_delete_filtering_column() {
+        let vector_orig: Vector = vec![1.0].into();
+        let filtering = CqlValue::Int(2);
+        let values = |ts1, ts2| {
+            NonemptyBox::new([
+                Timestamped::new(
+                    Timestamp::from_millis(ts1),
+                    Some(DbIndexedValue::Vector(vector_orig.clone())),
+                ),
+                Timestamped::new(
+                    Timestamp::from_millis(ts2),
+                    Some(DbIndexedValue::Filtering(filtering.clone())),
+                ),
+            ])
+            .unwrap()
+        };
+
+        for (pk, primary_key_columns, partition_key_columns) in [
+            (
+                PrimaryKey::from([CqlValue::Int(1)]),
+                NonemptyArc::new([ColumnName::from("p")]).unwrap(),
+                None,
+            ),
+            (
+                PrimaryKey::from([CqlValue::Int(1), CqlValue::Int(1)]),
+                NonemptyArc::new([ColumnName::from("p"), ColumnName::from("c")]).unwrap(),
+                Some(NonemptyArc::new([ColumnName::from("p")]).unwrap()),
+            ),
+        ] {
+            dbg!(&primary_key_columns);
+            let index_key = IndexKey::new(&"ks".into(), &"idx".into());
+            let mut table = Table::new(
+                index_key.clone(),
+                primary_key_columns,
+                1,
+                partition_key_columns,
+                NonZeroUsize::new(1).unwrap(),
+                Arc::new(["f".into()]),
+                Arc::new(
+                    [
+                        ("p".into(), NativeType::Int),
+                        ("c".into(), NativeType::Int),
+                        ("f".into(), NativeType::Int),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            )
+            .unwrap();
+
+            // insert the vector pk1
+            let mut operations = table
+                .upsert(&index_key, pk.clone(), values(10, 20))
+                .unwrap();
+            assert_eq!(operations.len(), 1);
+            let (primary_id, partition_id) = match operations.remove(0) {
+                Operation::AddVector {
+                    primary_id,
+                    partition_id,
+                    vector,
+                    is_update: false,
+                } => {
+                    assert_eq!(&vector, &vector_orig);
+                    (primary_id, partition_id)
+                }
+                _ => panic!("Expected AddVector operation"),
+            };
+            assert_eq!(&table.primary_key(partition_id, primary_id).unwrap(), &pk);
+            assert_eq!(
+                table
+                    .columns
+                    .get(&"f".into())
+                    .unwrap()
+                    .get(primary_id, &table.primary_keys),
+                Some(filtering.clone())
+            );
+
+            // remove the vector with timestamp in the past - should not remove the filtering value
+            _ = table
+                .delete(&index_key, pk.clone(), Timestamp::from_millis(3))
+                .unwrap();
+            assert_eq!(&table.primary_key(partition_id, primary_id).unwrap(), &pk);
+            assert_eq!(
+                table
+                    .columns
+                    .get(&"f".into())
+                    .unwrap()
+                    .get(primary_id, &table.primary_keys),
+                Some(filtering.clone())
+            );
+
+            // remove the vector with timestamp in the future - should remove the filtering value
+            _ = table
+                .delete(&index_key, pk.clone(), Timestamp::from_millis(300))
+                .unwrap();
+            assert!(
+                table
+                    .columns
+                    .get(&"f".into())
+                    .unwrap()
+                    .get(primary_id, &table.primary_keys)
+                    .is_none(),
+            );
+        }
+    }
+
+    #[test]
+    fn upsert_and_delete_unordered() {
+        let vector_orig: Vector = vec![1.0].into();
+        let values = |ts| {
+            NonemptyBox::new([Timestamped::new(
+                Timestamp::from_millis(ts),
+                Some(DbIndexedValue::Vector(vector_orig.clone())),
+            )])
+            .unwrap()
+        };
+
+        for (pk, primary_key_columns, partition_key_columns) in [
+            (
+                PrimaryKey::from([CqlValue::Int(1)]),
+                NonemptyArc::new([ColumnName::from("p")]).unwrap(),
+                None,
+            ),
+            (
+                PrimaryKey::from([CqlValue::Int(1), CqlValue::Int(1)]),
+                NonemptyArc::new([ColumnName::from("p"), ColumnName::from("c")]).unwrap(),
+                Some(NonemptyArc::new([ColumnName::from("p")]).unwrap()),
+            ),
+        ] {
+            dbg!(&primary_key_columns);
+            let index_key = IndexKey::new(&"ks".into(), &"idx".into());
+            let mut table = Table::new(
+                index_key.clone(),
+                primary_key_columns,
+                1,
+                partition_key_columns,
+                NonZeroUsize::new(1).unwrap(),
+                Arc::new([]),
+                Arc::new(
+                    [("p".into(), NativeType::Int), ("c".into(), NativeType::Int)]
+                        .into_iter()
+                        .collect(),
+                ),
+            )
+            .unwrap();
+
+            // delete the vector
+            let operations = table
+                .delete(&index_key, pk.clone(), Timestamp::from_millis(20))
+                .unwrap();
+            assert_eq!(operations.len(), 0);
+
+            // insert the vector with timestamp in the past - should'n update the vector
+            let operations = table.upsert(&index_key, pk.clone(), values(10)).unwrap();
+            assert_eq!(operations.len(), 0);
+
+            // delete the vector in the future
+            let operations = table
+                .delete(&index_key, pk.clone(), Timestamp::from_millis(40))
+                .unwrap();
+            assert_eq!(operations.len(), 0);
+
+            // insert the vector with timestamp in between the two deletes - should'n update the
+            // vector
+            let operations = table.upsert(&index_key, pk.clone(), values(30)).unwrap();
+            assert_eq!(operations.len(), 0);
+
+            // insert the vector with timestamp after the last delete - should update the
+            // vector
+            let operations = table.upsert(&index_key, pk.clone(), values(50)).unwrap();
+            assert_eq!(operations.len(), 1);
+
+            // delete the vector before the last upsert - should not delete the vector
+            let operations = table
+                .delete(&index_key, pk.clone(), Timestamp::from_millis(45))
+                .unwrap();
+            assert_eq!(operations.len(), 0);
+        }
+    }
+
+    #[test]
+    fn split_values_filtering_only_values_vector() {
+        let value = Timestamped::new(
+            Timestamp::from_millis(1),
+            Some(DbIndexedValue::Vector(vec![1.0].into())),
+        );
+        let values = NonemptyBox::new([value]).unwrap();
+        let split = split_values_filtering(values).unwrap();
+        assert_eq!(
+            split.values,
+            Some(SplittingValues::Vector(vec![1.0].into()))
+        );
+        assert_eq!(split.timestamps.len().get(), 1);
+        assert_eq!(
+            split.timestamps.first().timestamp(),
+            Timestamp::from_millis(1)
+        );
+        assert!(split.timestamps.first().is_valid());
+        assert!(split.filtering.is_empty());
+    }
+
+    #[test]
+    fn split_values_filtering_only_values_tombstone() {
+        let value = Timestamped::new(Timestamp::from_millis(2), None);
+        let values = NonemptyBox::new([value]).unwrap();
+        let split = split_values_filtering(values).unwrap();
+        assert!(split.values.is_none());
+        assert_eq!(split.timestamps.len().get(), 1);
+        assert_eq!(
+            split.timestamps.first().timestamp(),
+            Timestamp::from_millis(2)
+        );
+        assert!(split.timestamps.first().is_tombstone());
+        assert!(split.filtering.is_empty());
+    }
+
+    #[test]
+    fn split_values_filtering_values_and_filtering() {
+        let value = Timestamped::new(
+            Timestamp::from_millis(3),
+            Some(DbIndexedValue::Vector(vec![2.0].into())),
+        );
+        let filtering = Timestamped::new(
+            Timestamp::from_millis(4),
+            Some(DbIndexedValue::Filtering(CqlValue::Int(42))),
+        );
+        let values = NonemptyBox::new([value, filtering]).unwrap();
+        let split = split_values_filtering(values).unwrap();
+        assert_eq!(
+            split.values,
+            Some(SplittingValues::Vector(vec![2.0].into()))
+        );
+        assert_eq!(split.timestamps.len().get(), 1);
+        assert_eq!(
+            split.timestamps.first().timestamp(),
+            Timestamp::from_millis(3)
+        );
+        assert!(split.timestamps.first().is_valid());
+        assert_eq!(split.filtering.len(), 1);
+        assert_eq!(
+            split.filtering.first().unwrap(),
+            &(Timestamp::from_millis(4), Some(CqlValue::Int(42)))
+        );
+    }
+
+    #[test]
+    fn split_values_filtering_errors() {
+        // Filtering in the values place is not allowed
+        let value = Timestamped::new(
+            Timestamp::from_millis(5),
+            Some(DbIndexedValue::Filtering(CqlValue::Int(1))),
+        );
+        let values = NonemptyBox::new([value]).unwrap();
+        assert!(split_values_filtering(values).is_err());
+
+        // Vector in the filtering place is not allowed
+        let value1 = Timestamped::new(
+            Timestamp::from_millis(5),
+            Some(DbIndexedValue::Vector(vec![1.0].into())),
+        );
+        let value2 = Timestamped::new(
+            Timestamp::from_millis(5),
+            Some(DbIndexedValue::Vector(vec![2.0].into())),
+        );
+        let values = NonemptyBox::new([value1, value2]).unwrap();
+        assert!(split_values_filtering(values).is_err());
+
+        // Document in the filtering place is not allowed
+        let value1 = Timestamped::new(
+            Timestamp::from_millis(5),
+            Some(DbIndexedValue::Document("doc1".to_string())),
+        );
+        let value2 = Timestamped::new(
+            Timestamp::from_millis(5),
+            Some(DbIndexedValue::Document("doc2".to_string())),
+        );
+        let values = NonemptyBox::new([value1, value2]).unwrap();
+        assert!(split_values_filtering(values).is_err());
     }
 
     #[test]

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -330,7 +330,7 @@ fn partition_key(
 #[derive(Debug)]
 pub struct Table {
     primary_key_columns: NonemptyArc<ColumnName>,
-    partition_key_count: usize,
+    partition_primary_key_count: usize,
     needs_ck_normalization: bool,
     primary_ids: BTreeMap<PrimaryKey, PrimaryId>,
     free_primary_ids: FreePrimaryIds,
@@ -349,13 +349,14 @@ impl Table {
     pub(crate) fn new(
         index_key: IndexKey,
         primary_key_columns: NonemptyArc<ColumnName>,
-        partition_key_count: usize,
+        partition_primary_key_count: usize,
         partition_key_columns: Option<NonemptyArc<ColumnName>>,
         column_targets_count: NonZeroUsize,
         filtering_columns: &[ColumnName],
         table_columns: Arc<HashMap<ColumnName, NativeType>>,
     ) -> anyhow::Result<Self> {
-        let partition_key_count = partition_key_count.min(primary_key_columns.len().get());
+        let partition_primary_key_count =
+            partition_primary_key_count.min(primary_key_columns.len().get());
         let mut index_id_generator = IndexIdGenerator::new();
         let mut indexes = BTreeMap::new();
         let mut index_ids = BTreeMap::new();
@@ -398,7 +399,7 @@ impl Table {
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         columns.extend(column_with_values);
-        let needs_ck_normalization = primary_key_columns.as_slice()[partition_key_count..]
+        let needs_ck_normalization = primary_key_columns.as_slice()[partition_primary_key_count..]
             .iter()
             .any(|col| matches!(table_columns.get(col), Some(NativeType::Decimal)));
         let mut table = Self {
@@ -406,7 +407,7 @@ impl Table {
             free_primary_ids: FreePrimaryIds(VecDeque::new()),
             primary_keys: ColumnVec::new(),
             primary_key_columns,
-            partition_key_count,
+            partition_primary_key_count,
             needs_ck_normalization,
             columns,
             _index_id_generator: index_id_generator,
@@ -433,7 +434,7 @@ impl Table {
         let normalized: PrimaryKey = (0..key.len())
             .map(|idx| {
                 let value = key.get(idx).expect("primary key column exists");
-                if idx >= self.partition_key_count {
+                if idx >= self.partition_primary_key_count {
                     normalize(value)
                 } else {
                     value

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -12,7 +12,6 @@ mod primary_id;
 mod vec_chunks;
 
 use crate::ColumnName;
-use crate::DbIndexedRow;
 use crate::DbIndexedValue;
 use crate::IndexKey;
 use crate::NonemptyArc;
@@ -599,8 +598,10 @@ struct SplitValuesFiltering {
     filtering: Box<[(Timestamp, Option<CqlValue>)]>,
 }
 
-fn split_values_filtering(db_row: DbIndexedRow) -> anyhow::Result<SplitValuesFiltering> {
-    let mut row_values = db_row.values.into_iter();
+fn split_values_filtering(
+    values: NonemptyBox<Timestamped<DbIndexedValue>>,
+) -> anyhow::Result<SplitValuesFiltering> {
+    let mut row_values = values.into_iter();
 
     let (values, timestamps) = {
         let Some(value) = row_values.next() else {
@@ -646,24 +647,120 @@ fn split_values_filtering(db_row: DbIndexedRow) -> anyhow::Result<SplitValuesFil
     })
 }
 
-/// A trait that defines the add operation for the table.
-#[cfg_attr(test, mockall::automock)]
-pub(crate) trait TableAdd {
-    fn add(&mut self, index_key: &IndexKey, db_row: DbIndexedRow)
-    -> anyhow::Result<Vec<Operation>>;
+fn update_index(
+    primary_id: PrimaryId,
+    partition_id: PartitionId,
+    index: &mut Index,
+    columns: &mut BTreeMap<ColumnName, Column>,
+    splitting_values_filtering: SplitValuesFiltering,
+) -> anyhow::Result<Vec<Operation>> {
+    let mut operations = vec![];
+
+    let Some(mut values_timestamps) = index.values_timestamps.get_mut(primary_id) else {
+        bail!(
+            "Failed to update value: missing value timestamp \
+            for index_id {index_id:?} and primary_id {primary_id:?}",
+            index_id = index.index_id,
+        )
+    };
+
+    let SplitValuesFiltering {
+        values,
+        timestamps,
+        filtering,
+    } = splitting_values_filtering;
+
+    let filtering_columns = Arc::clone(&index.filtering_columns);
+    update_filtering_columns(columns, primary_id, &filtering_columns, filtering)?;
+    let epoch = values_timestamps.epoch();
+    let CompareTimestamps {
+        is_cur_tombstone,
+        is_new_tombstone,
+        is_newer,
+    } = compare_timestamps(&values_timestamps, timestamps.as_slice())?;
+    if !is_newer {
+        return Ok(operations);
+    }
+
+    let primary_id = primary_id.new_epoch(epoch);
+    if !is_new_tombstone {
+        let values = values.ok_or_else(|| {
+            anyhow!("Expected vector or document value for first column, got None")
+        })?;
+        if !is_cur_tombstone {
+            operations.push(Operation::RemoveBeforeAddValue {
+                primary_id,
+                partition_id,
+            });
+        }
+
+        let primary_id = primary_id.next_epoch();
+        values_timestamps.set_epoch(primary_id.epoch());
+        update_timestamps(values_timestamps, timestamps)?;
+
+        let is_update = !is_cur_tombstone;
+        let operation = match values {
+            SplittingValues::Vector(vector) => Operation::AddVector {
+                primary_id,
+                partition_id,
+                vector,
+                is_update,
+            },
+            SplittingValues::Document(document) => Operation::AddDocument {
+                primary_id,
+                partition_id,
+                document,
+                is_update,
+            },
+        };
+        operations.push(operation);
+    } else {
+        let epoch = primary_id.epoch().next();
+        values_timestamps.set_epoch(epoch);
+        update_timestamps(values_timestamps, timestamps)?;
+
+        if !is_cur_tombstone {
+            operations.push(Operation::RemoveValue {
+                primary_id,
+                partition_id,
+            });
+            if index.data.remove_row(primary_id) {
+                operations.push(Operation::RemovePartition { partition_id });
+            }
+        }
+    }
+
+    Ok(operations)
 }
 
-impl TableAdd for Table {
-    #[hotpath::measure]
-    fn add(
+/// A trait that defines the add operation for the table.
+#[cfg_attr(test, mockall::automock)]
+pub(crate) trait TableModify {
+    fn upsert(
         &mut self,
         index_key: &IndexKey,
-        db_row: DbIndexedRow,
+        primary_key: PrimaryKey,
+        values: NonemptyBox<Timestamped<DbIndexedValue>>,
+    ) -> anyhow::Result<Vec<Operation>>;
+
+    fn delete(
+        &mut self,
+        index_key: &IndexKey,
+        primary_key: PrimaryKey,
+        timestamp: Timestamp,
+    ) -> anyhow::Result<Vec<Operation>>;
+}
+
+impl TableModify for Table {
+    #[hotpath::measure]
+    fn upsert(
+        &mut self,
+        index_key: &IndexKey,
+        primary_key: PrimaryKey,
+        values: NonemptyBox<Timestamped<DbIndexedValue>>,
     ) -> anyhow::Result<Vec<Operation>> {
         self.reserve_primary_ids()?;
         self.reserve_partition_ids()?;
-
-        let mut operations = vec![];
 
         let index_id = self
             .index_ids
@@ -671,7 +768,7 @@ impl TableAdd for Table {
             .copied()
             .ok_or_else(|| anyhow!("Index key {index_key:?} not found"))?;
 
-        let primary_id = self.add_primary_key(&db_row.primary_key)?;
+        let primary_id = self.add_primary_key(&primary_key)?;
 
         let index = self
             .indexes
@@ -681,83 +778,63 @@ impl TableAdd for Table {
         let partition_id = index.add_partition_key(
             index_id,
             primary_id,
-            &db_row.primary_key,
+            &primary_key,
             self.primary_key_columns.as_slice(),
         )?;
 
-        let Some(mut values_timestamps) = index.values_timestamps.get_mut(primary_id) else {
-            bail!(
-                "Failed to update value: missing value timestamp \
-                for index_id {index_id:?} and primary_id {primary_id:?}"
-            )
-        };
+        update_index(
+            primary_id,
+            partition_id,
+            index,
+            &mut self.columns,
+            split_values_filtering(values)?,
+        )
+    }
 
-        let SplitValuesFiltering {
-            values,
-            timestamps,
-            filtering,
-        } = split_values_filtering(db_row)?;
+    #[hotpath::measure]
+    fn delete(
+        &mut self,
+        index_key: &IndexKey,
+        primary_key: PrimaryKey,
+        timestamp: Timestamp,
+    ) -> anyhow::Result<Vec<Operation>> {
+        let index_id = self
+            .index_ids
+            .get(index_key)
+            .copied()
+            .ok_or_else(|| anyhow!("Index key {index_key:?} not found"))?;
 
-        let filtering_columns = Arc::clone(&index.filtering_columns);
-        update_filtering_columns(&mut self.columns, primary_id, &filtering_columns, filtering)?;
-        let epoch = values_timestamps.epoch();
-        let CompareTimestamps {
-            is_cur_tombstone,
-            is_new_tombstone,
-            is_newer,
-        } = compare_timestamps(&values_timestamps, timestamps.as_slice())?;
-        if !is_newer {
-            return Ok(operations);
-        }
+        let primary_id = self.add_primary_key(&primary_key)?;
 
-        let primary_id = primary_id.new_epoch(epoch);
-        if !is_new_tombstone {
-            let values = values.ok_or_else(|| {
-                anyhow!("Expected vector or document value for first column, got None")
-            })?;
-            if !is_cur_tombstone {
-                operations.push(Operation::RemoveBeforeAddValue {
-                    primary_id,
-                    partition_id,
-                });
-            }
+        let index = self
+            .indexes
+            .get_mut(&index_id)
+            .ok_or_else(|| anyhow!("Index id {index_id:?} not found"))?;
 
-            let primary_id = primary_id.next_epoch();
-            values_timestamps.set_epoch(primary_id.epoch());
-            update_timestamps(values_timestamps, timestamps)?;
+        let partition_id = index.add_partition_key(
+            index_id,
+            primary_id,
+            &primary_key,
+            self.primary_key_columns.as_slice(),
+        )?;
 
-            let is_update = !is_cur_tombstone;
-            let operation = match values {
-                SplittingValues::Vector(vector) => Operation::AddVector {
-                    primary_id,
-                    partition_id,
-                    vector,
-                    is_update,
-                },
-                SplittingValues::Document(document) => Operation::AddDocument {
-                    primary_id,
-                    partition_id,
-                    document,
-                    is_update,
-                },
-            };
-            operations.push(operation);
-        } else {
-            let epoch = primary_id.epoch().next();
-            values_timestamps.set_epoch(epoch);
-            update_timestamps(values_timestamps, timestamps)?;
+        let filtering = index
+            .filtering_columns
+            .iter()
+            .map(|_| (timestamp, None))
+            .collect();
 
-            if !is_cur_tombstone {
-                operations.push(Operation::RemoveValue {
-                    primary_id,
-                    partition_id,
-                });
-                if index.data.remove_row(primary_id) {
-                    operations.push(Operation::RemovePartition { partition_id });
-                }
-            }
-        }
-        Ok(operations)
+        update_index(
+            primary_id,
+            partition_id,
+            index,
+            &mut self.columns,
+            SplitValuesFiltering {
+                values: None,
+                timestamps: NonemptyBox::new([Timestamped::new_tombstone(timestamp)]).unwrap(),
+                filtering,
+            },
+        )
     }
 }
 
@@ -1061,7 +1138,6 @@ pub(crate) enum Operation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Timestamp;
     use scylla::value::CqlDecimal;
 
     #[test]
@@ -1088,16 +1164,14 @@ mod tests {
 
             // insert first vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(1)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(100),
-                            Some(DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into())),
-                        )])
-                        .unwrap(),
-                    },
+                    [CqlValue::Int(1), CqlValue::Int(1)].into(),
+                    NonemptyBox::new([Timestamped::new(
+                        Timestamp::from_millis(100),
+                        Some(DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into())),
+                    )])
+                    .unwrap(),
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
@@ -1116,16 +1190,14 @@ mod tests {
 
             // insert second vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(100),
-                            Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
-                        )])
-                        .unwrap(),
-                    },
+                    [CqlValue::Int(1), CqlValue::Int(2)].into(),
+                    NonemptyBox::new([Timestamped::new(
+                        Timestamp::from_millis(100),
+                        Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
+                    )])
+                    .unwrap(),
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
@@ -1146,16 +1218,14 @@ mod tests {
 
             // insert third vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(3)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(100),
-                            Some(DbIndexedValue::Vector(vec![0.3, 0.2, 0.3].into())),
-                        )])
-                        .unwrap(),
-                    },
+                    [CqlValue::Int(1), CqlValue::Int(3)].into(),
+                    NonemptyBox::new([Timestamped::new(
+                        Timestamp::from_millis(100),
+                        Some(DbIndexedValue::Vector(vec![0.3, 0.2, 0.3].into())),
+                    )])
+                    .unwrap(),
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
@@ -1216,32 +1286,28 @@ mod tests {
 
             // insert second vector with older timestamp - should not update the vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(50),
-                            Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
-                        )])
-                        .unwrap(),
-                    },
+                    [CqlValue::Int(1), CqlValue::Int(2)].into(),
+                    NonemptyBox::new([Timestamped::new(
+                        Timestamp::from_millis(50),
+                        Some(DbIndexedValue::Vector(vec![0.2, 0.2, 0.3].into())),
+                    )])
+                    .unwrap(),
                 )
                 .unwrap();
             assert_eq!(operations.len(), 0);
 
             // insert second vector with newer timestamp - should update the vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(150),
-                            Some(DbIndexedValue::Vector(vec![0.5, 0.5, 0.3].into())),
-                        )])
-                        .unwrap(),
-                    },
+                    [CqlValue::Int(1), CqlValue::Int(2)].into(),
+                    NonemptyBox::new([Timestamped::new(
+                        Timestamp::from_millis(150),
+                        Some(DbIndexedValue::Vector(vec![0.5, 0.5, 0.3].into())),
+                    )])
+                    .unwrap(),
                 )
                 .unwrap();
             assert_eq!(operations.len(), 2);
@@ -1277,16 +1343,11 @@ mod tests {
 
             // remove first vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(1)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(200),
-                            None,
-                        )])
+                    [CqlValue::Int(1), CqlValue::Int(1)].into(),
+                    NonemptyBox::new([Timestamped::new(Timestamp::from_millis(200), None)])
                         .unwrap(),
-                    },
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
@@ -1303,16 +1364,11 @@ mod tests {
 
             // remove second vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(2)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(200),
-                            None,
-                        )])
+                    [CqlValue::Int(1), CqlValue::Int(2)].into(),
+                    NonemptyBox::new([Timestamped::new(Timestamp::from_millis(200), None)])
                         .unwrap(),
-                    },
                 )
                 .unwrap();
             assert_eq!(operations.len(), 1);
@@ -1329,16 +1385,11 @@ mod tests {
 
             // remove third vector
             let operations = table
-                .add(
+                .upsert(
                     &index_key,
-                    DbIndexedRow {
-                        primary_key: [CqlValue::Int(1), CqlValue::Int(3)].into(),
-                        values: NonemptyBox::new([Timestamped::new(
-                            Timestamp::from_millis(200),
-                            None,
-                        )])
+                    [CqlValue::Int(1), CqlValue::Int(3)].into(),
+                    NonemptyBox::new([Timestamped::new(Timestamp::from_millis(200), None)])
                         .unwrap(),
-                    },
                 )
                 .unwrap();
             if partition_key_columns.is_none() {
@@ -1371,17 +1422,12 @@ mod tests {
         let pk1 = PrimaryKey::from([CqlValue::Int(1)]);
         let pk2 = PrimaryKey::from([CqlValue::Int(2)]);
         let vector_orig: Vector = vec![1.0, 2.0, 3.0].into();
-        let db_row_add = |pk: &PrimaryKey, ts| DbIndexedRow {
-            primary_key: pk.clone(),
-            values: NonemptyBox::new([Timestamped::new(
+        let values = |ts| {
+            NonemptyBox::new([Timestamped::new(
                 Timestamp::from_millis(ts),
                 Some(DbIndexedValue::Vector(vector_orig.clone())),
             )])
-            .unwrap(),
-        };
-        let db_row_del = |pk: &PrimaryKey, ts| DbIndexedRow {
-            primary_key: pk.clone(),
-            values: NonemptyBox::new([Timestamped::new(Timestamp::from_millis(ts), None)]).unwrap(),
+            .unwrap()
         };
 
         let index_key = IndexKey::new(&"ks".into(), &"idx".into());
@@ -1397,7 +1443,7 @@ mod tests {
         .unwrap();
 
         // insert the vector pk1
-        let mut operations = table.add(&index_key, db_row_add(&pk1, 1)).unwrap();
+        let mut operations = table.upsert(&index_key, pk1.clone(), values(1)).unwrap();
         assert_eq!(operations.len(), 1);
         let (primary_id1, partition_id1) = match operations.remove(0) {
             Operation::AddVector {
@@ -1417,7 +1463,7 @@ mod tests {
         );
 
         // insert the vector pk2
-        let mut operations = table.add(&index_key, db_row_add(&pk2, 2)).unwrap();
+        let mut operations = table.upsert(&index_key, pk2.clone(), values(2)).unwrap();
         assert_eq!(operations.len(), 1);
         let (primary_id2, partition_id2) = match operations.remove(0) {
             Operation::AddVector {
@@ -1438,8 +1484,10 @@ mod tests {
             &pk2
         );
 
-        // remove the vector by nulling the value
-        let mut operations = table.add(&index_key, db_row_del(&pk2, 3)).unwrap();
+        // remove the vector
+        let mut operations = table
+            .delete(&index_key, pk2.clone(), Timestamp::from_millis(3))
+            .unwrap();
         assert_eq!(operations.len(), 1);
         match operations.remove(0) {
             Operation::RemoveValue {
@@ -1454,7 +1502,7 @@ mod tests {
         assert!(table.primary_key(partition_id2, primary_id2).is_none());
 
         // insert the vector pk2
-        let mut operations = table.add(&index_key, db_row_add(&pk2, 4)).unwrap();
+        let mut operations = table.upsert(&index_key, pk2.clone(), values(4)).unwrap();
         assert_eq!(operations.len(), 1);
         let (primary_id3, partition_id3) = match operations.remove(0) {
             Operation::AddVector {
@@ -1478,7 +1526,9 @@ mod tests {
         let mut primary_id_prev = primary_id3;
         for it in 0..10 {
             // upsert the vector with a new value
-            let mut operations = table.add(&index_key, db_row_add(&pk2, 5 + it)).unwrap();
+            let mut operations = table
+                .upsert(&index_key, pk2.clone(), values(5 + it))
+                .unwrap();
             assert_eq!(operations.len(), 2);
             match operations.remove(0) {
                 Operation::RemoveBeforeAddValue {

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -21,6 +21,7 @@ use vector_store::AsyncInProgress;
 use vector_store::ColumnName;
 use vector_store::DbCustomIndex;
 use vector_store::DbIndexKind;
+use vector_store::DbIndexedOperation;
 use vector_store::DbIndexedRow;
 use vector_store::DbIndexedValue;
 use vector_store::Dimensions;
@@ -75,11 +76,13 @@ where
             .into_iter()
             .map(|(primary_key, embedding, timestamp)| DbIndexedRow {
                 primary_key,
-                values: NonemptyBox::new([Timestamped::new(
-                    timestamp,
-                    embedding.map(DbIndexedValue::Vector),
-                )])
-                .unwrap(),
+                operation: DbIndexedOperation::Upsert(
+                    NonemptyBox::new([Timestamped::new(
+                        timestamp,
+                        embedding.map(DbIndexedValue::Vector),
+                    )])
+                    .unwrap(),
+                ),
             }),
     )
 }
@@ -92,11 +95,13 @@ where
     make_scan_fn(items.into_iter().map(|(primary_key, document, timestamp)| {
         DbIndexedRow {
             primary_key,
-            values: NonemptyBox::new([Timestamped::new(
-                timestamp,
-                document.map(DbIndexedValue::Document),
-            )])
-            .unwrap(),
+            operation: DbIndexedOperation::Upsert(
+                NonemptyBox::new([Timestamped::new(
+                    timestamp,
+                    document.map(DbIndexedValue::Document),
+                )])
+                .unwrap(),
+            ),
         }
     }))
 }

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -22,6 +22,7 @@ use vector_store::AsyncInProgress;
 use vector_store::Config;
 use vector_store::Connectivity;
 use vector_store::DbIndexPartitioning;
+use vector_store::DbIndexedOperation;
 use vector_store::DbIndexedRow;
 use vector_store::DbIndexedValue;
 use vector_store::ExpansionAdd;
@@ -102,11 +103,13 @@ async fn memory_limit_during_index_build() {
                         .send((
                             DbIndexedRow {
                                 primary_key: [CqlValue::Int(pk)].into(),
-                                values: NonemptyBox::new([Timestamped::new(
-                                    Timestamp::from_millis(10),
-                                    Some(DbIndexedValue::Vector(item)),
-                                )])
-                                .unwrap(),
+                                operation: DbIndexedOperation::Upsert(
+                                    NonemptyBox::new([Timestamped::new(
+                                        Timestamp::from_millis(10),
+                                        Some(DbIndexedValue::Vector(item)),
+                                    )])
+                                    .unwrap(),
+                                ),
                             },
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))


### PR DESCRIPTION
This PR refactor two things - adds filtering columns into the Table and change DbIndexedRow::values into DbIndexedOperation. Operation can be Upsert or Delete. This refactoring helps to distinguish between Upsert or Delete operation which is hard using only NonemptyArc<Timestamped<DbIndexedValue>> - we don't now if the full row was deleted or only values inside were deleted. This refactoring simplify processing.

Fixes: VECTOR-707
