### PR TITLE
vector-store: implement filtering by non-primary-key columns

### DIFF
--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -573,11 +573,18 @@ async fn ann_filter_by_vector_column_fails(actors: Arc<TestActors>) {
     info!("finished");
 }
 
-/// Test that filtering by a non-primary-key column in a WHERE clause fails.
+/// Test filtering on a non-indexed column with a global index.
 ///
-/// `WHERE f = 1` on a non-indexed column should be rejected.
+/// Steps:
+/// 1. Create a table with a vector column and a non-indexed integer column.
+/// 2. Create a global index on the vector column, specifying the integer column as a filtering
+///    column.
+/// 3. Insert rows with different values for the integer column.
+/// 4. Query the table with a WHERE clause filtering on the integer column and verify that only
+///   the rows matching the filter are returned.
+/// 5. Drop the keyspace.
 #[e2etest::test(group = filtering)]
-async fn ann_filter_by_non_indexed_column_fails(actors: Arc<TestActors>) {
+async fn global_index_filter_by_filtering_columns(actors: Arc<TestActors>) {
     info!("started");
 
     let (session, clients) = prepare_connection(&actors).await;
@@ -585,35 +592,154 @@ async fn ann_filter_by_non_indexed_column_fails(actors: Arc<TestActors>) {
     let keyspace = create_keyspace(&session).await;
     let table = create_table(
         &session,
-        "pk INT, f INT, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        "pk INT, ck INT, f INT, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk, ck)",
         None,
     )
     .await;
 
-    for pk in 0..5 {
+    for pk in 0..10 {
         session
             .query_unpaged(
-                format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
-                (pk, pk % 2, &vec![pk as f32, 0.0, 0.0]),
+                format!("INSERT INTO {table} (pk, ck, f, v) VALUES (?, ?, ?, ?)"),
+                (pk, pk % 4, pk % 2, &vec![pk as f32, 0.0, 0.0]),
             )
             .await
             .expect("failed to insert data");
     }
 
-    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
 
     for client in &clients {
         let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 5, "Expected 5 vectors to be indexed");
+        assert_eq!(
+            index_status.count, 10,
+            "Expected 10 vectors to be indexed in the index"
+        );
     }
 
+    info!("Querying index for f = 0");
+    let results: HashSet<_> = get_query_results(
+        format!("SELECT pk FROM {table} WHERE f = 0 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"),
+        &session,
+    )
+    .await
+        .rows::<(i32,)>()
+        .expect("failed to get rows")
+        .map(|row| row.expect("failed to get row"))
+        .collect();
+    assert_eq!(results, HashSet::from([(0,), (2,), (4,), (6,), (8,)]));
+
+    info!("Querying index for pk = 3 AND f = 1");
+    let results: HashSet<_> = get_query_results(
+        format!("SELECT pk FROM {table} WHERE pk = 3 AND f = 1 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"),
+        &session,
+    )
+    .await
+        .rows::<(i32,)>()
+        .expect("failed to get rows")
+        .map(|row| row.expect("failed to get row"))
+        .collect();
+    assert_eq!(results, HashSet::from([(3,)]));
+
+    info!("Querying index for ck = 2 AND f = 0");
+    let results: HashSet<_> = get_query_results(
+        format!("SELECT pk FROM {table} WHERE ck = 2 AND f = 0 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"),
+        &session,
+    )
+    .await
+        .rows::<(i32,)>()
+        .expect("failed to get rows")
+        .map(|row| row.expect("failed to get row"))
+        .collect();
+    assert_eq!(results, HashSet::from([(2,), (6,)]));
+
     session
-        .query_unpaged(
-            format!("SELECT pk FROM {table} WHERE f = 1 ORDER BY v ANN OF [1.0, 0.0, 0.0] LIMIT 5 ALLOW FILTERING"),
-            (),
-        )
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
         .await
-        .expect_err("WHERE on non-primary-key column should fail");
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test filtering on a non-indexed column with a local index.
+///
+/// Steps:
+/// 1. Create a table with a vector column and a non-indexed integer column.
+/// 2. Create a local index on the vector column, specifying the integer column as a filtering
+///    column.
+/// 3. Insert rows with different values for the integer column.
+/// 4. Query the table with a WHERE clause filtering on the integer column and verify that only
+///   the rows matching the filter are returned.
+/// 5. Drop the keyspace.
+#[e2etest::test(group = filtering)]
+async fn local_index_filter_by_filtering_columns(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, ck INT, f INT, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk, ck)",
+        None,
+    )
+    .await;
+
+    for pk in 0..10 {
+        for ck in 0..10 {
+            session
+                .query_unpaged(
+                    format!("INSERT INTO {table} (pk, ck, f, v) VALUES (?, ?, ?, ?)"),
+                    (pk, ck, ck % 2, &vec![pk as f32, ck as f32, 0.0]),
+                )
+                .await
+                .expect("failed to insert data");
+        }
+    }
+
+    let index = create_index(
+        CreateIndexQuery::new(&session, &clients, &table, "v")
+            .partition_columns(["pk"])
+            .filter_columns(["f"]),
+    )
+    .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(
+            index_status.count, 100,
+            "Expected 100 vectors to be indexed in the index"
+        );
+    }
+
+    info!("Querying index for pk = 3 AND f = 1");
+    let results: HashSet<_> = get_query_results(
+        format!("SELECT pk, ck FROM {table} WHERE pk = 3 AND f = 1 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"),
+        &session,
+    )
+    .await
+        .rows::<(i32, i32,)>()
+        .expect("failed to get rows")
+        .map(|row| row.expect("failed to get row"))
+        .collect();
+    assert_eq!(
+        results,
+        HashSet::from([(3, 1), (3, 3), (3, 5), (3, 7), (3, 9)])
+    );
+
+    info!("Querying index for pk = 7 AND ck = 2 AND f = 0");
+    let results: HashSet<_> = get_query_results(
+        format!("SELECT pk, ck FROM {table} WHERE pk = 7 AND ck = 2 AND f = 0 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"),
+        &session,
+    )
+    .await
+        .rows::<(i32, i32)>()
+        .expect("failed to get rows")
+        .map(|row| row.expect("failed to get row"))
+        .collect();
+    assert_eq!(results, HashSet::from([(7, 2),]));
 
     session
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())

--- a/crates/validator/src/index_create.rs
+++ b/crates/validator/src/index_create.rs
@@ -128,15 +128,17 @@ async fn global_index_with_filtering_columns(actors: Arc<TestActors>) {
 
     wait_for_index(&clients, &index).await;
 
-    // TODO: Re-enable this test after SCYLLADB-635 is solved.
-    // info!("Query the index");
-    // let results = common::get_query_results(
-    //     format!("SELECT pk FROM {table} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10"),
-    //     &session,
-    // )
-    // .await;
-    // let rows = results.rows::<(i32,)>().expect("failed to get rows");
-    // assert_eq!(rows.rows_remaining(), 10);
+    info!("Query the index");
+    common::wait_for(
+        || async {
+            let results = common::get_query_results(
+                format!("SELECT pk FROM {table} WHERE f = 1 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 100 ALLOW FILTERING"),
+                &session,
+            )
+                .await;
+            let rows = results.rows::<(i32,)>().expect("failed to get rows");
+            rows.rows_remaining() > 10
+        }, "Wait for the query to result more than 10 items", common::DEFAULT_OPERATION_TIMEOUT).await;
 
     cleanup_keyspace(&actors, &keyspace).await;
 
@@ -195,6 +197,14 @@ async fn local_index_with_filtering_columns(actors: Arc<TestActors>) {
     .await;
     let rows = results.rows::<(i32,)>().expect("failed to get rows");
     assert_eq!(rows.rows_remaining(), 10);
+
+    let results = common::get_query_results(
+        format!("SELECT ck FROM {table} WHERE pk = 1 AND f = 10 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"),
+        &session,
+    )
+    .await;
+    let rows = results.rows::<(i32,)>().expect("failed to get rows");
+    assert_eq!(rows.rows_remaining(), 1);
 
     cleanup_keyspace(&actors, &keyspace).await;
 

--- a/crates/validator/src/serde.rs
+++ b/crates/validator/src/serde.rs
@@ -8,10 +8,11 @@ use crate::common;
 use crate::common::*;
 use scylla::statement::{Consistency, Statement};
 use scylla::value::CqlValue;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-const CDC_WAIT: Duration = Duration::from_secs(2);
+const CDC_WAIT: Duration = Duration::from_secs(10);
 
 e2etest::group!(
     name = serde,
@@ -286,14 +287,19 @@ async fn test_decimal_key(actors: Arc<TestActors>) {
         "full scan: 2 rows (CK overwrite + PK identity)"
     );
 
-    assert_eq!(
-        get_keys().await,
-        vec![
-            ("1.0".to_string(), "3.14".to_string()),
-            ("1.00".to_string(), "3.140".to_string()),
-        ],
-        "full scan: PK byte-identity preserved, CK original representation returned"
-    );
+    let keys = get_keys().await;
+    let mut expected_pks: HashSet<_> = ["1.0".to_string(), "1.00".to_string()]
+        .into_iter()
+        .collect();
+    for (pk, ck) in &keys {
+        assert!(expected_pks.remove(pk), "PK byte-identity preserved");
+        match pk.as_str() {
+            "1.0" => assert!(ck == "3.14" || ck == "3.140"),
+            "1.00" => assert_eq!(ck, "3.140"),
+            _ => panic!("unexpected pk={pk}"),
+        }
+    }
+    assert!(expected_pks.is_empty());
 
     // Phase 2: after index creation (CDC path).
     // Same pattern as Phase 1.
@@ -301,26 +307,38 @@ async fn test_decimal_key(actors: Arc<TestActors>) {
     insert("2.0", "7.50", [4.0, 5.0, 6.0]).await;
     insert("2.00", "7.50", [7.0, 8.0, 9.0]).await;
 
-    wait_for(
-        || async {
-            let status = client.index_status(&index.keyspace, &index.index).await;
-            matches!(status, Ok(s) if s.count == 4)
-        },
-        "Waiting for CDC (count == 4)",
-        CDC_WAIT,
-    )
-    .await;
+    for client in &clients {
+        wait_for(
+            || async {
+                let status = client.index_status(&index.keyspace, &index.index).await;
+                matches!(status, Ok(s) if s.count == 4)
+            },
+            "Waiting for CDC (count == 4)",
+            CDC_WAIT,
+        )
+        .await;
+    }
 
-    assert_eq!(
-        get_keys().await,
-        vec![
-            ("1.0".to_string(), "3.14".to_string()),
-            ("1.00".to_string(), "3.140".to_string()),
-            ("2.0".to_string(), "7.5".to_string()),
-            ("2.00".to_string(), "7.50".to_string()),
-        ],
-        "CDC: PK byte-identity preserved, CK original representation returned"
-    );
+    let keys = get_keys().await;
+    let mut expected_pks: HashSet<_> = [
+        "1.0".to_string(),
+        "1.00".to_string(),
+        "2.0".to_string(),
+        "2.00".to_string(),
+    ]
+    .into_iter()
+    .collect();
+    for (pk, ck) in &keys {
+        assert!(expected_pks.remove(pk), "PK byte-identity preserved");
+        match pk.as_str() {
+            "1.0" => assert!(ck == "3.14" || ck == "3.140"),
+            "1.00" => assert_eq!(ck, "3.140"),
+            "2.0" => assert!(ck == "7.5" || ck == "7.50"),
+            "2.00" => assert_eq!(ck, "7.50"),
+            _ => panic!("unexpected pk={pk}"),
+        }
+    }
+    assert!(expected_pks.is_empty());
 
     session
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())

--- a/crates/vector-store/src/db_cdc/actor.rs
+++ b/crates/vector-store/src/db_cdc/actor.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 use tokio::sync::Notify;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
@@ -104,6 +105,7 @@ impl CdcReaderConfig {
 }
 
 /// Spawns a CDC actor that watches for session changes and manages a CDC reader.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn new(
     config_rx: watch::Receiver<Arc<Config>>,
     mut session_rx: watch::Receiver<Option<Arc<Session>>>,
@@ -111,6 +113,7 @@ pub(crate) fn new(
     internals: Sender<Internals>,
     metrics: Arc<Metrics>,
     tx_embeddings: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+    semaphore: Arc<Semaphore>,
     config: CdcReaderConfig,
 ) -> mpsc::Sender<DbCdc> {
     let (tx, mut rx) = mpsc::channel::<DbCdc>(perf::channel_size().into());
@@ -125,6 +128,7 @@ pub(crate) fn new(
         Arc::clone(&metrics),
         metadata.keyspace_name.clone(),
         metadata.index_name.clone(),
+        semaphore,
     );
     let name = reader.name;
     let actor_key = metadata.key();
@@ -200,6 +204,7 @@ struct CdcReaderState {
     handler_task: Option<tokio::task::JoinHandle<Duration>>,
     shutdown_notify: Arc<Notify>,
     error_notify: Arc<Notify>,
+    semaphore: Arc<Semaphore>,
     start: Duration,
     name: &'static str,
     params_fn: fn(&Config) -> CdcReaderParams,
@@ -215,12 +220,14 @@ impl CdcReaderState {
         metrics: Arc<Metrics>,
         keyspace: KeyspaceName,
         index_name: IndexName,
+        semaphore: Arc<Semaphore>,
     ) -> Self {
         let state = Self {
             reader: None,
             handler_task: None,
             shutdown_notify: Arc::new(Notify::new()),
             error_notify: Arc::new(Notify::new()),
+            semaphore,
             start: cdc_now(),
             name,
             params_fn,
@@ -289,6 +296,7 @@ impl CdcReaderState {
             Arc::clone(session),
             metadata.clone(),
             tx_embeddings.clone(),
+            Arc::clone(&self.semaphore),
             Arc::clone(&self.metrics),
             self.name,
         )
@@ -427,12 +435,14 @@ fn drain_pending_notifications(notify: &Notify) {
 }
 
 /// Creates a CDC log reader with the given parameters.
+#[allow(clippy::too_many_arguments)]
 async fn create_cdc_reader(
     start: Duration,
     params: CdcReaderParams,
     session: Arc<Session>,
     metadata: IndexMetadata,
     tx_embeddings: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+    semaphore: Arc<Semaphore>,
     metrics: Arc<Metrics>,
     reader_name: &str,
 ) -> anyhow::Result<(
@@ -444,7 +454,9 @@ async fn create_cdc_reader(
         &metadata,
         Arc::clone(&metrics),
         tx_embeddings,
-    )?;
+        semaphore,
+    )
+    .await?;
 
     let cdc_start = start - CHECKPOINT_TIMESTAMP_OFFSET;
     info!(
@@ -539,6 +551,7 @@ mod tests {
             metrics,
             "ks".into(),
             "idx".into(),
+            Semaphore::new(1).into(),
         )
     }
 

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -7,91 +7,183 @@ use crate::AsyncInProgress;
 use crate::ColumnName;
 use crate::DbIndexedOperation;
 use crate::DbIndexedRow;
-use crate::DbIndexedValue;
 use crate::IndexKey;
 use crate::IndexKind;
 use crate::IndexMetadata;
 use crate::Metrics;
 use crate::NonemptyArc;
-use crate::NonemptyBox;
 use crate::NonemptyIteratorExt;
-use crate::Timestamped;
-use crate::db_index_backend::CdcValueStatus;
-use crate::db_index_backend::DbIndexBackend;
+use crate::PrimaryKey;
+use crate::Timestamp;
+use crate::db_index;
+use crate::db_index_backend;
+use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
 use async_trait::async_trait;
 use scylla::client::session::Session;
+use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
+use scylla::value::Row;
 use scylla_cdc::consumer::CDCRow;
 use scylla_cdc::consumer::Consumer;
 use scylla_cdc::consumer::ConsumerFactory;
 use scylla_cdc::consumer::OperationType;
 use std::sync::Arc;
+use tap::Pipe;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
+use tracing::debug;
+use tracing::error;
 
-fn extract_indexed_value(
-    backend: &DbIndexBackend,
-    value: CqlValue,
-    kind: &IndexKind,
-) -> anyhow::Result<Option<DbIndexedValue>> {
-    match kind {
-        IndexKind::Vs(_) => backend
-            .extract_vector(value)
-            .map(|opt| opt.map(DbIndexedValue::Vector)),
-        IndexKind::Fts(_) => backend
-            .extract_document(value)
-            .map(|opt| opt.map(DbIndexedValue::Document)),
-    }
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Operation {
+    Upsert,
+    Delete,
 }
 
 struct CdcConsumerData {
+    session: Arc<Session>,
+    st_select_values: PreparedStatement,
     index_key: IndexKey,
     primary_key_columns: NonemptyArc<ColumnName>,
-    backend: DbIndexBackend,
+    target_columns: NonemptyArc<ColumnName>,
+    filtering_columns: Arc<[ColumnName]>,
     kind: IndexKind,
     tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     metrics: Arc<Metrics>,
+    semaphore: Arc<Semaphore>,
 }
 
-struct CdcConsumer(Arc<CdcConsumerData>);
+impl CdcConsumerData {
+    async fn process_upsert(
+        &self,
+        primary_key: Arc<Vec<CqlValue>>,
+        timestamp: Timestamp,
+    ) -> anyhow::Result<()> {
+        let rows_result = self
+            .session
+            .execute_unpaged(&self.st_select_values, primary_key.as_slice())
+            .await?
+            .into_rows_result()?;
+        let primary_key = PrimaryKey::from(primary_key.iter().cloned());
+
+        let async_in_progress = AsyncInProgress::cdc(
+            self.metrics.indexing_lag.with_label_values(&[
+                self.index_key.keyspace().as_ref(),
+                self.index_key.index().as_ref(),
+            ]),
+            timestamp,
+        );
+
+        let Some(row) = rows_result.maybe_first_row::<Row>()? else {
+            // If no row is found for the primary key, it is deleted
+            _ = self
+                .tx
+                .send((
+                    DbIndexedRow {
+                        primary_key,
+                        operation: DbIndexedOperation::Delete(timestamp),
+                    },
+                    async_in_progress,
+                ))
+                .await;
+            return Ok(());
+        };
+
+        let target_columns_len = self.target_columns.len();
+        let columns_len_expected = (target_columns_len.get() + self.filtering_columns.len()) * 2;
+        if row.columns.len() != columns_len_expected {
+            let msg = format!(
+                "Unexpected number of columns in row: expected {columns_len_expected}, got {received_len}",
+                received_len = row.columns.len()
+            );
+            debug!("process_upsert: {msg}");
+            bail!(msg);
+        }
+
+        let values =
+            db_index::parse_values(row.columns, Some(timestamp), target_columns_len, &self.kind)?;
+        _ = self
+            .tx
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    operation: DbIndexedOperation::Upsert(values),
+                },
+                async_in_progress,
+            ))
+            .await;
+        Ok(())
+    }
+}
+
+struct CdcConsumer {
+    consumer_data: Arc<CdcConsumerData>,
+    primary_key: Arc<Vec<CqlValue>>,
+    timestamp: Timestamp,
+    operation: Operation,
+}
+
+impl CdcConsumer {
+    async fn process_row(&self) {
+        if matches!(self.operation, Operation::Upsert) {
+            self.process_upsert().await;
+        } else {
+            self.process_delete().await;
+        }
+    }
+
+    async fn process_upsert(&self) {
+        let permit = Arc::clone(&self.consumer_data.semaphore)
+            .acquire_owned()
+            .await
+            .unwrap();
+        let primary_key = Arc::clone(&self.primary_key);
+        let timestamp = self.timestamp;
+        let consumer_data = Arc::clone(&self.consumer_data);
+        tokio::spawn(async move {
+            let _permit = permit;
+            if let Err(err) = consumer_data.process_upsert(primary_key, timestamp).await {
+                error!("Error processing upsert: {err}");
+            }
+        });
+    }
+
+    async fn process_delete(&self) {
+        let _ = self
+            .consumer_data
+            .tx
+            .send((
+                DbIndexedRow {
+                    primary_key: self.primary_key.iter().cloned().collect(),
+                    operation: DbIndexedOperation::Delete(self.timestamp),
+                },
+                AsyncInProgress::cdc(
+                    self.consumer_data.metrics.indexing_lag.with_label_values(&[
+                        self.consumer_data.index_key.keyspace().as_ref(),
+                        self.consumer_data.index_key.index().as_ref(),
+                    ]),
+                    self.timestamp,
+                ),
+            ))
+            .await;
+    }
+}
 
 #[async_trait]
 impl Consumer for CdcConsumer {
     async fn consume_cdc(&mut self, mut row: CDCRow<'_>) -> anyhow::Result<()> {
-        if self.0.tx.is_closed() {
+        if self.consumer_data.tx.is_closed() {
             // a consumer should be closed now, some concurrent tasks could stay in a pipeline
             return Ok(());
         }
 
-        let source = &self.0.backend;
-        // TODO: fix multi-target indexes
-        let column = source.target_column_names().first().as_ref();
-        if !row.column_deletable(column) {
-            bail!("CDC error: column {column} should be deletable");
-        }
-
-        let timestamp = row
-            .time
-            .try_into()
-            .map_err(|err| anyhow!("CDC error: converting row.time: {err}"))?;
-
         let operation = match row.operation {
-            OperationType::PartitionDelete | OperationType::RowDelete => {
-                DbIndexedOperation::Delete(timestamp)
-            }
+            OperationType::PartitionDelete | OperationType::RowDelete => Operation::Delete,
 
             OperationType::RowUpdate | OperationType::RowInsert | OperationType::PostImage => {
-                let value = match source.take_cdc_value(&mut row)? {
-                    CdcValueStatus::Deleted => None,
-                    CdcValueStatus::Skip => return Ok(()),
-                    CdcValueStatus::NewValue(value) => {
-                        extract_indexed_value(source, value, &self.0.kind)?
-                    }
-                };
-                DbIndexedOperation::Upsert(
-                    NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
-                )
+                Operation::Upsert
             }
 
             OperationType::PreImage
@@ -105,33 +197,34 @@ impl Consumer for CdcConsumer {
         };
 
         let Some(primary_key) = self
-            .0
+            .consumer_data
             .primary_key_columns
             .iter()
             .map(|column| row.take_value(column.as_ref()))
-            .collect()
+            .collect::<Option<Vec<_>>>()
         else {
             // If any primary key column is missing skip this row.
             return Ok(());
         };
 
-        _ = self
-            .0
-            .tx
-            .send((
-                DbIndexedRow {
-                    primary_key,
-                    operation,
-                },
-                AsyncInProgress::cdc(
-                    self.0.metrics.indexing_lag.with_label_values(&[
-                        self.0.index_key.keyspace().as_ref(),
-                        self.0.index_key.index().as_ref(),
-                    ]),
-                    timestamp,
-                ),
-            ))
-            .await;
+        let timestamp = row
+            .time
+            .try_into()
+            .map_err(|err| anyhow!("CDC error: converting row.time: {err}"))?;
+
+        if timestamp == self.timestamp
+            && &primary_key == self.primary_key.as_ref()
+            && operation == self.operation
+        {
+            // Skip duplicate rows with the same primary key and timestamp.
+            return Ok(());
+        }
+        self.primary_key = Arc::new(primary_key);
+        self.timestamp = timestamp;
+        self.operation = operation;
+
+        self.process_row().await;
+
         Ok(())
     }
 }
@@ -141,16 +234,22 @@ pub(super) struct CdcConsumerFactory(Arc<CdcConsumerData>);
 #[async_trait]
 impl ConsumerFactory for CdcConsumerFactory {
     async fn new_consumer(&self) -> Box<dyn Consumer> {
-        Box::new(CdcConsumer(Arc::clone(&self.0)))
+        Box::new(CdcConsumer {
+            consumer_data: Arc::clone(&self.0),
+            primary_key: Arc::new(vec![]),
+            timestamp: Timestamp::MIN,
+            operation: Operation::Upsert,
+        })
     }
 }
 
 impl CdcConsumerFactory {
-    pub(super) fn new(
+    pub(super) async fn new(
         session: Arc<Session>,
         metadata: &IndexMetadata,
         metrics: Arc<Metrics>,
         tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+        semaphore: Arc<Semaphore>,
     ) -> anyhow::Result<Self> {
         let cluster_state = session.get_cluster_state();
         let table = cluster_state
@@ -169,15 +268,41 @@ impl CdcConsumerFactory {
             .collect_nonempty_arc()
             .ok_or_else(|| anyhow!("primary key must have at least one column"))?;
 
-        let backend = DbIndexBackend::from(metadata);
+        let target_columns = metadata.target_columns.clone();
+        let filtering_columns: Arc<[_]> = metadata
+            .filtering_columns
+            .iter()
+            .filter(|column| !primary_key_columns.contains(column))
+            .cloned()
+            .collect();
+
+        let query = db_index_backend::request_query(
+            &metadata.keyspace_name.as_ref().into(),
+            &metadata.table_name.as_ref().into(),
+            target_columns.iter().chain(filtering_columns.iter()),
+            primary_key_columns.iter(),
+        );
+        let st_select_values =
+            session
+                .prepare(query)
+                .await
+                .context("request_query")?
+                .pipe(|mut stmt| {
+                    stmt.set_is_idempotent(true);
+                    stmt
+                });
 
         Ok(Self(Arc::new(CdcConsumerData {
+            session,
+            st_select_values,
             index_key: metadata.key(),
             primary_key_columns,
-            backend,
+            target_columns,
+            filtering_columns,
             kind: metadata.kind.clone(),
             tx,
             metrics,
+            semaphore,
         })))
     }
 }

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -181,6 +181,8 @@ pub(crate) async fn new(
 
     let statements = Arc::new(Statements::new(statements_session_rx, metadata.clone()).await?);
 
+    let semaphore = Arc::new(Semaphore::new(concurrency_limit()));
+
     // Create wide-framed CDC actor
     let cdc_wide = db_cdc::new(
         config_rx.clone(),
@@ -189,6 +191,7 @@ pub(crate) async fn new(
         internals.clone(),
         metrics.clone(),
         tx_embeddings.clone(),
+        Arc::clone(&semaphore),
         CdcReaderConfig::Wide,
     );
 
@@ -200,6 +203,7 @@ pub(crate) async fn new(
         internals,
         metrics,
         tx_embeddings.clone(),
+        semaphore,
         CdcReaderConfig::Fine,
     );
 
@@ -741,6 +745,11 @@ fn parse_indexed_value(value: CqlValue, kind: &IndexKind) -> anyhow::Result<DbIn
             }
         },
     }
+}
+
+fn concurrency_limit() -> usize {
+    const RATIO: usize = 3;
+    perf::num_workers().get() * RATIO
 }
 
 #[cfg(test)]

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -17,6 +17,7 @@ use crate::NonemptyArc;
 use crate::NonemptyBox;
 use crate::NonemptyIteratorExt;
 use crate::Percentage;
+use crate::PrimaryKey;
 use crate::Progress;
 use crate::TableIdentifier;
 use crate::Timestamp;
@@ -311,6 +312,8 @@ struct Statements {
     session_rx: tokio::sync::watch::Receiver<Option<Arc<Session>>>,
     primary_key_columns: NonemptyArc<ColumnName>,
     partition_key_count: usize,
+    target_columns: NonemptyArc<ColumnName>,
+    filtering_columns: Arc<[ColumnName]>,
     table_columns: GetTableColumnsR,
     st_range_scan: PreparedStatement,
     kind: IndexKind,
@@ -360,6 +363,14 @@ impl Statements {
             InvariantKey::MAX_COLUMNS,
         );
 
+        let target_columns = metadata.target_columns.clone();
+        let filtering_columns: Arc<[_]> = metadata
+            .filtering_columns
+            .iter()
+            .filter(|column| !primary_key_columns.contains(column))
+            .cloned()
+            .collect();
+
         let table_columns = Arc::new(
             table
                 .columns
@@ -387,7 +398,7 @@ impl Statements {
         let query = db_index_backend::range_scan_query(
             &keyspace_identifier,
             &table_identifier,
-            metadata.target_columns.first(),
+            target_columns.iter().chain(filtering_columns.iter()),
             &st_primary_key_list,
             &st_partition_key_list,
         );
@@ -403,6 +414,8 @@ impl Statements {
         Ok(Self {
             primary_key_columns,
             partition_key_count,
+            target_columns,
+            filtering_columns,
             table_columns,
             st_range_scan,
             session_rx,
@@ -579,8 +592,11 @@ impl Statements {
         begin: Token,
         end: Token,
     ) -> anyhow::Result<BoxStream<'static, DbIndexedRow>> {
-        // last two columns are embedding and writetime
-        let columns_len_expected = self.primary_key_columns.len().get() + 2;
+        // last values columns are value and writetime
+        let columns_len_expected = self.primary_key_columns.len().get()
+            + (self.target_columns.len().get() + self.filtering_columns.len()) * 2;
+        let target_columns_offset = self.primary_key_columns.len().get();
+        let target_columns_len = self.target_columns.len();
         let kind = self.kind.clone();
 
         // wait for an active session
@@ -612,39 +628,20 @@ impl Statements {
                     return None;
                 }
 
-                let Some(CqlValue::BigInt(timestamp)) = row.columns.pop().unwrap() else {
-                    debug!("range_scan_stream: bad type of a writetime");
-                    return None;
-                };
-                let timestamp = Timestamp::from_micros(timestamp as u64);
+                let values = parse_values(
+                    row.columns.drain(target_columns_offset..),
+                    None,
+                    target_columns_len,
+                    &kind,
+                )
+                .inspect_err(|err| error!("Error while parsing values: {err}"))
+                .ok()?;
 
-                let Some(column_value) = row.columns.pop().unwrap() else {
-                    debug!("range_scan_stream: missing target column");
-                    return None;
-                };
-
-                let value = parse_indexed_value(column_value, &kind)?;
-
-                let Ok(primary_key) = row
-                    .columns
-                    .into_iter()
-                    .map(|value| {
-                        let Some(value) = value else {
-                            bail!("range_scan_stream: missing a primary key column");
-                        };
-                        Ok(value)
-                    })
-                    .collect::<anyhow::Result<_>>()
-                    .inspect_err(|err| debug!("range_scan_stream: {err}"))
-                else {
-                    return None;
-                };
+                let primary_key = parse_primary_key(row.columns)?;
 
                 Some(DbIndexedRow {
                     primary_key,
-                    operation: DbIndexedOperation::Upsert(
-                        NonemptyBox::new([Timestamped::new(timestamp, value)]).unwrap(),
-                    ),
+                    operation: DbIndexedOperation::Upsert(values),
                 })
             })
             .filter_map(|value| async move {
@@ -657,22 +654,90 @@ impl Statements {
     }
 }
 
-fn parse_indexed_value(value: CqlValue, kind: &IndexKind) -> Option<Option<DbIndexedValue>> {
-    match kind {
-        IndexKind::Vs(_) => {
-            let Ok(vector) =
-                Vector::try_from(value).inspect_err(|err| debug!("range_scan_stream: {err}"))
-            else {
-                return None;
+pub(crate) fn parse_values(
+    columns: impl IntoIterator<Item = Option<CqlValue>>,
+    default_timestamp: Option<Timestamp>,
+    target_columns_len: NonZeroUsize,
+    kind: &IndexKind,
+) -> anyhow::Result<NonemptyBox<Timestamped<DbIndexedValue>>> {
+    let values = columns
+        .into_iter()
+        .chunks(2)
+        .into_iter()
+        .enumerate()
+        .map(|(idx, mut chunk)| {
+            let value = chunk.next().ok_or(anyhow!(
+                "parse_values: unable to get column value from chunk"
+            ))?;
+            let value = if idx < target_columns_len.get() {
+                // target columns
+                if let Some(value) = value {
+                    Some(parse_indexed_value(value, kind)?)
+                } else {
+                    None
+                }
+            } else {
+                // filtering columns
+                value.map(DbIndexedValue::Filtering)
             };
-            Some(Some(DbIndexedValue::Vector(vector)))
-        }
+
+            let timestamp = chunk
+                .next()
+                .ok_or(anyhow!(
+                    "parse_values: unable to get timestamp value from chunk"
+                ))?
+                .map(|timestamp| {
+                    if let CqlValue::BigInt(timestamp) = timestamp {
+                        Ok(Timestamp::from_micros(timestamp as u64))
+                    } else {
+                        bail!("parse_values: bad type of a writetime")
+                    }
+                })
+                .transpose()?
+                .or(default_timestamp);
+
+            Ok((timestamp, value))
+        })
+        .filter_map(|timestamp_value| {
+            timestamp_value
+                .and_then(|(timestamp, value)| match (timestamp, value) {
+                    (Some(timestamp), value) => Ok(Some((timestamp, value))),
+                    (None, _) => bail!("parse_values: missing timestamp for value"),
+                })
+                .transpose()
+        })
+        .map_ok(|(timestamp, value)| Timestamped::new(timestamp, value))
+        .collect::<anyhow::Result<Box<_>>>()?;
+    if target_columns_len.get() > values.len() {
+        bail!(
+            "parse_values: target len ({target_columns_len}) is greater than values len ({values_len})",
+            values_len = values.len()
+        );
+    }
+    Ok(NonemptyBox::try_from(values).unwrap())
+}
+
+fn parse_primary_key(columns: impl IntoIterator<Item = Option<CqlValue>>) -> Option<PrimaryKey> {
+    columns
+        .into_iter()
+        .inspect(|value| {
+            if value.is_none() {
+                debug!("parse_primary_key: missing a primary key column");
+            };
+        })
+        .collect::<Option<_>>()
+}
+
+fn parse_indexed_value(value: CqlValue, kind: &IndexKind) -> anyhow::Result<DbIndexedValue> {
+    match kind {
+        IndexKind::Vs(_) => Vector::try_from(value)
+            .map_err(|err| anyhow!("parse_indexed_value: {err}"))
+            .map(DbIndexedValue::Vector),
         IndexKind::Fts(_) => match value {
-            CqlValue::Text(s) => Some(Some(DbIndexedValue::Document(s))),
-            CqlValue::Ascii(s) => Some(Some(DbIndexedValue::Document(s))),
+            CqlValue::Text(s) => Ok(DbIndexedValue::Document(s)),
+            CqlValue::Ascii(s) => Ok(DbIndexedValue::Document(s)),
             other => {
-                debug!("range_scan_stream: expected text column, got {:?}", other);
-                None
+                bail!("parse_indexed_value: expected text column, got {:?}", other);
             }
         },
     }
@@ -690,6 +755,7 @@ mod tests {
     use crate::IndexOptionsVs;
     use crate::Quantization;
     use crate::SpaceType;
+    use std::assert_matches;
 
     fn vs_kind() -> IndexKind {
         IndexKind::Vs(IndexOptionsVs {
@@ -735,10 +801,8 @@ mod tests {
         ]);
         let result = parse_indexed_value(cql, &vs_kind());
         assert_eq!(
-            result,
-            Some(Some(DbIndexedValue::Vector(Vector::from(vec![
-                1.0, 2.0, 3.0
-            ]))))
+            result.unwrap(),
+            DbIndexedValue::Vector(Vector::from(vec![1.0, 2.0, 3.0]))
         );
     }
 
@@ -746,7 +810,7 @@ mod tests {
     fn parse_indexed_value_vector_rejects_invalid_type() {
         let cql = CqlValue::Text("not a vector".to_string());
         let result = parse_indexed_value(cql, &vs_kind());
-        assert_eq!(result, None);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -754,8 +818,8 @@ mod tests {
         let cql = CqlValue::Text("hello world".to_string());
         let result = parse_indexed_value(cql, &fts_kind());
         assert_eq!(
-            result,
-            Some(Some(DbIndexedValue::Document("hello world".to_string())))
+            result.unwrap(),
+            DbIndexedValue::Document("hello world".to_string())
         );
     }
 
@@ -764,8 +828,8 @@ mod tests {
         let cql = CqlValue::Ascii("ascii doc".to_string());
         let result = parse_indexed_value(cql, &fts_kind());
         assert_eq!(
-            result,
-            Some(Some(DbIndexedValue::Document("ascii doc".to_string())))
+            result.unwrap(),
+            DbIndexedValue::Document("ascii doc".to_string())
         );
     }
 
@@ -773,6 +837,118 @@ mod tests {
     fn parse_indexed_value_fts_rejects_invalid_type() {
         let cql = CqlValue::Int(42);
         let result = parse_indexed_value(cql, &fts_kind());
-        assert_eq!(result, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_values_with_missing_timestamp() {
+        let columns = vec![
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(CqlValue::BigInt(1234567890)),
+            Some(CqlValue::Vector(vec![CqlValue::Float(2.0)])),
+            None, // missing timestamp
+        ];
+
+        let result = parse_values(
+            columns.clone(),
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+        );
+        assert!(result.is_err());
+        assert_matches!(
+            result
+                .unwrap_err()
+                .to_string(),
+                err if err.contains("missing timestamp for value")
+        );
+
+        let result = parse_values(
+            columns,
+            Some(Timestamp::from_millis(1)),
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_values_with_wrong_timestamp() {
+        let columns = vec![
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(CqlValue::Int(1234567890)),
+        ];
+        let result = parse_values(
+            columns.clone(),
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+        );
+        assert_matches!(
+            result
+                .unwrap_err()
+                .to_string(),
+                err if err.contains("bad type of a writetime")
+        );
+    }
+
+    #[test]
+    fn parse_values_with_wrong_value() {
+        let columns = vec![Some(CqlValue::Int(1)), Some(CqlValue::BigInt(1234567890))];
+        let result = parse_values(
+            columns.clone(),
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+        );
+        assert_matches!(
+            result
+                .unwrap_err()
+                .to_string(),
+                err if err.contains("unsupported CQL type")
+        );
+    }
+
+    #[test]
+    fn parse_values_with_wrong_columns_len() {
+        let columns = vec![
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(CqlValue::BigInt(1234567890)),
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+        ];
+        let result = parse_values(
+            columns.clone(),
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+        );
+        assert_matches!(
+            result
+                .unwrap_err()
+                .to_string(),
+                err if err.contains("unable to get timestamp value from chunk")
+        );
+    }
+
+    #[test]
+    fn parse_values_with_wrong_target_len() {
+        let columns = vec![
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(CqlValue::BigInt(1234567890)),
+            Some(CqlValue::Vector(vec![CqlValue::Float(2.0)])),
+            Some(CqlValue::BigInt(1234567891)),
+        ];
+        let result = parse_values(
+            columns.clone(),
+            None,
+            NonZeroUsize::new(3).unwrap(),
+            &vs_kind(),
+        );
+        assert_matches!(
+            result
+                .unwrap_err()
+                .to_string(),
+                err if err.contains("target len (3) is greater than values len (2)")
+        );
     }
 }

--- a/crates/vector-store/src/db_index_backend.rs
+++ b/crates/vector-store/src/db_index_backend.rs
@@ -159,39 +159,44 @@ fn take_alternator_attr(attrs: CqlValue, target: &str) -> anyhow::Result<Option<
 ///
 /// For CQL-native tables, selects the vector column directly.
 /// For Alternator tables, selects from the `:attrs` map column.
-pub(crate) fn range_scan_query(
+pub(crate) fn range_scan_query<'a>(
     keyspace: &KeyspaceIdentifier,
     table: &TableIdentifier,
-    target_column: &ColumnName,
+    columns: impl IntoIterator<Item = &'a ColumnName>,
     primary_key_list: &str,
     partition_key_list: &str,
 ) -> String {
-    if keyspace.is_alternator() {
+    let columns = if keyspace.is_alternator() {
         let attributes = CqlIdentifier::new(ALTERNATOR_ATTRS_COLUMN);
-        let vector = CqlLiteral::new(target_column.as_ref());
-        format!(
-            "
-            SELECT {primary_key_list}, {attributes}[{vector}], writetime({attributes}[{vector}])
-            FROM {keyspace}.{table}
-            WHERE
-                token({partition_key_list}) >= ?
-                AND token({partition_key_list}) <= ?
-            BYPASS CACHE
-            "
+        itertools::join(
+            columns.into_iter().map(CqlLiteral::new).flat_map(|column| {
+                [
+                    format!("{attributes}[{column}]"),
+                    format!("writetime({attributes}[{column}])"),
+                ]
+            }),
+            ", ",
         )
     } else {
-        let vector = CqlIdentifier::new(target_column.as_ref());
-        format!(
-            "
-            SELECT {primary_key_list}, {vector}, writetime({vector})
-            FROM {keyspace}.{table}
-            WHERE
-                token({partition_key_list}) >= ?
-                AND token({partition_key_list}) <= ?
-            BYPASS CACHE
-            "
+        itertools::join(
+            columns
+                .into_iter()
+                .map(AsRef::as_ref)
+                .map(CqlIdentifier::new)
+                .flat_map(|column| [format!("{column}"), format!("writetime({column})")]),
+            ", ",
         )
-    }
+    };
+    format!(
+        "
+        SELECT {primary_key_list}, {columns}
+        FROM {keyspace}.{table}
+        WHERE
+            token({partition_key_list}) >= ?
+            AND token({partition_key_list}) <= ?
+        BYPASS CACHE
+        "
+    )
 }
 
 /// Retrieves the vector dimensions for the given index, dispatching to the
@@ -283,7 +288,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("ks"),
             &TableIdentifier::from("tbl"),
-            &ColumnName::from("embedding"),
+            &[ColumnName::from("embedding")],
             &CqlIdentifier::new("id").to_string(),
             &CqlIdentifier::new("id").to_string(),
         );
@@ -303,7 +308,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("MyKeyspace"),
             &TableIdentifier::from("MyTable"),
-            &ColumnName::from("EmbeddingCol"),
+            &[ColumnName::from("EmbeddingCol")],
             &pk_list,
             &CqlIdentifier::new("UserId").to_string(),
         );
@@ -326,7 +331,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("UPPER_KS"),
             &TableIdentifier::from("UPPER_TBL"),
-            &ColumnName::from("VEC"),
+            &[ColumnName::from("VEC")],
             &CqlIdentifier::new("ID").to_string(),
             &CqlIdentifier::new("ID").to_string(),
         );
@@ -348,7 +353,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("my-app"),
             &TableIdentifier::from("my-table:v1"),
-            &ColumnName::from("my-vector"),
+            &[ColumnName::from("my-vector")],
             &pk_list,
             &CqlIdentifier::new(":pk").to_string(),
         );
@@ -374,7 +379,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("alternator_my-app"),
             &TableIdentifier::from("my-table"),
-            &ColumnName::from("v"),
+            &[ColumnName::from("v")],
             &pk_list,
             &CqlIdentifier::new(":pk").to_string(),
         );
@@ -402,7 +407,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("alternator_ks"),
             &TableIdentifier::from("tbl"),
-            &ColumnName::from("my-vector:v1"),
+            &[ColumnName::from("my-vector:v1")],
             &pk_list,
             &pk_list,
         );
@@ -422,7 +427,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("alternator_Ks"),
             &TableIdentifier::from("Tbl"),
-            &ColumnName::from("EmbeddingCol"),
+            &[ColumnName::from("EmbeddingCol")],
             &pk_list,
             &pk_list,
         );
@@ -442,7 +447,7 @@ mod tests {
         let query = range_scan_query(
             &KeyspaceIdentifier::from("alternator_ks"),
             &TableIdentifier::from("tbl"),
-            &ColumnName::from("it's a \"test\""),
+            &[ColumnName::from("it's a \"test\"")],
             &pk_list,
             &pk_list,
         );

--- a/crates/vector-store/src/db_index_backend.rs
+++ b/crates/vector-store/src/db_index_backend.rs
@@ -6,24 +6,18 @@
 use crate::ColumnName;
 use crate::CqlLiteral;
 use crate::Dimensions;
-use crate::IndexMetadata;
 use crate::IndexName;
 use crate::KeyspaceIdentifier;
 use crate::KeyspaceName;
-use crate::NonemptyArc;
 use crate::TableIdentifier;
 use crate::TableName;
-use crate::Vector;
 use futures::TryStreamExt;
 use regex::Regex;
 use scylla::client::session::Session;
 use scylla::statement::prepared::PreparedStatement;
-use scylla::value::CqlValue;
 use scylla_cdc::CqlIdentifier;
-use scylla_cdc::consumer::CDCRow;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
-use std::sync::OnceLock;
 
 /// Alternator tables store all user attributes in a single map column `:attrs`.
 /// Because Alternator (DynamoDB-compatible) is schemaless, different items can
@@ -34,139 +28,17 @@ use std::sync::OnceLock;
 /// are text keys and attribute values are serialized blobs.
 const ALTERNATOR_ATTRS_COLUMN: &str = ":attrs";
 
-pub(crate) enum CdcValueStatus {
-    NewValue(CqlValue),
-    Deleted,
-    Skip,
-}
-
 pub(crate) struct IndexLocation {
     pub keyspace: KeyspaceName,
     pub table: TableName,
     pub index: IndexName,
 }
 
-pub(crate) enum DbIndexBackend {
-    Cql {
-        target_columns: NonemptyArc<ColumnName>,
-    },
-    Alternator {
-        target_columns: NonemptyArc<ColumnName>,
-    },
-}
-
-impl From<&IndexMetadata> for DbIndexBackend {
-    fn from(metadata: &IndexMetadata) -> Self {
-        let target_columns = metadata.target_columns.clone();
-        if metadata.keyspace_name.is_alternator() {
-            Self::Alternator { target_columns }
-        } else {
-            Self::Cql { target_columns }
-        }
-    }
-}
-
-impl DbIndexBackend {
-    pub fn target_column_names(&self) -> &NonemptyArc<ColumnName> {
-        match self {
-            Self::Cql { target_columns } => target_columns,
-            Self::Alternator { .. } => {
-                static ALTERNATOR_ATTRS_COLUMN_NAMES: OnceLock<NonemptyArc<ColumnName>> =
-                    OnceLock::new();
-                ALTERNATOR_ATTRS_COLUMN_NAMES.get_or_init(|| {
-                    NonemptyArc::new([ColumnName::from(ALTERNATOR_ATTRS_COLUMN)]).unwrap()
-                })
-            }
-        }
-    }
-
-    pub fn extract_vector(&self, value: CqlValue) -> anyhow::Result<Option<Vector>> {
-        Vector::try_from(value).map(Some)
-    }
-
-    pub fn extract_document(&self, value: CqlValue) -> anyhow::Result<Option<String>> {
-        match self {
-            Self::Cql { .. } => match value {
-                CqlValue::Text(s) => Ok(Some(s)),
-                CqlValue::Ascii(s) => Ok(Some(s)),
-                other => anyhow::bail!("expected text column, got {:?}", other),
-            },
-            Self::Alternator { .. } => {
-                anyhow::bail!("FTS not supported for Alternator")
-            }
-        }
-    }
-
-    pub fn take_cdc_value(&self, row: &mut CDCRow<'_>) -> anyhow::Result<CdcValueStatus> {
-        match self {
-            Self::Cql { target_columns } => {
-                let column = target_columns.first().as_ref();
-                if row.is_value_deleted(column) {
-                    return Ok(CdcValueStatus::Deleted);
-                }
-                Ok(match row.take_value(column) {
-                    Some(value) => CdcValueStatus::NewValue(value),
-                    None => CdcValueStatus::Skip,
-                })
-            }
-            Self::Alternator { target_columns } => {
-                // Check take_value before is_value_deleted.
-                // PutItem in Alternator deletes and re-adds :attrs in a single CDC event,
-                // so is_value_deleted can be true even when a new value is present.
-                // We must check for a value first to avoid misreporting it as deleted.
-                let column = ALTERNATOR_ATTRS_COLUMN;
-                let target = target_columns.first().as_ref();
-                let value = match row.take_value(column) {
-                    Some(attrs) => take_alternator_attr(attrs, target)?,
-                    None => None,
-                };
-
-                match value {
-                    Some(value) => Ok(CdcValueStatus::NewValue(value)),
-                    None if row.is_value_deleted(column) => Ok(CdcValueStatus::Deleted),
-                    None => {
-                        let target_deleted = row
-                            .take_deleted_elements(column)
-                            .iter()
-                            .any(|el| alternator_attr_key_matches_target(el, target));
-                        if target_deleted {
-                            Ok(CdcValueStatus::Deleted)
-                        } else {
-                            Ok(CdcValueStatus::Skip)
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn alternator_attr_key_matches_target(key: &CqlValue, target: &str) -> bool {
-    key.as_text().map(String::as_str) == Some(target)
-}
-
-fn take_alternator_attr(attrs: CqlValue, target: &str) -> anyhow::Result<Option<CqlValue>> {
-    let CqlValue::Map(entries) = attrs else {
-        anyhow::bail!("expected Map for :attrs column, got {attrs:?}");
-    };
-
-    Ok(entries
-        .into_iter()
-        .find_map(|(key, value)| alternator_attr_key_matches_target(&key, target).then_some(value)))
-}
-
-/// Builds the CQL range scan query appropriate for the given keyspace.
-///
-/// For CQL-native tables, selects the vector column directly.
-/// For Alternator tables, selects from the `:attrs` map column.
-pub(crate) fn range_scan_query<'a>(
+fn build_columns_list<'a>(
     keyspace: &KeyspaceIdentifier,
-    table: &TableIdentifier,
     columns: impl IntoIterator<Item = &'a ColumnName>,
-    primary_key_list: &str,
-    partition_key_list: &str,
 ) -> String {
-    let columns = if keyspace.is_alternator() {
+    if keyspace.is_alternator() {
         let attributes = CqlIdentifier::new(ALTERNATOR_ATTRS_COLUMN);
         itertools::join(
             columns.into_iter().map(CqlLiteral::new).flat_map(|column| {
@@ -186,7 +58,21 @@ pub(crate) fn range_scan_query<'a>(
                 .flat_map(|column| [format!("{column}"), format!("writetime({column})")]),
             ", ",
         )
-    };
+    }
+}
+
+/// Builds the CQL range scan query appropriate for the given keyspace.
+///
+/// For CQL-native tables, selects the vector column directly.
+/// For Alternator tables, selects from the `:attrs` map column.
+pub(crate) fn range_scan_query<'a>(
+    keyspace: &KeyspaceIdentifier,
+    table: &TableIdentifier,
+    columns: impl IntoIterator<Item = &'a ColumnName>,
+    primary_key_list: &str,
+    partition_key_list: &str,
+) -> String {
+    let columns = build_columns_list(keyspace, columns);
     format!(
         "
         SELECT {primary_key_list}, {columns}
@@ -196,6 +82,34 @@ pub(crate) fn range_scan_query<'a>(
             AND token({partition_key_list}) <= ?
         BYPASS CACHE
         "
+    )
+}
+
+/// Builds the CQL request query appropriate for the given keyspace.
+///
+/// For CQL-native tables, selects the vector column directly.
+/// For Alternator tables, selects from the `:attrs` map column.
+pub(crate) fn request_query<'a, 'b>(
+    keyspace: &KeyspaceIdentifier,
+    table: &TableIdentifier,
+    columns: impl IntoIterator<Item = &'a ColumnName>,
+    primary_key_columns: impl IntoIterator<Item = &'b ColumnName>,
+) -> String {
+    let columns = build_columns_list(keyspace, columns);
+    let restrictions = itertools::join(
+        primary_key_columns
+            .into_iter()
+            .map(AsRef::as_ref)
+            .map(CqlIdentifier::new)
+            .map(|column| format!("{column} = ?")),
+        " AND ",
+    );
+    format!(
+        "
+            SELECT {columns}
+            FROM {keyspace}.{table}
+            WHERE {restrictions}
+            "
     )
 }
 
@@ -459,49 +373,5 @@ mod tests {
             query.contains(r#"writetime(":attrs"['it''s a "test"'])"#),
             "writetime must use the same escaped attribute access: {query}"
         );
-    }
-
-    #[test]
-    fn alternator_attr_text_key_matches_target() {
-        assert!(alternator_attr_key_matches_target(
-            &CqlValue::Text("vec".into()),
-            "vec"
-        ));
-    }
-
-    #[test]
-    fn alternator_attr_non_text_key_does_not_match_target() {
-        assert!(!alternator_attr_key_matches_target(
-            &CqlValue::Blob(b"vec".to_vec()),
-            "vec"
-        ));
-    }
-
-    #[test]
-    fn take_alternator_attr_returns_target_value() {
-        let attrs = CqlValue::Map(vec![
-            (CqlValue::Text("unrelated".into()), CqlValue::Blob(vec![1])),
-            (CqlValue::Text("vec".into()), CqlValue::Blob(vec![2])),
-        ]);
-
-        assert_eq!(
-            take_alternator_attr(attrs, "vec").unwrap(),
-            Some(CqlValue::Blob(vec![2]))
-        );
-    }
-
-    #[test]
-    fn take_alternator_attr_skips_unrelated_attrs() {
-        let attrs = CqlValue::Map(vec![(
-            CqlValue::Text("unrelated".into()),
-            CqlValue::Blob(vec![1]),
-        )]);
-
-        assert_eq!(take_alternator_attr(attrs, "vec").unwrap(), None);
-    }
-
-    #[test]
-    fn take_alternator_attr_rejects_non_map() {
-        assert!(take_alternator_attr(CqlValue::Blob(vec![1]), "vec").is_err());
     }
 }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -574,7 +574,7 @@ async fn post_index_ann(
         let index_key = IndexKey::new(&keyspace, &index_name);
         let (equality_cols, range_cols) = restriction_columns(&request.filter);
         let allow_filtering = request.filter.as_ref().is_some_and(|f| f.allow_filtering);
-        let (routed_key, index, primary_key_columns, table_columns) = match state
+        let (routed_key, index, primary_key_columns, filtering_columns, table_columns) = match state
             .indexes
             .read()
             .unwrap()
@@ -585,6 +585,7 @@ async fn post_index_ann(
                 index,
                 needs_filtering,
                 primary_key_columns,
+                filtering_columns,
                 table_columns,
             } => {
                 if matches!(needs_filtering, indexes::NeedsFiltering::Yes(_)) && !allow_filtering {
@@ -596,7 +597,13 @@ async fn post_index_ann(
                     debug!("post_index_ann: {msg}");
                     return (StatusCode::BAD_REQUEST, msg).into_response();
                 }
-                (routed_key, index, primary_key_columns, table_columns)
+                (
+                    routed_key,
+                    index,
+                    primary_key_columns,
+                    filtering_columns,
+                    table_columns,
+                )
             }
             indexes::BestIndexState::NoGlobalIndex => {
                 timer.observe_duration();
@@ -653,7 +660,7 @@ async fn post_index_ann(
         let search_result = if let Some(filter) = request.filter {
             let filter = match try_from_post_index_ann_filter(
                 filter,
-                primary_key_columns.as_slice(),
+                filtering_columns.as_slice(),
                 &table_columns,
             ) {
                 Ok(filter) => filter,
@@ -884,7 +891,7 @@ async fn post_index_bm25(
 
 fn try_from_post_index_ann_filter(
     json_filter: httpapi::PostIndexAnnFilter,
-    primary_key_columns: &[crate::ColumnName],
+    filtering_columns: &[crate::ColumnName],
     table_columns: &HashMap<crate::ColumnName, NativeType>,
 ) -> anyhow::Result<Filter> {
     let is_same_len = |columns: &[crate::ColumnName], values: &[Value]| -> anyhow::Result<()> {
@@ -898,8 +905,10 @@ fn try_from_post_index_ann_filter(
         Ok(())
     };
     let from_json = |column: &crate::ColumnName, value: Value| -> anyhow::Result<CqlValue> {
-        if !primary_key_columns.contains(column) {
-            bail!("Filtering on non primary key columns is not supported");
+        if !filtering_columns.contains(column) {
+            bail!(
+                "Column '{column}' in filter restriction is not part of the primary key or filtering columns, and cannot be used for filtering"
+            );
         };
         let Some(native_type) = table_columns.get(column) else {
             bail!(

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -10,6 +10,7 @@ use crate::IndexMetadata;
 use crate::IndexVersion;
 use crate::KeyspaceName;
 use crate::NonemptyArc;
+use crate::NonemptyIteratorExt;
 use crate::Progress;
 use crate::TableName;
 use crate::db_index::DbIndex;
@@ -103,7 +104,7 @@ pub(crate) type FtsIndexEntry = IndexEntry<FtsIndex>;
 pub(crate) struct VsIndexData {
     routing_group: RoutingGroupKey,
     partitioning: DbIndexPartitioning,
-    filtering_columns: Arc<[ColumnName]>,
+    filtering_columns: NonemptyArc<ColumnName>,
     table_columns: Arc<HashMap<ColumnName, NativeType>>,
     version: IndexVersion,
     options: crate::IndexOptionsVs,
@@ -154,12 +155,12 @@ impl VsIndexEntry {
             })?
             .clone();
         let primary_key_columns = db_index.get_primary_key_columns().await;
-        let filtering_columns = metadata
-            .filtering_columns
+        let filtering_columns = primary_key_columns
             .iter()
-            .chain(primary_key_columns.iter())
+            .chain(metadata.filtering_columns.iter())
             .cloned()
-            .collect();
+            .collect_nonempty_arc()
+            .expect("primary key columns are always non-empty");
         let table_columns = db_index.get_table_columns().await;
         let progress = db_index.full_scan_progress().await;
         Ok(Self {
@@ -265,6 +266,7 @@ pub(crate) enum BestIndexState {
         key: IndexKey,
         index: mpsc::Sender<VsIndex>,
         primary_key_columns: NonemptyArc<ColumnName>,
+        filtering_columns: NonemptyArc<ColumnName>,
         table_columns: Arc<HashMap<ColumnName, NativeType>>,
         needs_filtering: NeedsFiltering,
     },
@@ -393,6 +395,7 @@ impl Indexes {
                     key: routed_key.clone(),
                     index: routed_entry.index.clone(),
                     primary_key_columns: routed_entry.primary_key_columns.clone(),
+                    filtering_columns: routed_entry.data.filtering_columns.clone(),
                     table_columns: Arc::clone(&routed_entry.data.table_columns),
                     needs_filtering: needs_filtering.clone(),
                 }

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -9,7 +9,9 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlTimeuuid;
+use scylla::value::CqlValue;
 use std::collections::HashMap;
+use std::iter;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::AtomicBool;
@@ -68,19 +70,32 @@ fn make_scan_fn(rows: impl Iterator<Item = DbIndexedRow> + Send + Sync + 'static
 
 pub(crate) fn scan_fn_vectors<I>(items: I) -> ScanFn
 where
-    I: IntoIterator<Item = (PrimaryKey, Option<Vector>, Timestamp)>,
+    I: IntoIterator<
+        Item = (
+            PrimaryKey,
+            Option<Vector>,
+            Box<[Option<CqlValue>]>,
+            Timestamp,
+        ),
+    >,
     I::IntoIter: Send + Sync + 'static,
 {
     make_scan_fn(
         items
             .into_iter()
-            .map(|(primary_key, embedding, timestamp)| DbIndexedRow {
+            .map(|(primary_key, vector, filtering, timestamp)| DbIndexedRow {
                 primary_key,
                 operation: DbIndexedOperation::Upsert(
-                    NonemptyBox::new([Timestamped::new(
-                        timestamp,
-                        embedding.map(DbIndexedValue::Vector),
-                    )])
+                    NonemptyBox::new(
+                        iter::once(vector)
+                            .map(|vector| vector.map(DbIndexedValue::Vector))
+                            .chain(
+                                filtering
+                                    .into_iter()
+                                    .map(|filtering| filtering.map(DbIndexedValue::Filtering)),
+                            )
+                            .map(|value| Timestamped::new(timestamp, value)),
+                    )
                     .unwrap(),
                 ),
             }),

--- a/crates/vector-store/tests/integration/metrics.rs
+++ b/crates/vector-store/tests/integration/metrics.rs
@@ -35,6 +35,7 @@ async fn setup_single_vector_index() -> (
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
+            [].into(),
             Timestamp::from_millis(10),
         )])),
         None,

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -99,16 +99,19 @@ async fn simple_create_search_delete_index() {
             (
                 [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
                 Some(vec![1., 1., 1.].into()),
+                [].into(),
                 Timestamp::from_millis(10),
             ),
             (
                 [CqlValue::Int(2), CqlValue::Text("two".to_string())].into(),
                 Some(vec![2., -2., 2.].into()),
+                [].into(),
                 Timestamp::from_millis(20),
             ),
             (
                 [CqlValue::Int(3), CqlValue::Text("three".to_string())].into(),
                 Some(vec![3., 3., 3.].into()),
+                [].into(),
                 Timestamp::from_millis(30),
             ),
         ])),

--- a/crates/vector-store/tests/integration/quantization.rs
+++ b/crates/vector-store/tests/integration/quantization.rs
@@ -47,6 +47,7 @@ async fn quantization_is_effectively_applied() {
         let values = [(
             [CqlValue::Int(1)].into(),
             Some(add_vector.into()),
+            [].into(),
             Timestamp::from_millis(10),
         )];
         let values_len = values.len();
@@ -179,6 +180,7 @@ async fn search_with_quantization(quantization: Quantization, filter: Option<Pos
     let vectors = vec![(
         [CqlValue::Int(pk_value)].into(),
         Some(vector.clone().into()),
+        [].into(),
         Timestamp::from_millis(10),
     )];
 
@@ -298,6 +300,7 @@ async fn binary_quantization_with_non_divisible_by_8_dimensions() {
     let vectors = vec![(
         [CqlValue::Int(pk_value)].into(),
         Some(vector.clone().into()),
+        [].into(),
         Timestamp::from_millis(10),
     )];
 

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -50,6 +50,7 @@ fn single_row_scan(pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'stat
     db_basic::scan_fn_vectors([(
         pks.into_iter().collect::<Vec<_>>().into(),
         Some(vec![1.0, 2.0, 3.0].into()),
+        [].into(),
         Timestamp::from_millis(10),
     )])
 }
@@ -532,16 +533,13 @@ async fn ann_routes_to_local_index_with_filter_columns_covering_restriction() {
         allow_filtering: true,
     };
 
-    // TODO: update this assertion to expect StatusCode::OK once filtering on
-    // non-primary-key columns is supported end-to-end. Currently the request
-    // is routed correctly but fails at the filter validation layer.
     let response = assert_ann_served_by(
         &client,
         &covering,
         post_ann_with_filter(&client, &non_covering, filter),
     )
     .await;
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]
@@ -607,16 +605,13 @@ async fn ann_routes_to_global_index_with_filter_columns_covering_restriction() {
         allow_filtering: true,
     };
 
-    // TODO: update this assertion to expect StatusCode::OK once filtering on
-    // non-primary-key columns is supported end-to-end. Currently the request
-    // is routed correctly but fails at the filter validation layer.
     let response = assert_ann_served_by(
         &client,
         &covering,
         post_ann_with_filter(&client, &non_covering, filter),
     )
     .await;
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -103,14 +103,20 @@ pub(crate) async fn setup_store_with_quantization(
 
     let (db_actor, db) = db_basic::new(node_state.clone());
 
+    let primary_keys = primary_keys.into_iter().collect_nonempty_arc().unwrap();
     let columns: Arc<HashMap<_, _>> = Arc::new(columns.into_iter().collect());
+    let filtering_columns = columns
+        .keys()
+        .filter(|c| !primary_keys.contains(c))
+        .cloned()
+        .collect();
     let index = IndexMetadata {
         keyspace_name: "vector".into(),
         table_name: "items".into(),
         index_name: "ann".into(),
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning,
-        filtering_columns: columns.keys().cloned().collect(),
+        filtering_columns,
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: dimension,
@@ -126,7 +132,7 @@ pub(crate) async fn setup_store_with_quantization(
         index.keyspace_name.clone(),
         index.table_name.clone(),
         Table {
-            primary_keys: primary_keys.into_iter().collect_nonempty_arc().unwrap(),
+            primary_keys,
             partition_key_count,
             columns,
             dimensions: [(
@@ -230,16 +236,19 @@ async fn simple_create_search_delete_index() {
             (
                 [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
                 Some(vec![1., 1., 1.].into()),
+                [].into(),
                 Timestamp::from_millis(10),
             ),
             (
                 [CqlValue::Int(2), CqlValue::Text("two".to_string())].into(),
                 Some(vec![2., -2., 2.].into()),
+                [].into(),
                 Timestamp::from_millis(20),
             ),
             (
                 [CqlValue::Int(3), CqlValue::Text("three".to_string())].into(),
                 Some(vec![3., 3., 3.].into()),
+                [].into(),
                 Timestamp::from_millis(30),
             ),
         ])),
@@ -442,6 +451,7 @@ async fn ann_returns_bad_request_when_provided_vector_size_is_not_eq_index_dimen
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
+            [].into(),
             Timestamp::from_millis(10),
         )])),
         None,
@@ -480,6 +490,7 @@ async fn ann_returns_bad_request_when_filtering_required_but_not_allowed() {
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Int(1)].into(),
             Some(vec![1., 1., 1.].into()),
+            [].into(),
             Timestamp::from_millis(10),
         )])),
         None,
@@ -571,6 +582,7 @@ async fn ann_failed_when_wrong_number_of_primary_keys() {
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
+            [].into(),
             Timestamp::from_millis(10),
         )])),
         None,
@@ -610,7 +622,7 @@ async fn ann_failed_when_wrong_number_of_primary_keys() {
 async fn ann_filter_partition_key_int_eq() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column_http: httpapi::ColumnName = pk_column.into();
@@ -667,7 +679,7 @@ async fn ann_filter_partition_key_int_eq() {
 async fn ann_filter_clustering_key_int_eq() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column_http: httpapi::ColumnName = pk_column.into();
@@ -724,7 +736,7 @@ async fn ann_filter_clustering_key_int_eq() {
 async fn ann_filter_partition_key_int_in() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column_http: httpapi::ColumnName = pk_column.into();
@@ -785,7 +797,7 @@ async fn ann_filter_partition_key_int_in() {
 async fn ann_filter_clustering_key_int_in() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column_http: httpapi::ColumnName = pk_column.into();
@@ -846,7 +858,7 @@ async fn ann_filter_clustering_key_int_in() {
 async fn ann_filter_primary_key_int_eq_tuple() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column_http: httpapi::ColumnName = pk_column.into();
@@ -873,7 +885,7 @@ async fn ann_filter_primary_key_int_eq_tuple() {
 async fn ann_filter_primary_key_int_in_tuple() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column_http: httpapi::ColumnName = pk_column.into();
@@ -904,12 +916,14 @@ async fn setup_int_int_store() -> (
     HttpClient,
     ColumnName,
     ColumnName,
+    ColumnName,
     DbBasic,
     impl Sized,
     Sender<NodeState>,
 ) {
     let pk_column: ColumnName = "pk".into();
     let ck_column: ColumnName = "ck".into();
+    let f_column: ColumnName = "f".into();
     let (index, client, db, server, node_state) = setup_store_and_wait_for_index(
         DbIndexPartitioning::Global,
         [pk_column.clone(), ck_column.clone()],
@@ -917,12 +931,14 @@ async fn setup_int_int_store() -> (
         [
             (pk_column.clone(), NativeType::Int),
             (ck_column.clone(), NativeType::Int),
+            (f_column.clone(), NativeType::Int),
         ],
         Some(db_basic::scan_fn_vectors(
             (0..INT_INT_VECTOR_COUNT as i32).map(|i| {
                 (
                     [CqlValue::Int(i / 10), CqlValue::Int(i % 10)].into(),
                     Some(vec![i as f32, i as f32, i as f32].into()),
+                    [Some(CqlValue::Int(i))].into(),
                     Timestamp::from_millis(10),
                 )
             }),
@@ -932,7 +948,9 @@ async fn setup_int_int_store() -> (
     )
     .await;
 
-    (index, client, pk_column, ck_column, db, server, node_state)
+    (
+        index, client, pk_column, ck_column, f_column, db, server, node_state,
+    )
 }
 
 /// Runs an ANN query with the given restrictions and returns a HashSet of (pk, ck) values.
@@ -998,7 +1016,7 @@ fn assert_pk_ck_combinations(
 async fn ann_filter_clustering_key_int_lt() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1038,7 +1056,7 @@ async fn ann_filter_clustering_key_int_lt() {
 async fn ann_filter_clustering_key_int_lte() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1078,7 +1096,7 @@ async fn ann_filter_clustering_key_int_lte() {
 async fn ann_filter_clustering_key_int_gt() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1118,7 +1136,7 @@ async fn ann_filter_clustering_key_int_gt() {
 async fn ann_filter_clustering_key_int_gte() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1158,7 +1176,7 @@ async fn ann_filter_clustering_key_int_gte() {
 async fn ann_filter_clustering_key_int_range() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1204,7 +1222,7 @@ async fn ann_filter_clustering_key_int_range() {
 async fn ann_filter_primary_key_int_lt_tuple() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1252,7 +1270,7 @@ async fn ann_filter_primary_key_int_lt_tuple() {
 async fn ann_filter_primary_key_int_lte_tuple() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1301,7 +1319,7 @@ async fn ann_filter_primary_key_int_lte_tuple() {
 async fn ann_filter_primary_key_int_gt_tuple() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1348,7 +1366,7 @@ async fn ann_filter_primary_key_int_gt_tuple() {
 async fn ann_filter_primary_key_int_gte_tuple() {
     crate::enable_tracing();
 
-    let (index, client, pk_column, ck_column, _db, _server, _node_state) =
+    let (index, client, pk_column, ck_column, _, _db, _server, _node_state) =
         setup_int_int_store().await;
 
     let pk_column = pk_column.into();
@@ -1413,6 +1431,7 @@ async fn ann_filter_partition_key_text_gt() {
                 (
                     [CqlValue::Text(pk.to_string()), CqlValue::Int(i as i32)].into(),
                     Some(vec![i as f32, i as f32, i as f32].into()),
+                    [].into(),
                     Timestamp::from_millis(10),
                 )
             }),
@@ -1477,6 +1496,34 @@ async fn ann_filter_partition_key_text_gt() {
 
 #[tokio::test]
 #[ntest::timeout(10_000)]
+async fn ann_filter_filtering_columns_int_eq() {
+    crate::enable_tracing();
+
+    let (index, client, pk_column, ck_column, f_column, _db, _server, _node_state) =
+        setup_int_int_store().await;
+
+    let pk_column_http: httpapi::ColumnName = pk_column.into();
+    let ck_column_http: httpapi::ColumnName = ck_column.into();
+    let f_column_http: httpapi::ColumnName = f_column.into();
+
+    // Search for nearest neighbors with a filter on primary key ("pk", "ck") = (1, 5)
+    let pk_ck_values = run_ann_filter_int_int(
+        &client,
+        &index,
+        &pk_column_http,
+        &ck_column_http,
+        vec![PostIndexAnnRestriction::Eq {
+            lhs: f_column_http.clone(),
+            rhs: 1.into(),
+        }],
+        1,
+    )
+    .await;
+    assert_pk_ck_combinations(&pk_ck_values, [(0, 1)]);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
 async fn http_server_is_responsive_when_index_add_hangs() {
     crate::enable_tracing();
     let config = Config {
@@ -1499,6 +1546,7 @@ async fn http_server_is_responsive_when_index_add_hangs() {
         Some(db_basic::scan_fn_vectors([(
             [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
             Some(vec![1., 1., 1.].into()),
+            [].into(),
             Timestamp::from_millis(10),
         )])),
         None,
@@ -1528,9 +1576,15 @@ async fn null_vector_is_not_indexed() {
             (
                 [CqlValue::Int(1)].into(),
                 Some(vec![1., 1., 1.].into()),
+                [].into(),
                 Timestamp::from_millis(10),
             ),
-            ([CqlValue::Int(2)].into(), None, Timestamp::from_millis(20)),
+            (
+                [CqlValue::Int(2)].into(),
+                None,
+                [].into(),
+                Timestamp::from_millis(20),
+            ),
         ])),
         None,
     )
@@ -1615,16 +1669,19 @@ async fn similarity_scores_are_decreasing_and_correctly_converted() {
             (
                 [CqlValue::Int(1)].into(),
                 Some(vec![0.0_f32].into()),
+                [].into(),
                 Timestamp::from_millis(10),
             ),
             (
                 [CqlValue::Int(2)].into(),
                 Some(vec![1.0_f32].into()),
+                [].into(),
                 Timestamp::from_millis(20),
             ),
             (
                 [CqlValue::Int(3)].into(),
                 Some(vec![3.0_f32].into()),
+                [].into(),
                 Timestamp::from_millis(30),
             ),
         ])),


### PR DESCRIPTION
This PR refactors db_index fullscan to retrieve filtering columns. It also refactors db_cdc to use CDC table only for operation type and primary_key - then ask directly database for target values and filtering column values. Tests on 500k showed that this process is faster or not-slower than the previous one. It helps to synchronize retrieval of filtering columns with future multi-column targets.

This PR adds single integration test and two e2e tests in validator.

This PR refactors validator's serde::test_decimal_key.

Fixes: VECTOR-708