### PR TITLE
scripts: fix building and uploading docker images

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,9 +33,7 @@ per-architecture docker images, and a multi-platform docker manifest. You can
 push the docker images and manifest to docker hub:
 
 ```bash
-docker push scylladb/vector-store:X.Y.Z-amd64
-docker push scylladb/vector-store:X.Y.Z-arm64
-docker manifest push scylladb/vector-store:X.Y.Z
+./scripts/upload-dockers
 ```
 
 The build script also generates SBOM files in CycloneDX JSON format:

--- a/scripts/build-dockers
+++ b/scripts/build-dockers
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+repo=$(dirname "${BASH_SOURCE[0]}")
+repo=$(realpath $repo/..)
+
+cd $repo
+
+vector_store_version=$(./scripts/run-with-release-toolchain cargo info vector-store | grep ^version: | cut -d ' ' -f 2)
+
+archs="amd64 arm64"
+
+dockerfile=$(cat <<EOF
+FROM redhat/ubi9-minimal
+ARG TARGETARCH
+RUN mkdir /opt/vector-store
+COPY target/\$TARGETARCH/release/vector-store /opt/vector-store
+CMD ["/opt/vector-store/vector-store"]
+EOF
+)
+
+docker_tag=scylladb/vector-store:$vector_store_version
+for arch in $archs ; do
+    echo Build the docker image for linux/$arch
+    docker build --platform linux/$arch --tag $docker_tag-$arch -f- . <<EOF
+$dockerfile
+EOF
+done
+
+for arch in $archs ; do
+    [[ -z $platform ]] && platform="linux/$arch" || platform="$platform,linux/$arch"
+done
+
+echo Build the multi-arch docker image for $platform
+docker build --platform $platform --tag $docker_tag -f- . <<EOF
+$dockerfile
+EOF
+
+docker images -f "reference=$docker_tag*"

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -47,29 +47,13 @@ cargo_sbom=crates/vector-store/vector-store.cdx.json
 mv $cargo_sbom vector-store-$vector_store_version.cdx.json
 echo "Cargo SBOM: vector-store-$vector_store_version.cdx.json"
 
-for arch in $archs ; do
-    echo build the docker image for linux/$arch
-    docker_tag=scylladb/vector-store:$vector_store_version-$arch
-    docker build --platform linux/$arch --tag $docker_tag -f- . <<EOF
-FROM redhat/ubi9-minimal
-ARG TARGETARCH
-RUN mkdir /opt/vector-store
-COPY target/\$TARGETARCH/release/vector-store /opt/vector-store
-CMD ["/opt/vector-store/vector-store"]
-EOF
+./scripts/build-dockers
 
+for arch in $archs ; do
     echo generate Docker image SBOM for $arch using syft
     docker_sbom=vector-store-docker-$vector_store_version-$arch.cdx.json
+    docker_tag=scylladb/vector-store:$vector_store_version-$arch
     syft $docker_tag -o cyclonedx-json > $docker_sbom
     [[ -s $docker_sbom ]] || { echo "error: Docker SBOM is empty at $docker_sbom"; exit 1; }
     echo "Docker SBOM: $docker_sbom"
 done
-
-echo create multi-platform docker manifest
-docker_manifest=scylladb/vector-store:$vector_store_version
-docker_arch_tags=()
-for arch in $archs ; do
-    docker_arch_tags+=("scylladb/vector-store:$vector_store_version-$arch")
-done
-docker manifest create $docker_manifest "${docker_arch_tags[@]}"
-echo "Docker manifest: $docker_manifest"

--- a/scripts/upload-dockers
+++ b/scripts/upload-dockers
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+repo=$(dirname "${BASH_SOURCE[0]}")
+repo=$(realpath $repo/..)
+
+cd $repo
+
+vector_store_version=$(./scripts/run-with-release-toolchain cargo info vector-store | grep ^version: | cut -d ' ' -f 2)
+
+archs="amd64 arm64"
+
+docker_tag=scylladb/vector-store:$vector_store_version
+for arch in $archs ; do
+    docker push $docker_tag-$arch
+done
+docker push $docker_tag


### PR DESCRIPTION
The issue with docker images was that using 'docker manifest crate' functionality doesn't work reliably. This fix creates multi-platform docker image by 'docker build' for multiplatform. Most of the docker images will be cached, so it will use the same images as for building single-arch image.

This commit provides two additional scripts: build-dockers and upload-dockers for building and uploading docker images.

Fixes: VECTOR-734