### PR TITLE
validator: try to reproduce bad vector-store behavior

### DIFF
--- a/crates/validator/src/crud.rs
+++ b/crates/validator/src/crud.rs
@@ -7,6 +7,8 @@ use crate::TestActors;
 use crate::common::*;
 use httpapi::IndexStatus;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio::time;
 use tracing::info;
 
 e2etest::group!(name = crud, fixtures = (Fixture), parent = crate::validator);
@@ -300,6 +302,148 @@ async fn null_vector_is_not_indexed(actors: Arc<TestActors>) {
         );
     }
 
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test that adding the same row multiple times after deleting it works correctly.
+///
+/// This is an attempt the reproduction of failed scenario (failed once in the developer
+/// environment):
+///
+/// CREATE KEYSPACE ks;
+/// CREATE TABLE ks.tbl (p int primary key, v vector<float, 3>);
+/// INSERT INTO ks.tbl (p, v) VALUES (1, [1.0, 2.0, 3.0]);
+/// INSERT INTO ks.tbl (p, v) VALUES (2, [1.0, 2.0, 3.0]);
+/// CREATE INDEX ON ks.tbl (v) USING 'vector_index';
+/// DELETE FROM ks.tbl WHERE p = 2;
+///
+/// INSERT INTO ks.tbl (p, v) VALUES (2, [1.0, 2.0, 3.0]); <- this increases index size indefinitely and makes SELECT to return no rows
+#[e2etest::test(group = crud)]
+async fn global_add_remove_multiple_add(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(&session, "p INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+
+    info!("Insert two rows");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (p, v) VALUES (?, ?)"),
+            (1i32, &vec![1.0f32, 2.0f32, 3.0f32]),
+        )
+        .await
+        .expect("failed to insert row with vector");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (p, v) VALUES (?, ?)"),
+            (2i32, &vec![1.0f32, 2.0f32, 3.0f32]),
+        )
+        .await
+        .expect("failed to insert row with vector");
+
+    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    info!("Wait for the full scan to complete");
+    for client in &clients {
+        wait_for_index(client, &index).await;
+        let index_status = client
+            .index_status(&index.keyspace, &index.index)
+            .await
+            .expect("failed to get index status");
+        assert_eq!(index_status.count, 2);
+    }
+
+    info!("Delete a row");
+    session
+        .query_unpaged(format!("DELETE FROM {table} WHERE p = ?"), (2,))
+        .await
+        .expect("failed to delete row");
+
+    for client in &clients {
+        wait_for(
+            || async {
+                let index_status = client
+                    .index_status(&index.keyspace, &index.index)
+                    .await
+                    .expect("failed to get index status");
+                index_status.count == 1
+            },
+            "Waiting for index count to be updated after deletion",
+            DEFAULT_OPERATION_TIMEOUT,
+        )
+        .await;
+    }
+
+    let rows = get_query_results(
+        format!("SELECT p FROM {table} ORDER BY v ANN OF [1.0, 2.0, 3.0] LIMIT 5"),
+        &session,
+    )
+    .await;
+    let rows = rows.rows::<(i32,)>().expect("failed to get rows");
+    assert_eq!(
+        rows.rows_remaining(),
+        1,
+        "Expected 1 rows in the result after adding the same row multiple times"
+    );
+
+    info!("Add same row several times");
+    for _ in 0..10 {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (p, v) VALUES (?, ?)"),
+                (2i32, &vec![1.0f32, 2.0f32, 3.0f32]),
+            )
+            .await
+            .expect("failed to insert row with vector");
+    }
+
+    info!("Wait for the CDC to be processed and the index to be updated");
+    const CDC_PROCESSING_WAIT_TIME: Duration = Duration::from_secs(5);
+    time::sleep(CDC_PROCESSING_WAIT_TIME).await;
+
+    info!("Run query ann and check that only 2 rows are returned");
+    let rows = get_query_results(
+        format!("SELECT p FROM {table} ORDER BY v ANN OF [1.0, 2.0, 3.0] LIMIT 5"),
+        &session,
+    )
+    .await;
+    let rows = rows.rows::<(i32,)>().expect("failed to get rows");
+    assert_eq!(
+        rows.rows_remaining(),
+        2,
+        "Expected 2 rows in the result after adding the same row multiple times"
+    );
+
+    info!("Check index count of indexed rows");
+    for client in &clients {
+        let index_status = client
+            .index_status(&index.keyspace, &index.index)
+            .await
+            .expect("failed to get index status");
+        assert_eq!(index_status.count, 2);
+    }
+
+    info!("Run query ann and check that only 2 rows are returned");
+    let rows = get_query_results(
+        format!("SELECT p FROM {table} ORDER BY v ANN OF [1.0, 2.0, 3.0] LIMIT 5"),
+        &session,
+    )
+    .await;
+    let rows = rows.rows::<(i32,)>().expect("failed to get rows");
+    assert_eq!(
+        rows.rows_remaining(),
+        2,
+        "Expected 2 rows in the result after adding the same row multiple times"
+    );
+
+    info!("Drop keyspace");
     session
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
         .await

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -1311,6 +1311,153 @@ mod tests {
     }
 
     #[test]
+    fn global_add_remove_multiple_add() {
+        let pk1 = PrimaryKey::from([CqlValue::Int(1)]);
+        let pk2 = PrimaryKey::from([CqlValue::Int(2)]);
+        let vector_orig: Vector = vec![1.0, 2.0, 3.0].into();
+        let db_row_add = |pk: &PrimaryKey, ts| DbIndexedRow {
+            primary_key: pk.clone(),
+            values: NonemptyBox::new([Timestamped::new(
+                Timestamp::from_millis(ts),
+                Some(DbIndexedValue::Vector(vector_orig.clone())),
+            )])
+            .unwrap(),
+        };
+        let db_row_del = |pk: &PrimaryKey, ts| DbIndexedRow {
+            primary_key: pk.clone(),
+            values: NonemptyBox::new([Timestamped::new(Timestamp::from_millis(ts), None)]).unwrap(),
+        };
+
+        let index_key = IndexKey::new(&"ks".into(), &"idx".into());
+        let mut table = Table::new(
+            index_key.clone(),
+            NonemptyArc::new(["p"]).unwrap(),
+            1,
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &[],
+            Arc::new([("p".into(), NativeType::Int)].into_iter().collect()),
+        )
+        .unwrap();
+
+        // insert the vector pk1
+        let mut operations = table.add(&index_key, db_row_add(&pk1, 1)).unwrap();
+        assert_eq!(operations.len(), 1);
+        let (primary_id1, partition_id1) = match operations.remove(0) {
+            Operation::AddVector {
+                primary_id,
+                partition_id,
+                vector,
+                is_update: false,
+            } => {
+                assert_eq!(&vector, &vector_orig);
+                (primary_id, partition_id)
+            }
+            _ => panic!("Expected AddVector operation"),
+        };
+        assert_eq!(
+            &table.primary_key(partition_id1, primary_id1).unwrap(),
+            &pk1
+        );
+
+        // insert the vector pk2
+        let mut operations = table.add(&index_key, db_row_add(&pk2, 2)).unwrap();
+        assert_eq!(operations.len(), 1);
+        let (primary_id2, partition_id2) = match operations.remove(0) {
+            Operation::AddVector {
+                primary_id,
+                partition_id,
+                vector,
+                is_update: false,
+            } => {
+                assert_eq!(&vector, &vector_orig);
+                (primary_id, partition_id)
+            }
+            _ => panic!("Expected AddVector operation"),
+        };
+        assert_ne!(primary_id1, primary_id2);
+        assert_eq!(partition_id1, partition_id2);
+        assert_eq!(
+            &table.primary_key(partition_id2, primary_id2).unwrap(),
+            &pk2
+        );
+
+        // remove the vector by nulling the value
+        let mut operations = table.add(&index_key, db_row_del(&pk2, 3)).unwrap();
+        assert_eq!(operations.len(), 1);
+        match operations.remove(0) {
+            Operation::RemoveValue {
+                primary_id,
+                partition_id,
+            } => {
+                assert_eq!(primary_id, primary_id2);
+                assert_eq!(partition_id, partition_id2);
+            }
+            _ => panic!("Expected RemoveValue operation"),
+        };
+        assert!(table.primary_key(partition_id2, primary_id2).is_none());
+
+        // insert the vector pk2
+        let mut operations = table.add(&index_key, db_row_add(&pk2, 4)).unwrap();
+        assert_eq!(operations.len(), 1);
+        let (primary_id3, partition_id3) = match operations.remove(0) {
+            Operation::AddVector {
+                primary_id,
+                partition_id,
+                vector,
+                is_update: false,
+            } => {
+                assert_eq!(&vector, &vector_orig);
+                (primary_id, partition_id)
+            }
+            _ => panic!("Expected AddVector operation"),
+        };
+        assert_ne!(primary_id2, primary_id3);
+        assert_eq!(partition_id2, partition_id3);
+        assert_eq!(
+            &table.primary_key(partition_id3, primary_id3).unwrap(),
+            &pk2
+        );
+
+        let mut primary_id_prev = primary_id3;
+        for it in 0..10 {
+            // upsert the vector with a new value
+            let mut operations = table.add(&index_key, db_row_add(&pk2, 5 + it)).unwrap();
+            assert_eq!(operations.len(), 2);
+            match operations.remove(0) {
+                Operation::RemoveBeforeAddValue {
+                    primary_id,
+                    partition_id,
+                } => {
+                    assert_eq!(primary_id, primary_id_prev);
+                    assert_eq!(partition_id, partition_id3);
+                }
+                _ => panic!("Expected RemoveBeforeAddValue operation"),
+            };
+            let (primary_id4, partition_id4) = match operations.remove(0) {
+                Operation::AddVector {
+                    primary_id,
+                    partition_id,
+                    vector,
+                    is_update: true,
+                } => {
+                    assert_eq!(&vector, &vector_orig);
+                    (primary_id, partition_id)
+                }
+                _ => panic!("Expected AddValue operation"),
+            };
+            assert_ne!(primary_id_prev, primary_id4);
+            assert_eq!(partition_id3, partition_id4);
+            assert!(table.primary_key(partition_id3, primary_id_prev).is_none());
+            assert_eq!(
+                &table.primary_key(partition_id4, primary_id4).unwrap(),
+                &pk2
+            );
+            primary_id_prev = primary_id4;
+        }
+    }
+
+    #[test]
     fn cql_cmp_integers() {
         assert_eq!(
             cql_cmp(&CqlValue::Int(1), &CqlValue::Int(2)),


### PR DESCRIPTION
validator: try to reproduce bad vector-store behavior                                                                              
                                                                                                                                   
Once in the developer environment this scenario failed:                                                                            
                                                                                                                                   
CREATE KEYSPACE ks;                                                                                                                
CREATE TABLE ks.tbl (p int primary key, v vector<float, 3>);                                                                       
INSERT INTO ks.tbl (p, v) VALUES (1, [1.0, 2.0, 3.0]);                                                                             
INSERT INTO ks.tbl (p, v) VALUES (2, [1.0, 2.0, 3.0]);                                                                             
CREATE INDEX ON ks.tbl (v) USING 'vector_index';                                                                                   
DELETE FROM ks.tbl WHERE p = 2;                                                                                                    
                                                                                                                                   
INSERT INTO ks.tbl (p, v) VALUES (2, [1.0, 2.0, 3.0]); <- this increases index size indefinitely and makes SELECT to return no rows
                                                                                                                                   
We were not able to reproduce it. This commit prepares a validator tests and                                                       
table module unit test to catch this problem in the future.                                                                        
                                                                                                                                   
Fixes: VECTOR-735                                                                                                                  
