### PR TITLE
vector-store: use `CDCCheckpointSaver` to expose last processed timestamp metric

### DIFF
--- a/crates/vector-store/src/db_cdc/actor.rs
+++ b/crates/vector-store/src/db_cdc/actor.rs
@@ -4,34 +4,22 @@
  */
 
 use crate::AsyncInProgress;
-use crate::ColumnName;
 use crate::Config;
 use crate::DbIndexedRow;
-use crate::DbIndexedValue;
-use crate::IndexKind;
 use crate::IndexMetadata;
 use crate::IndexName;
 use crate::KeyspaceName;
 use crate::Metrics;
-use crate::NonemptyArc;
-use crate::NonemptyIteratorExt;
-use crate::db_index_backend::CdcValueStatus;
-use crate::db_index_backend::DbIndexBackend;
+use crate::db_cdc::READER_FINE;
+use crate::db_cdc::READER_WIDE;
+use crate::db_cdc::consumer::CdcConsumerFactory;
 use crate::internals::Internals;
 use crate::internals::InternalsExt;
 use crate::perf;
 use ::time::OffsetDateTime;
 use anyhow::Context;
-use anyhow::anyhow;
-use anyhow::bail;
-use async_trait::async_trait;
 use futures::FutureExt;
 use scylla::client::session::Session;
-use scylla::value::CqlValue;
-use scylla_cdc::consumer::CDCRow;
-use scylla_cdc::consumer::Consumer;
-use scylla_cdc::consumer::ConsumerFactory;
-use scylla_cdc::consumer::OperationType;
 use scylla_cdc::log_reader::CDCLogReaderBuilder;
 use std::future;
 use std::sync::Arc;
@@ -98,9 +86,6 @@ impl CdcReaderParams {
 }
 
 pub(crate) enum DbCdc {}
-
-pub(crate) const READER_WIDE: &str = "wide";
-pub(crate) const READER_FINE: &str = "fine";
 
 /// Preset configurations for CDC reader actors.
 pub(crate) enum CdcReaderConfig {
@@ -514,143 +499,6 @@ fn spawn_handler_task(
         }
         .instrument(error_span!("cdc_handler", "{}", span_name)),
     )
-}
-
-fn extract_indexed_value(
-    backend: &DbIndexBackend,
-    value: CqlValue,
-    kind: &IndexKind,
-) -> anyhow::Result<Option<DbIndexedValue>> {
-    match kind {
-        IndexKind::Vs(_) => backend
-            .extract_vector(value)
-            .map(|opt| opt.map(DbIndexedValue::Vector)),
-        IndexKind::Fts(_) => backend
-            .extract_document(value)
-            .map(|opt| opt.map(DbIndexedValue::Document)),
-    }
-}
-
-struct CdcConsumerData {
-    primary_key_columns: NonemptyArc<ColumnName>,
-    backend: DbIndexBackend,
-    kind: IndexKind,
-    tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
-}
-
-struct CdcConsumer(Arc<CdcConsumerData>);
-
-#[async_trait]
-impl Consumer for CdcConsumer {
-    async fn consume_cdc(&mut self, mut row: CDCRow<'_>) -> anyhow::Result<()> {
-        if self.0.tx.is_closed() {
-            // a consumer should be closed now, some concurrent tasks could stay in a pipeline
-            return Ok(());
-        }
-
-        let source = &self.0.backend;
-        // TODO: fix multi-target indexes
-        let column = source.target_column_names().first().as_ref();
-        if !row.column_deletable(column) {
-            bail!("CDC error: column {column} should be deletable");
-        }
-
-        let value = match row.operation {
-            OperationType::PartitionDelete | OperationType::RowDelete => None,
-
-            OperationType::RowUpdate | OperationType::RowInsert | OperationType::PostImage => {
-                match source.take_cdc_value(&mut row)? {
-                    CdcValueStatus::Deleted => None,
-                    CdcValueStatus::Skip => return Ok(()),
-                    CdcValueStatus::NewValue(value) => {
-                        extract_indexed_value(source, value, &self.0.kind)?
-                    }
-                }
-            }
-
-            OperationType::PreImage
-            | OperationType::RowRangeDelInclLeft
-            | OperationType::RowRangeDelExclLeft
-            | OperationType::RowRangeDelInclRight
-            | OperationType::RowRangeDelExclRight => {
-                // These operations are unspported by our CDC reader, skip them.
-                return Ok(());
-            }
-        };
-
-        let Some(primary_key) = self
-            .0
-            .primary_key_columns
-            .iter()
-            .map(|column| row.take_value(column.as_ref()))
-            .collect()
-        else {
-            // If any primary key column is missing skip this row.
-            return Ok(());
-        };
-
-        let timestamp = row
-            .time
-            .try_into()
-            .map_err(|err| anyhow!("CDC error: converting row.time: {err}"))?;
-
-        _ = self
-            .0
-            .tx
-            .send((
-                DbIndexedRow {
-                    primary_key,
-                    value,
-                    timestamp,
-                },
-                AsyncInProgress::None,
-            ))
-            .await;
-        Ok(())
-    }
-}
-
-struct CdcConsumerFactory(Arc<CdcConsumerData>);
-
-#[async_trait]
-impl ConsumerFactory for CdcConsumerFactory {
-    async fn new_consumer(&self) -> Box<dyn Consumer> {
-        Box::new(CdcConsumer(Arc::clone(&self.0)))
-    }
-}
-
-impl CdcConsumerFactory {
-    fn new(
-        session: Arc<Session>,
-        metadata: &IndexMetadata,
-        tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
-    ) -> anyhow::Result<Self> {
-        let cluster_state = session.get_cluster_state();
-        let table = cluster_state
-            .get_keyspace(metadata.keyspace_name.as_ref())
-            .ok_or_else(|| anyhow!("keyspace {} does not exist", metadata.keyspace_name))?
-            .tables
-            .get(metadata.table_name.as_ref())
-            .ok_or_else(|| anyhow!("table {} does not exist", metadata.table_name))?;
-
-        let primary_key_columns = table
-            .partition_key
-            .iter()
-            .chain(table.clustering_key.iter())
-            .cloned()
-            .map(ColumnName::from)
-            .collect_nonempty_arc()
-            .ok_or_else(|| anyhow!("primary key must have at least one column"))?;
-
-        let backend = DbIndexBackend::from(metadata);
-
-        Ok(Self(Arc::new(CdcConsumerData {
-            primary_key_columns,
-            backend,
-            kind: metadata.kind.clone(),
-            tx,
-        })))
-    }
 }
 
 #[cfg(test)]

--- a/crates/vector-store/src/db_cdc/actor.rs
+++ b/crates/vector-store/src/db_cdc/actor.rs
@@ -12,6 +12,7 @@ use crate::KeyspaceName;
 use crate::Metrics;
 use crate::db_cdc::READER_FINE;
 use crate::db_cdc::READER_WIDE;
+use crate::db_cdc::checkpoint_saver::MetricsCheckpointSaver;
 use crate::db_cdc::consumer::CdcConsumerFactory;
 use crate::internals::Internals;
 use crate::internals::InternalsExt;
@@ -288,6 +289,7 @@ impl CdcReaderState {
             Arc::clone(session),
             metadata.clone(),
             tx_embeddings.clone(),
+            Arc::clone(&self.metrics),
             self.name,
         )
         .await
@@ -431,6 +433,7 @@ async fn create_cdc_reader(
     session: Arc<Session>,
     metadata: IndexMetadata,
     tx_embeddings: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+    metrics: Arc<Metrics>,
     reader_name: &str,
 ) -> anyhow::Result<(
     scylla_cdc::log_reader::CDCLogReader,
@@ -445,6 +448,13 @@ async fn create_cdc_reader(
         OffsetDateTime::UNIX_EPOCH + cdc_start
     );
 
+    let checkpoint_saver = Arc::new(MetricsCheckpointSaver::new(
+        metrics,
+        metadata.keyspace_name.as_ref().to_string(),
+        metadata.index_name.as_ref().to_string(),
+        reader_name.to_string(),
+    ));
+
     CDCLogReaderBuilder::new()
         .session(session)
         .keyspace(metadata.keyspace_name.as_ref())
@@ -453,6 +463,8 @@ async fn create_cdc_reader(
         .start_timestamp(chrono::Duration::from_std(cdc_start)?)
         .safety_interval(params.safety_interval)
         .sleep_interval(params.sleep_interval)
+        .should_save_progress(true)
+        .checkpoint_saver(checkpoint_saver)
         .build()
         .await
         .context(format!("Failed to build {reader_name} CDC log reader"))

--- a/crates/vector-store/src/db_cdc/checkpoint_saver.rs
+++ b/crates/vector-store/src/db_cdc/checkpoint_saver.rs
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::Metrics;
+use async_trait::async_trait;
+use scylla_cdc::cdc_types::GenerationTimestamp;
+use scylla_cdc::cdc_types::StreamID;
+use scylla_cdc::checkpoints::CDCCheckpointSaver;
+use scylla_cdc::checkpoints::Checkpoint;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// Updates the `cdc_last_processed_timestamp_seconds` gauge instead of persisting to storage.
+/// Reports the minimum timestamp across all streams.
+pub(super) struct MetricsCheckpointSaver {
+    metrics: Arc<Metrics>,
+    keyspace: String,
+    index_name: String,
+    reader_name: String,
+    state: Mutex<StreamProgress>,
+}
+
+/// Tracks progress across all streams to compute the reader-wide minimum.
+#[derive(Default)]
+struct StreamProgress {
+    positions: HashMap<StreamID, Duration>,
+    counts: BTreeMap<Duration, usize>,
+}
+
+impl StreamProgress {
+    /// Records `timestamp` for `stream_id` and returns the new reader-wide minimum.
+    ///
+    /// `counts` maps each timestamp to how many streams are currently at it.
+    /// Because `BTreeMap` iterates in sorted order, `counts.keys().next()` is
+    /// the minimum timestamp across all streams.
+    fn record(&mut self, stream_id: StreamID, timestamp: Duration) -> Option<Duration> {
+        if let Some(previous) = self.positions.insert(stream_id, timestamp)
+            && let Some(count) = self.counts.get_mut(&previous)
+        {
+            *count -= 1;
+            if *count == 0 {
+                self.counts.remove(&previous);
+            }
+        }
+        *self.counts.entry(timestamp).or_insert(0) += 1;
+        self.counts.keys().next().copied()
+    }
+
+    fn clear(&mut self) {
+        self.positions.clear();
+        self.counts.clear();
+    }
+}
+
+impl MetricsCheckpointSaver {
+    pub(super) fn new(
+        metrics: Arc<Metrics>,
+        keyspace: String,
+        index_name: String,
+        reader_name: String,
+    ) -> Self {
+        Self {
+            metrics,
+            keyspace,
+            index_name,
+            reader_name,
+            state: Mutex::new(StreamProgress::default()),
+        }
+    }
+
+    fn record_stream_progress(&self, stream_id: StreamID, timestamp: Duration) {
+        let min_progress = self.state.lock().unwrap().record(stream_id, timestamp);
+        if let Some(progress) = min_progress {
+            self.metrics
+                .cdc_last_processed_timestamp_seconds
+                .with_label_values(&[&self.keyspace, &self.index_name, &self.reader_name])
+                .set(progress.as_secs_f64());
+        }
+    }
+
+    fn reset(&self) {
+        self.state.lock().unwrap().clear();
+    }
+}
+
+#[async_trait]
+impl CDCCheckpointSaver for MetricsCheckpointSaver {
+    async fn save_checkpoint(&self, checkpoint: &Checkpoint) -> anyhow::Result<()> {
+        self.record_stream_progress(checkpoint.stream_id.clone(), checkpoint.timestamp);
+        Ok(())
+    }
+
+    async fn save_new_generation(&self, _generation: &GenerationTimestamp) -> anyhow::Result<()> {
+        self.reset();
+        Ok(())
+    }
+
+    async fn load_last_generation(&self) -> anyhow::Result<Option<GenerationTimestamp>> {
+        Ok(None)
+    }
+
+    async fn load_last_checkpoint(
+        &self,
+        _stream_id: &StreamID,
+    ) -> anyhow::Result<Option<chrono::Duration>> {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db_cdc::READER_FINE;
+    use crate::db_cdc::READER_WIDE;
+    use prometheus::Encoder;
+    use prometheus::TextEncoder;
+
+    fn metric_families_text(metrics: &Metrics) -> String {
+        let mut buf = Vec::new();
+        TextEncoder::new()
+            .encode(&metrics.registry.gather(), &mut buf)
+            .unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn stream_id(id: u8) -> StreamID {
+        StreamID::new(vec![id])
+    }
+
+    #[test]
+    fn checkpoint_saver_reports_minimum_across_tracked_streams() {
+        let metrics = Arc::new(Metrics::new());
+        let saver = MetricsCheckpointSaver::new(
+            Arc::clone(&metrics),
+            "ks".to_string(),
+            "idx".to_string(),
+            READER_WIDE.to_string(),
+        );
+
+        saver.record_stream_progress(stream_id(1), Duration::from_secs(1_700_000_100));
+        saver.record_stream_progress(stream_id(2), Duration::from_secs(1_700_000_050));
+
+        // Progress is the minimum across all tracked streams, which is timestamp of stream 2.
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains(
+                r#"cdc_last_processed_timestamp_seconds{index_name="idx",keyspace="ks",reader="wide"} 1700000050"#
+            ),
+            "expected the minimum of the two streams' progress, got:\n{output}"
+        );
+
+        // Stream 2 catches up. Minimum should now follow stream 1.
+        saver.record_stream_progress(stream_id(2), Duration::from_secs(1_700_000_200));
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains(
+                r#"cdc_last_processed_timestamp_seconds{index_name="idx",keyspace="ks",reader="wide"} 1700000100"#
+            ),
+            "expected the minimum to follow the now-slowest stream, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn checkpoint_saver_resets_tracking_on_new_generation() {
+        let metrics = Arc::new(Metrics::new());
+        let saver = MetricsCheckpointSaver::new(
+            Arc::clone(&metrics),
+            "ks".to_string(),
+            "idx".to_string(),
+            READER_FINE.to_string(),
+        );
+
+        saver.record_stream_progress(stream_id(1), Duration::from_secs(1_700_000_000));
+
+        saver.reset();
+
+        // After reset, the new generation's later timestamp must not be dragged down by the previous generation.
+        saver.record_stream_progress(stream_id(1), Duration::from_secs(1_700_000_500));
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains(
+                r#"cdc_last_processed_timestamp_seconds{index_name="idx",keyspace="ks",reader="fine"} 1700000500"#
+            ),
+            "expected stale generation's progress to have been cleared, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn checkpoint_saver_tracks_minimum_when_streams_share_a_timestamp() {
+        let metrics = Arc::new(Metrics::new());
+        let saver = MetricsCheckpointSaver::new(
+            Arc::clone(&metrics),
+            "ks".to_string(),
+            "idx".to_string(),
+            READER_WIDE.to_string(),
+        );
+
+        // Two streams at the same timestamp.
+        saver.record_stream_progress(stream_id(1), Duration::from_secs(1_700_000_000));
+        saver.record_stream_progress(stream_id(2), Duration::from_secs(1_700_000_000));
+
+        // Stream 1 advances. Stream 2 still holds the shared timestamp, so minimum must not move.
+        saver.record_stream_progress(stream_id(1), Duration::from_secs(1_700_000_100));
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains(
+                r#"cdc_last_processed_timestamp_seconds{index_name="idx",keyspace="ks",reader="wide"} 1700000000"#
+            ),
+            "expected the minimum to stay at the shared timestamp, got:\n{output}"
+        );
+
+        // Stream 2 also advances.
+        saver.record_stream_progress(stream_id(2), Duration::from_secs(1_700_000_200));
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains(
+                r#"cdc_last_processed_timestamp_seconds{index_name="idx",keyspace="ks",reader="wide"} 1700000100"#
+            ),
+            "expected the minimum to advance once the shared timestamp is vacated, got:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_saver_never_loads_progress() {
+        let saver = MetricsCheckpointSaver::new(
+            Arc::new(Metrics::new()),
+            "ks".to_string(),
+            "idx".to_string(),
+            READER_WIDE.to_string(),
+        );
+
+        assert!(saver.load_last_generation().await.unwrap().is_none());
+        assert!(
+            saver
+                .load_last_checkpoint(&stream_id(1))
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+use crate::AsyncInProgress;
+use crate::ColumnName;
+use crate::DbIndexedRow;
+use crate::DbIndexedValue;
+use crate::IndexKind;
+use crate::IndexMetadata;
+use crate::NonemptyArc;
+use crate::NonemptyIteratorExt;
+use crate::db_index_backend::CdcValueStatus;
+use crate::db_index_backend::DbIndexBackend;
+use anyhow::anyhow;
+use anyhow::bail;
+use async_trait::async_trait;
+use scylla::client::session::Session;
+use scylla::value::CqlValue;
+use scylla_cdc::consumer::CDCRow;
+use scylla_cdc::consumer::Consumer;
+use scylla_cdc::consumer::ConsumerFactory;
+use scylla_cdc::consumer::OperationType;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+fn extract_indexed_value(
+    backend: &DbIndexBackend,
+    value: CqlValue,
+    kind: &IndexKind,
+) -> anyhow::Result<Option<DbIndexedValue>> {
+    match kind {
+        IndexKind::Vs(_) => backend
+            .extract_vector(value)
+            .map(|opt| opt.map(DbIndexedValue::Vector)),
+        IndexKind::Fts(_) => backend
+            .extract_document(value)
+            .map(|opt| opt.map(DbIndexedValue::Document)),
+    }
+}
+
+struct CdcConsumerData {
+    primary_key_columns: NonemptyArc<ColumnName>,
+    backend: DbIndexBackend,
+    kind: IndexKind,
+    tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+}
+
+struct CdcConsumer(Arc<CdcConsumerData>);
+
+#[async_trait]
+impl Consumer for CdcConsumer {
+    async fn consume_cdc(&mut self, mut row: CDCRow<'_>) -> anyhow::Result<()> {
+        if self.0.tx.is_closed() {
+            // a consumer should be closed now, some concurrent tasks could stay in a pipeline
+            return Ok(());
+        }
+
+        let source = &self.0.backend;
+        // TODO: fix multi-target indexes
+        let column = source.target_column_names().first().as_ref();
+        if !row.column_deletable(column) {
+            bail!("CDC error: column {column} should be deletable");
+        }
+
+        let value = match row.operation {
+            OperationType::PartitionDelete | OperationType::RowDelete => None,
+
+            OperationType::RowUpdate | OperationType::RowInsert | OperationType::PostImage => {
+                match source.take_cdc_value(&mut row)? {
+                    CdcValueStatus::Deleted => None,
+                    CdcValueStatus::Skip => return Ok(()),
+                    CdcValueStatus::NewValue(value) => {
+                        extract_indexed_value(source, value, &self.0.kind)?
+                    }
+                }
+            }
+
+            OperationType::PreImage
+            | OperationType::RowRangeDelInclLeft
+            | OperationType::RowRangeDelExclLeft
+            | OperationType::RowRangeDelInclRight
+            | OperationType::RowRangeDelExclRight => {
+                // These operations are unsupported by our CDC reader, skip them.
+                return Ok(());
+            }
+        };
+
+        let Some(primary_key) = self
+            .0
+            .primary_key_columns
+            .iter()
+            .map(|column| row.take_value(column.as_ref()))
+            .collect()
+        else {
+            // If any primary key column is missing skip this row.
+            return Ok(());
+        };
+
+        let timestamp = row
+            .time
+            .try_into()
+            .map_err(|err| anyhow!("CDC error: converting row.time: {err}"))?;
+
+        _ = self
+            .0
+            .tx
+            .send((
+                DbIndexedRow {
+                    primary_key,
+                    value,
+                    timestamp,
+                },
+                AsyncInProgress::None,
+            ))
+            .await;
+        Ok(())
+    }
+}
+
+pub(super) struct CdcConsumerFactory(Arc<CdcConsumerData>);
+
+#[async_trait]
+impl ConsumerFactory for CdcConsumerFactory {
+    async fn new_consumer(&self) -> Box<dyn Consumer> {
+        Box::new(CdcConsumer(Arc::clone(&self.0)))
+    }
+}
+
+impl CdcConsumerFactory {
+    pub(super) fn new(
+        session: Arc<Session>,
+        metadata: &IndexMetadata,
+        tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+    ) -> anyhow::Result<Self> {
+        let cluster_state = session.get_cluster_state();
+        let table = cluster_state
+            .get_keyspace(metadata.keyspace_name.as_ref())
+            .ok_or_else(|| anyhow!("keyspace {} does not exist", metadata.keyspace_name))?
+            .tables
+            .get(metadata.table_name.as_ref())
+            .ok_or_else(|| anyhow!("table {} does not exist", metadata.table_name))?;
+
+        let primary_key_columns = table
+            .partition_key
+            .iter()
+            .chain(table.clustering_key.iter())
+            .cloned()
+            .map(ColumnName::from)
+            .collect_nonempty_arc()
+            .ok_or_else(|| anyhow!("primary key must have at least one column"))?;
+
+        let backend = DbIndexBackend::from(metadata);
+
+        Ok(Self(Arc::new(CdcConsumerData {
+            primary_key_columns,
+            backend,
+            kind: metadata.kind.clone(),
+            tx,
+        })))
+    }
+}

--- a/crates/vector-store/src/db_cdc/mod.rs
+++ b/crates/vector-store/src/db_cdc/mod.rs
@@ -4,6 +4,7 @@
  */
 
 pub(crate) mod actor;
+mod checkpoint_saver;
 mod consumer;
 
 pub(crate) const READER_WIDE: &str = "wide";

--- a/crates/vector-store/src/db_cdc/mod.rs
+++ b/crates/vector-store/src/db_cdc/mod.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+pub(crate) mod actor;
+mod consumer;
+
+pub(crate) const READER_WIDE: &str = "wide";
+pub(crate) const READER_FINE: &str = "fine";
+
+pub(crate) use actor::CdcReaderConfig;
+pub(crate) use actor::new;

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -24,6 +24,7 @@ pub struct Metrics {
     pub cdc_reader_up: GaugeVec,
     pub cdc_handler_errors_total: CounterVec,
     pub cdc_reader_restarts_total: CounterVec,
+    pub cdc_last_processed_timestamp_seconds: GaugeVec,
     dirty_indexes: Arc<DashSet<(String, String)>>,
 }
 
@@ -128,6 +129,16 @@ impl Metrics {
         )
         .unwrap();
 
+        let cdc_last_processed_timestamp_seconds = GaugeVec::new(
+            prometheus::Opts::new(
+                "cdc_last_processed_timestamp_seconds",
+                "Unix timestamp (seconds) up to which the CDC log has been fully consumed. \
+                 This is the reader's checkpoint position, not the wall-clock time of the last mutation.",
+            ),
+            &["keyspace", "index_name", "reader"],
+        )
+        .unwrap();
+
         registry.register(Box::new(latency.clone())).unwrap();
         registry.register(Box::new(size.clone())).unwrap();
         registry.register(Box::new(modified.clone())).unwrap();
@@ -139,6 +150,9 @@ impl Metrics {
         registry
             .register(Box::new(cdc_reader_restarts_total.clone()))
             .unwrap();
+        registry
+            .register(Box::new(cdc_last_processed_timestamp_seconds.clone()))
+            .unwrap();
 
         Self {
             registry,
@@ -149,6 +163,7 @@ impl Metrics {
             cdc_reader_up,
             cdc_handler_errors_total,
             cdc_reader_restarts_total,
+            cdc_last_processed_timestamp_seconds,
             dirty_indexes: Arc::new(DashSet::new()),
         }
     }
@@ -194,6 +209,9 @@ impl Metrics {
             .remove_label_values(&[keyspace, index_name, reader]);
         let _ = self
             .cdc_reader_restarts_total
+            .remove_label_values(&[keyspace, index_name, reader]);
+        let _ = self
+            .cdc_last_processed_timestamp_seconds
             .remove_label_values(&[keyspace, index_name, reader]);
     }
 }
@@ -416,6 +434,28 @@ mod tests {
     }
 
     #[test]
+    fn cdc_last_processed_timestamp_seconds_is_exported() {
+        let metrics = Metrics::new();
+
+        metrics
+            .cdc_last_processed_timestamp_seconds
+            .with_label_values(&["ks", "idx", READER_WIDE])
+            .set(1_700_000_000.0);
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains("# TYPE cdc_last_processed_timestamp_seconds gauge"),
+            "cdc_last_processed_timestamp_seconds gauge missing from export:\n{output}"
+        );
+        assert!(
+            output.contains(
+                r#"cdc_last_processed_timestamp_seconds{index_name="idx",keyspace="ks",reader="wide"} 1700000000"#
+            ),
+            "expected observed value in export:\n{output}"
+        );
+    }
+
+    #[test]
     fn remove_reader_labels_clears_only_the_given_readers_cdc_metrics() {
         let metrics = Metrics::new();
 
@@ -432,6 +472,10 @@ mod tests {
                 .cdc_reader_restarts_total
                 .with_label_values(&["ks", "idx", reader])
                 .inc();
+            metrics
+                .cdc_last_processed_timestamp_seconds
+                .with_label_values(&["ks", "idx", reader])
+                .set(1_700_000_000.0);
         }
 
         metrics.remove_reader_labels("ks", "idx", READER_WIDE);


### PR DESCRIPTION
Adds last Prometheus metric for CDC reader health (after https://github.com/scylladb/vector-store/pull/515), as a follow-up to a recent incident where a CDC reader silently stopped processing changes without any visible signal.

The added metric is `cdc_last_processed_timestamp_seconds` - a cause-agnostic lag indicator showing how far each CDC reader has consumed its log window (minimum across all tracked streams), reported through a `CDCCheckpointSaver` so it keeps advancing even when the table receives no writes. Resets on generation transitions.

Also splits `db_cdc` into its own module, since the actor loop and the CDC consumer were two fairly independent responsibilities sharing one large file, and this metric needed its own submodule for the `checkpoint-saver` wiring.

Fixes: VECTOR-722
