### PR TITLE
vector-store: minimal DiskANN integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,20 @@ name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -1759,6 +1773,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "diskann"
+version = "0.55.0"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "diskann-utils",
+ "diskann-vector",
+ "diskann-wide",
+ "futures-util",
+ "half",
+ "hashbrown 0.16.0",
+ "num-traits",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "diskann-utils"
+version = "0.55.0"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "diskann-vector",
+ "diskann-wide",
+ "half",
+ "rand 0.9.4",
+ "rand_distr",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "diskann-vector"
+version = "0.55.0"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+dependencies = [
+ "cfg-if",
+ "diskann-wide",
+ "half",
+]
+
+[[package]]
+name = "diskann-wide"
+version = "0.55.0"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+dependencies = [
+ "cfg-if",
+ "half",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2303,9 +2371,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
+ "rand 0.9.4",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -4187,6 +4258,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6001,6 +6082,7 @@ dependencies = [
  "criterion",
  "dashmap 6.1.0",
  "derive_more",
+ "diskann",
  "dotenvy",
  "futures",
  "hotpath",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ console-subscriber = "0.5.0"
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
+diskann = { git = "https://github.com/microsoft/DiskANN.git", rev = "541472a8d0bbfa4d458ec1b909e1d41a18adaabc" }
 dotenvy = "0.15.7"
 e2etest = "0.2.0"
 e2etest-dns = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ service supports also `.env` files.
 | `VECTOR_STORE_MONITOR_INDEXES_INTERVAL`    | How often to poll Scylla for schema changes (new/removed vector indexes). The value is in human readable format (ie. `100ms`)                                                        | `1s`                     |
 | `VECTOR_STORE_INDEX_STATUS_UPDATE_INTERVAL` | How often to sync index status (e.g., BOOTSTRAPPING->SERVING) into the engine's cached state. The value is in human readable format (ie. `100ms`) | `1s`            |
 | `VECTOR_STORE_USEARCH_SIMULATOR`           | Enable simulator for USearch. Provides human readable delays for simulated operations (`search:add-remove:reserve`).                                                                 |                          |
+| `VECTOR_STORE_USE_DISKANN`                 | Use DiskANN as the indexing engine instead of USearch.                                                | `false`                  |
+| `VECTOR_STORE_DISKANN_ALPHA`               | DiskANN parameter that controls the trade-off between index quality and build time. | (DiskANN default)                    |
 | `VECTOR_STORE_ALTER_INDEX_SIMULATOR`       | Enable simulator for missing `ALTER INDEX`. When enable indexes aren't deleted and their version is not checked.                                                                     | `false`                  |
 
 ## Development builds

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -40,6 +40,7 @@ const-hex.workspace = true
 console-subscriber = {workspace = true, optional = true}
 dashmap.workspace = true
 derive_more.workspace = true
+diskann.workspace = true
 dotenvy.workspace = true
 futures.workspace = true
 hotpath.workspace = true

--- a/crates/vector-store/src/config_manager.rs
+++ b/crates/vector-store/src/config_manager.rs
@@ -5,6 +5,7 @@
 
 use crate::Config;
 use crate::Credentials;
+use crate::DiskannAlpha;
 use crate::file_monitor::TlsFilesMonitor;
 use crate::tls;
 use crate::tls::TlsServerConfig;
@@ -435,6 +436,23 @@ pub async fn load_config(env: impl Fn(&str) -> anyhow::Result<String>) -> anyhow
         .map(|v| v.split(':').map(|s| s.parse::<humantime::Duration>()).map_ok(|v| v.into()).collect::<Result<Vec<_>, _>>().map_err(|err| {
             anyhow!("Unable to parse VECTOR_STORE_USEARCH_SIMULATOR env (search_us:add_us:delete_us:...): {err}")
         })).transpose()?;
+
+    if let Ok(diskann_alpha) = env("VECTOR_STORE_DISKANN_ALPHA") {
+        let alpha = diskann_alpha
+            .trim()
+            .parse::<f32>()
+            .map_err(|_| anyhow!("Unable to parse VECTOR_STORE_DISKANN_ALPHA env (float)"))?;
+        config.diskann_alpha = Some(
+            DiskannAlpha::new(alpha)
+                .map_err(|e| anyhow!("Invalid VECTOR_STORE_DISKANN_ALPHA: {e}"))?,
+        );
+    }
+
+    config.use_diskann = env("VECTOR_STORE_USE_DISKANN")
+        .unwrap_or("false".into())
+        .trim()
+        .parse()
+        .map_err(|_| anyhow!("Unable to parse VECTOR_STORE_USE_DISKANN env (bool)"))?;
 
     config.alter_index_simulator = env("VECTOR_STORE_ALTER_INDEX_SIMULATOR")
         .unwrap_or("false".into())
@@ -878,6 +896,22 @@ mod tests {
                 .to_string()
                 .contains("Unable to parse VECTOR_STORE_FULLTEXT_INDEXES")
         );
+    }
+
+    #[tokio::test]
+    async fn load_config_diskann() {
+        let env = mock_env(HashMap::new());
+        let config = load_config(env).await.unwrap();
+        assert!(config.diskann_alpha.is_none());
+        assert!(!config.use_diskann);
+
+        let env = mock_env(HashMap::from([
+            ("VECTOR_STORE_DISKANN_ALPHA", "1.2".into()),
+            ("VECTOR_STORE_USE_DISKANN", "true".into()),
+        ]));
+        let config = load_config(env).await.unwrap();
+        assert_eq!(config.diskann_alpha, Some(DiskannAlpha::new(1.2).unwrap()));
+        assert!(config.use_diskann);
     }
 
     #[test]

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -157,6 +157,25 @@ impl std::fmt::Display for TableIdentifier {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct DiskannAlpha(f32);
+
+impl DiskannAlpha {
+    pub fn new(value: f32) -> Result<Self, String> {
+        if !value.is_finite() {
+            Err(format!("DiskannAlpha must be finite, got {value}"))
+        } else if value <= 0.0 {
+            Err(format!("DiskannAlpha must be > 0, got {value}"))
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    pub fn get(self) -> f32 {
+        self.0
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Config {
     pub vector_store_addr: std::net::SocketAddr,
@@ -167,6 +186,8 @@ pub struct Config {
     pub opensearch_addr: Option<String>,
     pub credentials: Option<Credentials>,
     pub usearch_simulator: Option<Vec<Duration>>,
+    pub diskann_alpha: Option<DiskannAlpha>,
+    pub use_diskann: bool,
     pub alter_index_simulator: bool,
     pub fulltext_indexes: bool,
     pub cql_connection_timeout: Option<Duration>,
@@ -198,6 +219,8 @@ impl Default for Config {
             opensearch_addr: None,
             credentials: None,
             usearch_simulator: None,
+            diskann_alpha: None,
+            use_diskann: false,
             alter_index_simulator: false,
             fulltext_indexes: true,
             disable_colors: false,
@@ -765,6 +788,12 @@ pub fn new_index_factory_opensearch(
     Ok(Box::new(vs_index::opensearch::new_opensearch(
         &addr, config_rx,
     )?))
+}
+
+pub fn new_index_factory_diskann(
+    config_rx: watch::Receiver<Arc<Config>>,
+) -> anyhow::Result<Box<dyn VsIndexFactory + Send + Sync>> {
+    Ok(Box::new(vs_index::diskann::new_diskann(config_rx)?))
 }
 
 pub fn openapi() -> OpenApi {

--- a/crates/vector-store/src/main.rs
+++ b/crates/vector-store/src/main.rs
@@ -77,10 +77,14 @@ fn main() -> anyhow::Result<()> {
 
         let config_rx = config_receivers.config.clone();
         let opensearch_addr = config_rx.borrow().opensearch_addr.clone();
+        let use_diskann = config_rx.borrow().use_diskann;
 
         let index_factory = if let Some(addr) = opensearch_addr {
             tracing::info!("Using OpenSearch index factory at {addr}");
             vector_store::new_index_factory_opensearch(addr, config_rx.clone())?
+        } else if use_diskann {
+            tracing::info!("Using DiskANN index factory");
+            vector_store::new_index_factory_diskann(config_rx.clone())?
         } else {
             tracing::info!("Using Usearch index factory");
             vector_store::new_index_factory_usearch(config_rx.clone())?

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::Config;
+use crate::VsIndexFactory;
+use crate::memory::Memory;
+use crate::perf;
+use crate::table::Table;
+use crate::vs_index::actor::VsIndex;
+use crate::vs_index::factory::VsIndexConfiguration;
+use std::sync::Arc;
+use std::sync::RwLock;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tracing::Instrument;
+use tracing::debug;
+use tracing::debug_span;
+use tracing::warn;
+
+pub struct DiskannIndexFactory;
+
+impl VsIndexFactory for DiskannIndexFactory {
+    fn create_index(
+        &self,
+        index: VsIndexConfiguration,
+        _table: Arc<RwLock<Table>>,
+        _memory: mpsc::Sender<Memory>,
+    ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
+        new(index.key)
+    }
+
+    fn index_engine_version(&self) -> String {
+        format!("diskann-{}", diskann::version())
+    }
+}
+
+pub fn new_diskann(
+    _config_rx: watch::Receiver<Arc<Config>>,
+) -> anyhow::Result<DiskannIndexFactory> {
+    Ok(DiskannIndexFactory)
+}
+
+fn new(index_key: crate::IndexKey) -> anyhow::Result<mpsc::Sender<VsIndex>> {
+    let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
+
+    tokio::spawn(perf::hotpath_async(
+        {
+            async move {
+                debug!("starting");
+
+                while let Some(msg) = rx.recv().await {
+                    match msg {
+                        VsIndex::AddVector { .. }
+                        | VsIndex::RemoveVector { .. }
+                        | VsIndex::RemovePartition { .. } => {
+                            warn!("not implemented yet");
+                        }
+                        VsIndex::Ann { tx, .. } | VsIndex::FilteredAnn { tx, .. } => {
+                            _ = tx
+                                .send(Err(anyhow::anyhow!("DiskANN index is not implemented yet")));
+                        }
+                        VsIndex::Count { tx, .. } => {
+                            _ = tx
+                                .send(Err(anyhow::anyhow!("DiskANN index is not implemented yet")));
+                        }
+                    }
+                }
+
+                debug!("finished");
+            }
+        }
+        .instrument(debug_span!("diskann", "{index_key}")),
+    ));
+
+    Ok(tx)
+}

--- a/crates/vector-store/src/vs_index/mod.rs
+++ b/crates/vector-store/src/vs_index/mod.rs
@@ -11,5 +11,7 @@ pub(crate) use actor::VsIndex;
 pub(crate) use actor::VsIndexExt;
 pub(crate) use validator::Error;
 
+#[allow(dead_code)]
+pub(crate) mod diskann;
 pub(crate) mod opensearch;
 pub(crate) mod usearch;

--- a/crates/vector-store/src/vs_index/mod.rs
+++ b/crates/vector-store/src/vs_index/mod.rs
@@ -11,7 +11,6 @@ pub(crate) use actor::VsIndex;
 pub(crate) use actor::VsIndexExt;
 pub(crate) use validator::Error;
 
-#[allow(dead_code)]
 pub(crate) mod diskann;
 pub(crate) mod opensearch;
 pub(crate) mod usearch;

--- a/crates/vector-store/tests/integration/info.rs
+++ b/crates/vector-store/tests/integration/info.rs
@@ -55,3 +55,20 @@ async fn get_application_info_opensearch() {
     assert_eq!(info.service, env!("CARGO_PKG_NAME"));
     assert_eq!(info.engine, "opensearch");
 }
+
+#[tokio::test]
+async fn get_application_info_diskann() {
+    let diskann_config = vector_store::Config {
+        ..Default::default()
+    };
+
+    let (_, config_rx) = watch::channel(Arc::new(diskann_config));
+    let (client, _server, _config_senders) =
+        run_vs(vector_store::new_index_factory_diskann(config_rx).unwrap()).await;
+
+    let info = client.info().await;
+
+    assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(info.service, env!("CARGO_PKG_NAME"));
+    assert_eq!(info.engine, format!("diskann-{}", diskann::version()));
+}


### PR DESCRIPTION
This PR are the first steps towards integrating DiskANN. 
There is 1 new imported crate: `diskann`.
Implemented end-to-end getter for version of diskann reported via GET.

The USearch and OpenSearch code paths behave unchanged.

Fixes: VECTOR-713
Fixes: VECTOR-716
Fixes: VECTOR-718
Fixes: VECTOR-712