### PR TITLE
vector_store: fix forever BOOTSTRAPPING state while replacing indexes

### DIFF
--- a/crates/vector-store/src/node_state.rs
+++ b/crates/vector-store/src/node_state.rs
@@ -151,7 +151,9 @@ pub(crate) async fn new() -> mpsc::Sender<NodeState> {
                                 .expect("initial_idxs should be Some here");
 
                             // remove any initial indexes that are no longer present
-                            initial_idxs.retain(|idx| idxs.contains_key(&idx.key()));
+                            initial_idxs.retain(|idx| {
+                                idxs.contains_key(&idx.key()) && indexes.contains(idx)
+                            });
 
                             if initial_idxs.is_empty() {
                                 if status != NodeStatus::Serving {
@@ -447,6 +449,55 @@ mod tests {
 
         node_state
             .send_event(Event::IndexesDiscovered(HashSet::from([idx1.clone()])))
+            .await;
+        let status = node_state.get_status().await;
+        assert_eq!(status, NodeStatus::Serving);
+    }
+
+    #[tokio::test]
+    async fn node_state_update_index_with_changed_metadata_while_bootstrapping() {
+        let node_state = new().await;
+        let idx1 = index_metadata("idx1");
+        let idx2 = index_metadata("idx2");
+        let idx2_updated = IndexMetadata {
+            version: Uuid::new_v4().into(),
+            ..idx2.clone()
+        };
+
+        let status = node_state.get_status().await;
+        assert_eq!(status, NodeStatus::Initializing);
+
+        node_state.send_event(Event::ConnectingToDb).await;
+        let status = node_state.get_status().await;
+        assert_eq!(status, NodeStatus::ConnectingToDb);
+
+        node_state.send_event(Event::ConnectedToDb).await;
+        assert_eq!(status, NodeStatus::ConnectingToDb);
+
+        node_state.send_event(Event::DiscoveringIndexes).await;
+        let status = node_state.get_status().await;
+        assert_eq!(status, NodeStatus::DiscoveringIndexes);
+
+        node_state
+            .send_event(Event::IndexesDiscovered(HashSet::from([
+                idx1.clone(),
+                idx2.clone(),
+            ])))
+            .await;
+        let status = node_state.get_status().await;
+        assert_eq!(status, NodeStatus::IndexingEmbeddings);
+
+        node_state
+            .send_event(Event::FullScanFinished(idx1.clone()))
+            .await;
+        let status = node_state.get_status().await;
+        assert_eq!(status, NodeStatus::IndexingEmbeddings);
+
+        node_state
+            .send_event(Event::IndexesDiscovered(HashSet::from([
+                idx1.clone(),
+                idx2_updated.clone(),
+            ])))
             .await;
         let status = node_state.get_status().await;
         assert_eq!(status, NodeStatus::Serving);


### PR DESCRIPTION
There is a seldom case when vector-store could stay in a forever BOOTSTRAPPING state. When the user recreates an index during BOOTSTRAPPING and a monitor_indexes actor doesn't a retrieve state when index was deleted, a node_state actor won't remove the old index from the initial list. This commit fixes this and provides a unit test.

Fixes: VECTOR-732