### PR TITLE
vector-store: expose index build progress in status endpoint

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "LicenseRef-ScyllaDB-Source-Available-1.0"
     },
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "paths": {
     "/api/v1/indexes": {
@@ -439,6 +439,13 @@
           "count"
         ],
         "properties": {
+          "build_progress": {
+            "type": "number",
+            "format": "double",
+            "description": "Progress of the initial full table scan that backfills the index,\nexpressed as a percentage in the range `0.0..=100.0`. This reflects\nonly how far the full scan has advanced; it is not a source of truth\nfor the index state. The `status` field is authoritative: an index\nreporting `SERVING` is serving regardless of `build_progress`, which\nmay not reach `100.0` (e.g. if some scan ranges failed). Defaults to\n`100.0` when omitted, so a new client talking to an older server that\ndoes not report the field falls back to relying solely on `status`.",
+            "maximum": 100,
+            "minimum": 0
+          },
           "count": {
             "type": "integer",
             "minimum": 0

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -149,6 +149,21 @@ pub enum IndexStatus {
 pub struct IndexStatusResponse {
     pub status: IndexStatus,
     pub count: usize,
+    /// Progress of the initial full table scan that backfills the index,
+    /// expressed as a percentage in the range `0.0..=100.0`. This reflects
+    /// only how far the full scan has advanced; it is not a source of truth
+    /// for the index state. The `status` field is authoritative: an index
+    /// reporting `SERVING` is serving regardless of `build_progress`, which
+    /// may not reach `100.0` (e.g. if some scan ranges failed). Defaults to
+    /// `100.0` when omitted, so a new client talking to an older server that
+    /// does not report the field falls back to relying solely on `status`.
+    #[serde(default = "default_build_progress")]
+    #[schema(minimum = 0, maximum = 100)]
+    pub build_progress: f64,
+}
+
+fn default_build_progress() -> f64 {
+    100.0
 }
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -91,7 +91,7 @@ use utoipa_swagger_ui::SwaggerUi;
             name = "LicenseRef-ScyllaDB-Source-Available-1.0"
         ),
         // version should be updated manually when there are changes in API
-        version = "2.0.0"
+        version = "2.1.0"
     ),
     tags(
         (
@@ -372,6 +372,10 @@ async fn get_index_status(
             response::Json(httpapi::IndexStatusResponse {
                 status: status.into(),
                 count,
+                // Placeholder; the real full-scan progress is wired up in a
+                // follow-up commit. Defaults to 100.0 so the field is always
+                // populated and `status` remains authoritative.
+                build_progress: 100.0,
             }),
         )
             .into_response(),

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -344,12 +344,20 @@ async fn get_index_status(
         Fts(Sender<crate::fts_index::FtsIndex>),
     }
 
-    let (index, status) = {
+    let (index, status, progress) = {
         let indexes = state.indexes.read().unwrap();
         if let Some(entry) = indexes.get_vs(&index_key) {
-            (IndexSender::Vs(entry.index().clone()), entry.status())
+            (
+                IndexSender::Vs(entry.index().clone()),
+                entry.status(),
+                entry.progress(),
+            )
         } else if let Some(entry) = indexes.get_fts(&index_key) {
-            (IndexSender::Fts(entry.index().clone()), entry.status())
+            (
+                IndexSender::Fts(entry.index().clone()),
+                entry.status(),
+                entry.progress(),
+            )
         } else {
             let msg = format!("missing index: {keyspace_name}.{index_name}");
             debug!("get_index_status: {msg}");
@@ -372,10 +380,7 @@ async fn get_index_status(
             response::Json(httpapi::IndexStatusResponse {
                 status: status.into(),
                 count,
-                // Placeholder; the real full-scan progress is wired up in a
-                // follow-up commit. Defaults to 100.0 so the field is always
-                // populated and `status` remains authoritative.
-                build_progress: 100.0,
+                build_progress: progress_to_percentage(progress),
             }),
         )
             .into_response(),
@@ -419,6 +424,15 @@ async fn refresh_index_metrics(
             .fts_segment_count
             .with_label_values(&labels)
             .set(stats.segment_count as f64);
+    }
+}
+
+/// Convert a build [`Progress`] into a percentage in the range `0.0..=100.0`.
+/// A finished full scan (`Progress::Done`) maps to `100.0`.
+fn progress_to_percentage(progress: Progress) -> f64 {
+    match progress {
+        Progress::Done => 100.0,
+        Progress::InProgress(percentage) => percentage.get(),
     }
 }
 
@@ -2132,6 +2146,19 @@ mod tests {
         assert_eq!(
             httpapi::IndexStatus::from(crate::node_state::IndexStatus::Serving),
             httpapi::IndexStatus::Serving
+        );
+    }
+
+    #[test]
+    fn progress_to_percentage_conversion() {
+        assert_eq!(super::progress_to_percentage(Progress::Done), 100.0);
+        assert_eq!(
+            super::progress_to_percentage(Progress::InProgress(42.0.try_into().unwrap())),
+            42.0
+        );
+        assert_eq!(
+            super::progress_to_percentage(Progress::InProgress(0.0.try_into().unwrap())),
+            0.0
         );
     }
 }

--- a/crates/vector-store/tests/integration/index_status.rs
+++ b/crates/vector-store/tests/integration/index_status.rs
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::routing::add_table;
+use crate::routing::blocking_scan_fn;
+use crate::routing::make_index;
+use crate::routing::ordered_timeuuid;
+use crate::routing::setup;
+use crate::routing::single_row_scan;
+use crate::wait_for;
+use httpapi::IndexStatus;
+use scylla::cluster::metadata::NativeType;
+use scylla::value::CqlValue;
+use vector_store::DbIndexPartitioning;
+use vector_store::Percentage;
+use vector_store::Progress;
+
+// While the initial full table scan that backfills an index is paused (held
+// open via blocking_scan_fn, simulating a paused/slow scan), the index status
+// endpoint must report it as BOOTSTRAPPING and surface the build progress
+// percentage reported by the database. Once the scan finishes the index
+// becomes SERVING with build_progress == 100.
+#[tokio::test]
+#[ntest::timeout(10_000)]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn index_status_reports_build_progress_while_bootstrapping() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    // Pin the reported full-scan progress to a partial value, then add an index
+    // whose scan never completes, keeping it bootstrapping at that progress.
+    db.set_next_full_scan_progress(Progress::InProgress(Percentage::try_from(37.0).unwrap()));
+
+    let index = make_index(
+        "building",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(index.clone(), Some(blocking_scan_fn()), None)
+        .unwrap();
+
+    let ks = index.keyspace_name.as_ref().into();
+    let idx = index.index_name.as_ref().into();
+    wait_for(
+        || async {
+            client
+                .index_status(&ks, &idx)
+                .await
+                .is_ok_and(|s| s.status == IndexStatus::Bootstrapping && s.build_progress == 37.0)
+        },
+        "index to be bootstrapping with build_progress == 37%",
+    )
+    .await;
+}
+
+// A fully built (serving) index reports build_progress == 100.
+#[tokio::test]
+#[ntest::timeout(10_000)]
+async fn index_status_reports_full_progress_when_serving() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    let index = make_index(
+        "ready",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        index.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+
+    let ks = index.keyspace_name.as_ref().into();
+    let idx = index.index_name.as_ref().into();
+    wait_for(
+        || async {
+            client
+                .index_status(&ks, &idx)
+                .await
+                .is_ok_and(|s| s.status == IndexStatus::Serving && s.build_progress == 100.0)
+        },
+        "index to be serving with build_progress == 100%",
+    )
+    .await;
+}

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -6,6 +6,7 @@
 mod db_basic;
 mod fts;
 mod https;
+mod index_status;
 mod info;
 mod memory_limit;
 mod metrics;

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -33,7 +33,7 @@ use vector_store::Timestamp;
 
 const ANN_LIMIT: usize = 5;
 
-fn ordered_timeuuid(time: u32) -> Uuid {
+pub(crate) fn ordered_timeuuid(time: u32) -> Uuid {
     let mut bytes = [0u8; 16];
     bytes[0..4].copy_from_slice(&time.to_be_bytes());
     bytes[6] = 0x10;
@@ -42,11 +42,13 @@ fn ordered_timeuuid(time: u32) -> Uuid {
 }
 
 /// A scan function that never completes, keeping the index bootstrapping.
-fn blocking_scan_fn() -> ScanFn {
+pub(crate) fn blocking_scan_fn() -> ScanFn {
     Box::new(|_tx| std::future::pending::<()>().boxed())
 }
 
-fn single_row_scan(pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'static) -> ScanFn {
+pub(crate) fn single_row_scan(
+    pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'static,
+) -> ScanFn {
     db_basic::scan_fn_vectors([(
         pks.into_iter().collect::<Vec<_>>().into(),
         Some(vec![1.0, 2.0, 3.0].into()),
@@ -55,7 +57,7 @@ fn single_row_scan(pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'stat
     )])
 }
 
-fn make_index(
+pub(crate) fn make_index(
     name: &str,
     primary_key_columns: &[&str],
     partition_key_count: usize,
@@ -91,7 +93,7 @@ fn make_index(
     }
 }
 
-async fn setup() -> (HttpClient, DbBasic, impl Sized) {
+pub(crate) async fn setup() -> (HttpClient, DbBasic, impl Sized) {
     let node_state = vector_store::new_node_state().await;
     let internals = vector_store::new_internals();
     let (db_actor, db) = db_basic::new(node_state.clone());
@@ -111,7 +113,7 @@ async fn setup() -> (HttpClient, DbBasic, impl Sized) {
     (HttpClient::new(addr), db, (server, senders))
 }
 
-fn add_table(
+pub(crate) fn add_table(
     db: &DbBasic,
     primary_keys: impl IntoIterator<Item = ColumnName>,
     partition_key_count: usize,


### PR DESCRIPTION
The GET /api/v1/indexes/{keyspace}/{index}/status handler now reports the
build_progress percentage taken from the index entry's full-scan progress
(Progress::Done maps to 100%). This lets clients observe how far the
initial backfill scan has advanced while an index is BOOTSTRAPPING.

Refs: https://scylladb.atlassian.net/browse/SCYLLADB-2327