### PR TITLE
vector-store: add CDC reader health metrics

### DIFF
--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -202,9 +202,16 @@ async fn run_vector_store(
         mtls_http: mtls_http_rx,
     };
 
-    let (server, _mtls) = vector_store::run(node_state, db, internals, index_factory, receivers)
-        .await
-        .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
 
     let client = Arc::new(TestClient::new(server.router().await.unwrap()));
     ((http_tx, server), client)

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -19,6 +19,7 @@ use crate::IndexMetadata;
 use crate::IndexName;
 use crate::IndexVersion;
 use crate::KeyspaceName;
+use crate::Metrics;
 use crate::NonemptyArc;
 use crate::NonemptyIteratorExt;
 use crate::Quantization;
@@ -257,6 +258,7 @@ pub(crate) async fn new(
     node_state: Sender<NodeState>,
     internals: Sender<Internals>,
     mut config_rx: watch::Receiver<Arc<Config>>,
+    metrics: Arc<Metrics>,
 ) -> anyhow::Result<mpsc::Sender<Db>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
     tokio::spawn(
@@ -286,7 +288,7 @@ pub(crate) async fn new(
                                     internals.create_session(Some(session.clone())).await;
                                     session_tx.send(Some(session)).ok();
                                     if statements.is_none() {
-                                        statements = Some(Arc::new(Statements::new(config_rx.clone(), session_rx.clone()).await.unwrap()));
+                                        statements = Some(Arc::new(Statements::new(config_rx.clone(), session_rx.clone(), metrics.clone()).await.unwrap()));
                                     }
                                     info!("Connected to ScyllaDB at {}", config.scylladb_uri);
                                 }
@@ -505,6 +507,7 @@ fn credentials_changed(
 struct Statements {
     config_rx: watch::Receiver<Arc<Config>>,
     session_rx: watch::Receiver<Option<Arc<Session>>>,
+    metrics: Arc<Metrics>,
     st_latest_schema_version: PreparedStatement,
     st_get_indexes: PreparedStatement,
     st_get_index_target_type: PreparedStatement,
@@ -641,6 +644,7 @@ impl Statements {
     async fn new(
         config_rx: watch::Receiver<Arc<Config>>,
         session_rx: watch::Receiver<Option<Arc<Session>>>,
+        metrics: Arc<Metrics>,
     ) -> anyhow::Result<Self> {
         let session = session_rx.borrow().clone().ok_or_else(|| {
             anyhow::anyhow!("No session available during Statements initialization")
@@ -648,6 +652,7 @@ impl Statements {
 
         Ok(Self {
             config_rx,
+            metrics,
 
             st_latest_schema_version: session
                 .prepare(Self::ST_LATEST_SCHEMA_VERSION)
@@ -689,6 +694,7 @@ impl Statements {
             metadata,
             node_state,
             internals,
+            self.metrics.clone(),
             cdc_error_notify,
         )
         .await

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -384,6 +384,7 @@ impl CdcReaderState {
     ) {
         let session = session_rx.borrow().clone();
         if let Some(session) = session {
+            record_reader_restart(&self.metrics, &self.keyspace, &self.index_name, self.name);
             let config = config_rx.borrow().clone();
             let params = (self.params_fn)(&config);
             self.restart(params, &session, metadata, tx_embeddings, internals)
@@ -401,6 +402,19 @@ fn record_handler_error(
 ) {
     metrics
         .cdc_handler_errors_total
+        .with_label_values(&[keyspace.as_ref(), index_name.as_ref(), reader])
+        .inc();
+}
+
+/// Increments the `cdc_reader_restarts_total` counter for the given index and reader.
+fn record_reader_restart(
+    metrics: &Metrics,
+    keyspace: &KeyspaceName,
+    index_name: &IndexName,
+    reader: &str,
+) {
+    metrics
+        .cdc_reader_restarts_total
         .with_label_values(&[keyspace.as_ref(), index_name.as_ref(), reader])
         .inc();
 }

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -10,6 +10,7 @@ use crate::DbIndexedRow;
 use crate::DbIndexedValue;
 use crate::IndexKind;
 use crate::IndexMetadata;
+use crate::Metrics;
 use crate::NonemptyArc;
 use crate::NonemptyIteratorExt;
 use crate::db_index_backend::CdcValueStatus;
@@ -117,6 +118,7 @@ pub(crate) fn new(
     mut session_rx: watch::Receiver<Option<Arc<Session>>>,
     metadata: IndexMetadata,
     internals: Sender<Internals>,
+    _metrics: Arc<Metrics>,
     tx_embeddings: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     config: CdcReaderConfig,
 ) -> mpsc::Sender<DbCdc> {

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -10,6 +10,8 @@ use crate::DbIndexedRow;
 use crate::DbIndexedValue;
 use crate::IndexKind;
 use crate::IndexMetadata;
+use crate::IndexName;
+use crate::KeyspaceName;
 use crate::Metrics;
 use crate::NonemptyArc;
 use crate::NonemptyIteratorExt;
@@ -121,7 +123,7 @@ pub(crate) fn new(
     mut session_rx: watch::Receiver<Option<Arc<Session>>>,
     metadata: IndexMetadata,
     internals: Sender<Internals>,
-    _metrics: Arc<Metrics>,
+    metrics: Arc<Metrics>,
     tx_embeddings: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     config: CdcReaderConfig,
 ) -> mpsc::Sender<DbCdc> {
@@ -131,7 +133,13 @@ pub(crate) fn new(
     session_rx.mark_changed();
 
     let (name, params_fn) = config.name_and_params_fn();
-    let mut reader = CdcReaderState::new(name, params_fn);
+    let mut reader = CdcReaderState::new(
+        name,
+        params_fn,
+        metrics,
+        metadata.keyspace_name.clone(),
+        metadata.index_name.clone(),
+    );
     let name = reader.name;
     let actor_key = metadata.key();
     let span_key = actor_key.clone();
@@ -168,6 +176,7 @@ pub(crate) fn new(
                     _ = reader.error_notify.notified() => {
                         err_counter += 1;
                         backoff_duration = Some(DEFAULT_BACKOFF_DURATION);
+                        reader.set_reader_metric_down();
                         warn!(
                             "{name} CDC reader error {err_counter}, restarting after {duration:?} backoff",
                             name = reader.name,
@@ -186,6 +195,7 @@ pub(crate) fn new(
 
             // Cleanup
             reader.stop().await;
+            reader.remove_metrics();
 
             internals
                 .increment_counter(format!("{actor_key}-{name}-cdc-actor-stopped"))
@@ -207,11 +217,20 @@ struct CdcReaderState {
     start: Duration,
     name: &'static str,
     params_fn: fn(&Config) -> CdcReaderParams,
+    metrics: Arc<Metrics>,
+    keyspace: KeyspaceName,
+    index_name: IndexName,
 }
 
 impl CdcReaderState {
-    fn new(name: &'static str, params_fn: fn(&Config) -> CdcReaderParams) -> Self {
-        Self {
+    fn new(
+        name: &'static str,
+        params_fn: fn(&Config) -> CdcReaderParams,
+        metrics: Arc<Metrics>,
+        keyspace: KeyspaceName,
+        index_name: IndexName,
+    ) -> Self {
+        let state = Self {
             reader: None,
             handler_task: None,
             shutdown_notify: Arc::new(Notify::new()),
@@ -219,7 +238,39 @@ impl CdcReaderState {
             start: cdc_now(),
             name,
             params_fn,
-        }
+            metrics,
+            keyspace,
+            index_name,
+        };
+        state.set_reader_metric_down();
+        state
+    }
+
+    /// Sets the `cdc_reader_up` gauge to 1 (running) for this reader.
+    fn set_reader_metric_up(&self) {
+        self.metrics
+            .cdc_reader_up
+            .with_label_values(&[self.keyspace.as_ref(), self.index_name.as_ref(), self.name])
+            .set(1.0);
+    }
+
+    /// Sets the `cdc_reader_up` gauge to 0 (stopped) for this reader.
+    fn set_reader_metric_down(&self) {
+        self.metrics
+            .cdc_reader_up
+            .with_label_values(&[self.keyspace.as_ref(), self.index_name.as_ref(), self.name])
+            .set(0.0);
+    }
+
+    /// Removes this reader's metric series.
+    /// Must only be called after the actor loop has exited.
+    /// Calling it earlier races with updates that would recreate the series.
+    fn remove_metrics(&self) {
+        self.metrics.remove_reader_labels(
+            self.keyspace.as_ref(),
+            self.index_name.as_ref(),
+            self.name,
+        );
     }
 
     /// Stops the current CDC reader and handler task, preserving the last checkpoint.
@@ -231,6 +282,7 @@ impl CdcReaderState {
             self.shutdown_notify.notify_one();
             self.start = task.await.unwrap_or(cdc_now());
         }
+        self.set_reader_metric_down();
     }
 
     /// Stops the current reader, drains stale notifications, and starts a new reader with the given parameters.
@@ -266,6 +318,8 @@ impl CdcReaderState {
                     self.name,
                 ));
 
+                self.set_reader_metric_up();
+
                 info!(
                     "{} CDC reader created successfully for {} (safety: {:?}, sleep: {:?})",
                     self.name,
@@ -276,6 +330,7 @@ impl CdcReaderState {
             }
             Err(e) => {
                 error!("Failed to create {} CDC reader: {e}", self.name);
+                self.set_reader_metric_down();
                 self.error_notify.notify_one();
             }
         }
@@ -562,5 +617,58 @@ impl CdcConsumerFactory {
             kind: metadata.kind.clone(),
             tx,
         })))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus::Encoder;
+    use prometheus::TextEncoder;
+
+    fn metric_families_text(metrics: &Metrics) -> String {
+        let mut buf = Vec::new();
+        TextEncoder::new()
+            .encode(&metrics.registry.gather(), &mut buf)
+            .unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn new_state(metrics: Arc<Metrics>) -> CdcReaderState {
+        CdcReaderState::new(
+            READER_WIDE,
+            CdcReaderParams::wide,
+            metrics,
+            "ks".into(),
+            "idx".into(),
+        )
+    }
+
+    #[test]
+    fn new_state_initializes_reader_up_gauge_to_zero() {
+        let metrics = Arc::new(Metrics::new());
+
+        // The gauge must be present immediately, even for a reader that never starts.
+        let _state = new_state(Arc::clone(&metrics));
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains(r#"cdc_reader_up{index_name="idx",keyspace="ks",reader="wide"} 0"#),
+            "expected cdc_reader_up=0 immediately after creation, got:\n{output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_on_freshly_created_state_sets_reader_up_to_zero() {
+        let metrics = Arc::new(Metrics::new());
+        let mut state = new_state(Arc::clone(&metrics));
+
+        // Never started: `stop()` should be a no-op but must still report the reader as down.
+        state.stop().await;
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains(r#"cdc_reader_up{index_name="idx",keyspace="ks",reader="wide"} 0"#)
+        );
     }
 }

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -97,17 +97,20 @@ impl CdcReaderParams {
 
 pub(crate) enum DbCdc {}
 
+pub(crate) const READER_WIDE: &str = "wide";
+pub(crate) const READER_FINE: &str = "fine";
+
 /// Preset configurations for CDC reader actors.
 pub(crate) enum CdcReaderConfig {
     Wide,
     Fine,
 }
 
-impl From<CdcReaderConfig> for CdcReaderState {
-    fn from(config: CdcReaderConfig) -> Self {
-        match config {
-            CdcReaderConfig::Wide => Self::new("wide", CdcReaderParams::wide),
-            CdcReaderConfig::Fine => Self::new("fine", CdcReaderParams::fine),
+impl CdcReaderConfig {
+    fn name_and_params_fn(self) -> (&'static str, fn(&Config) -> CdcReaderParams) {
+        match self {
+            CdcReaderConfig::Wide => (READER_WIDE, CdcReaderParams::wide),
+            CdcReaderConfig::Fine => (READER_FINE, CdcReaderParams::fine),
         }
     }
 }
@@ -127,7 +130,8 @@ pub(crate) fn new(
     // Mark the receiver to ensure first session update is visible
     session_rx.mark_changed();
 
-    let mut reader: CdcReaderState = config.into();
+    let (name, params_fn) = config.name_and_params_fn();
+    let mut reader = CdcReaderState::new(name, params_fn);
     let name = reader.name;
     let actor_key = metadata.key();
     let span_key = actor_key.clone();

--- a/crates/vector-store/src/db_cdc.rs
+++ b/crates/vector-store/src/db_cdc.rs
@@ -314,6 +314,7 @@ impl CdcReaderState {
                     Arc::clone(&self.shutdown_notify),
                     Arc::clone(&self.error_notify),
                     internals.clone(),
+                    Arc::clone(&self.metrics),
                     metadata,
                     self.name,
                 ));
@@ -391,6 +392,19 @@ impl CdcReaderState {
     }
 }
 
+/// Increments the `cdc_handler_errors_total` counter for the given index and reader.
+fn record_handler_error(
+    metrics: &Metrics,
+    keyspace: &KeyspaceName,
+    index_name: &IndexName,
+    reader: &str,
+) {
+    metrics
+        .cdc_handler_errors_total
+        .with_label_values(&[keyspace.as_ref(), index_name.as_ref(), reader])
+        .inc();
+}
+
 fn cdc_now() -> Duration {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -451,6 +465,7 @@ fn spawn_handler_task(
     shutdown_notify: Arc<Notify>,
     cdc_error_notify: Arc<Notify>,
     internals: Sender<Internals>,
+    metrics: Arc<Metrics>,
     metadata: &IndexMetadata,
     reader_name: &str,
 ) -> tokio::task::JoinHandle<Duration> {
@@ -459,6 +474,9 @@ fn spawn_handler_task(
     let started_counter_name = format!("{handler_key}-{reader_name}-cdc-handler-started");
     let stopped_counter_name = format!("{handler_key}-{reader_name}-cdc-handler-stopped");
     let errors_counter_name = format!("{handler_key}-{reader_name}-cdc-handler-errors");
+    let keyspace = metadata.keyspace_name.clone();
+    let index_name = metadata.index_name.clone();
+    let reader_name = reader_name.to_string();
 
     tokio::spawn(
         async move {
@@ -468,6 +486,7 @@ fn spawn_handler_task(
                     if let Err(err) = result {
                         warn!("CDC handler error: {err}");
                         internals.increment_counter(errors_counter_name).await;
+                        record_handler_error(&metrics, &keyspace, &index_name, &reader_name);
                         cdc_error_notify.notify_one();
                     }
                 }

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -11,6 +11,7 @@ use crate::DbIndexedValue;
 use crate::IndexKind;
 use crate::IndexMetadata;
 use crate::KeyspaceIdentifier;
+use crate::Metrics;
 use crate::NonemptyArc;
 use crate::NonemptyIteratorExt;
 use crate::Percentage;
@@ -153,6 +154,7 @@ pub(crate) async fn new(
     metadata: IndexMetadata,
     node_state: Sender<NodeState>,
     internals: Sender<Internals>,
+    metrics: Arc<Metrics>,
     cdc_error_notify: Arc<Notify>,
 ) -> anyhow::Result<(
     mpsc::Sender<DbIndex>,
@@ -181,6 +183,7 @@ pub(crate) async fn new(
         session_rx.clone(),
         metadata.clone(),
         internals.clone(),
+        metrics.clone(),
         tx_embeddings.clone(),
         CdcReaderConfig::Wide,
     );
@@ -191,6 +194,7 @@ pub(crate) async fn new(
         session_rx.clone(),
         metadata.clone(),
         internals,
+        metrics,
         tx_embeddings.clone(),
         CdcReaderConfig::Fine,
     );

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -692,8 +692,8 @@ pub async fn run(
     internals: Sender<Internals>,
     index_factory: Box<dyn VsIndexFactory + Send + Sync>,
     receivers: ConfigReceivers,
+    metrics: Arc<Metrics>,
 ) -> anyhow::Result<(Sender<HttpServer>, Sender<HttpServer>)> {
-    let metrics: Arc<Metrics> = Arc::new(metrics::Metrics::new());
     let index_engine_version = index_factory.index_engine_version();
     let indexes = Arc::new(RwLock::new(Indexes::new()));
     let fts_index_factory: Box<dyn fts_index::FtsIndexFactory + Send + Sync> =
@@ -741,8 +741,13 @@ pub async fn new_db(
     node_state: Sender<NodeState>,
     internals: Sender<Internals>,
     config_rx: watch::Receiver<Arc<Config>>,
+    metrics: Arc<Metrics>,
 ) -> anyhow::Result<Sender<Db>> {
-    db::new(node_state, internals, config_rx).await
+    db::new(node_state, internals, config_rx, metrics).await
+}
+
+pub fn new_metrics() -> Arc<Metrics> {
+    Arc::new(Metrics::new())
 }
 
 pub async fn new_node_state() -> Sender<NodeState> {

--- a/crates/vector-store/src/main.rs
+++ b/crates/vector-store/src/main.rs
@@ -87,8 +87,14 @@ fn main() -> anyhow::Result<()> {
         };
 
         let internals = vector_store::new_internals();
-        let db_actor =
-            vector_store::new_db(node_state.clone(), internals.clone(), config_rx).await?;
+        let metrics = vector_store::new_metrics();
+        let db_actor = vector_store::new_db(
+            node_state.clone(),
+            internals.clone(),
+            config_rx,
+            metrics.clone(),
+        )
+        .await?;
 
         let (server, _mtls) = vector_store::run(
             node_state,
@@ -96,6 +102,7 @@ fn main() -> anyhow::Result<()> {
             internals,
             index_factory,
             config_receivers,
+            metrics,
         )
         .await?;
         let addr = (*server.address().await.borrow())

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -23,6 +23,7 @@ pub struct Metrics {
     pub indexing_lag: HistogramVec,
     pub cdc_reader_up: GaugeVec,
     pub cdc_handler_errors_total: CounterVec,
+    pub cdc_reader_restarts_total: CounterVec,
     dirty_indexes: Arc<DashSet<(String, String)>>,
 }
 
@@ -118,6 +119,15 @@ impl Metrics {
         )
         .unwrap();
 
+        let cdc_reader_restarts_total = CounterVec::new(
+            prometheus::Opts::new(
+                "cdc_reader_restarts_total",
+                "Total number of CDC reader restart attempts after an error, per index and reader",
+            ),
+            &["keyspace", "index_name", "reader"],
+        )
+        .unwrap();
+
         registry.register(Box::new(latency.clone())).unwrap();
         registry.register(Box::new(size.clone())).unwrap();
         registry.register(Box::new(modified.clone())).unwrap();
@@ -125,6 +135,9 @@ impl Metrics {
         registry.register(Box::new(cdc_reader_up.clone())).unwrap();
         registry
             .register(Box::new(cdc_handler_errors_total.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(cdc_reader_restarts_total.clone()))
             .unwrap();
 
         Self {
@@ -135,6 +148,7 @@ impl Metrics {
             indexing_lag,
             cdc_reader_up,
             cdc_handler_errors_total,
+            cdc_reader_restarts_total,
             dirty_indexes: Arc::new(DashSet::new()),
         }
     }
@@ -177,6 +191,9 @@ impl Metrics {
             .remove_label_values(&[keyspace, index_name, reader]);
         let _ = self
             .cdc_handler_errors_total
+            .remove_label_values(&[keyspace, index_name, reader]);
+        let _ = self
+            .cdc_reader_restarts_total
             .remove_label_values(&[keyspace, index_name, reader]);
     }
 }
@@ -351,6 +368,28 @@ mod tests {
     }
 
     #[test]
+    fn cdc_reader_restarts_total_is_exported() {
+        let metrics = Metrics::new();
+
+        metrics
+            .cdc_reader_restarts_total
+            .with_label_values(&["ks", "idx", READER_FINE])
+            .inc_by(2.0);
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains("# TYPE cdc_reader_restarts_total counter"),
+            "cdc_reader_restarts_total counter missing from export:\n{output}"
+        );
+        assert!(
+            output.contains(
+                r#"cdc_reader_restarts_total{index_name="idx",keyspace="ks",reader="fine"} 2"#
+            ),
+            "expected two observed restarts in export:\n{output}"
+        );
+    }
+
+    #[test]
     fn remove_index_labels_does_not_clear_cdc_reader_metrics() {
         let metrics = Metrics::new();
 
@@ -387,6 +426,10 @@ mod tests {
                 .set(1.0);
             metrics
                 .cdc_handler_errors_total
+                .with_label_values(&["ks", "idx", reader])
+                .inc();
+            metrics
+                .cdc_reader_restarts_total
                 .with_label_values(&["ks", "idx", reader])
                 .inc();
         }

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -22,6 +22,7 @@ pub struct Metrics {
     pub modified: CounterVec,
     pub indexing_lag: HistogramVec,
     pub cdc_reader_up: GaugeVec,
+    pub cdc_handler_errors_total: CounterVec,
     dirty_indexes: Arc<DashSet<(String, String)>>,
 }
 
@@ -108,11 +109,23 @@ impl Metrics {
         )
         .unwrap();
 
+        let cdc_handler_errors_total = CounterVec::new(
+            prometheus::Opts::new(
+                "cdc_handler_errors_total",
+                "Total number of CDC handler errors per index and reader",
+            ),
+            &["keyspace", "index_name", "reader"],
+        )
+        .unwrap();
+
         registry.register(Box::new(latency.clone())).unwrap();
         registry.register(Box::new(size.clone())).unwrap();
         registry.register(Box::new(modified.clone())).unwrap();
         registry.register(Box::new(indexing_lag.clone())).unwrap();
         registry.register(Box::new(cdc_reader_up.clone())).unwrap();
+        registry
+            .register(Box::new(cdc_handler_errors_total.clone()))
+            .unwrap();
 
         Self {
             registry,
@@ -121,6 +134,7 @@ impl Metrics {
             modified,
             indexing_lag,
             cdc_reader_up,
+            cdc_handler_errors_total,
             dirty_indexes: Arc::new(DashSet::new()),
         }
     }
@@ -160,6 +174,9 @@ impl Metrics {
     pub fn remove_reader_labels(&self, keyspace: &str, index_name: &str, reader: &str) {
         let _ = self
             .cdc_reader_up
+            .remove_label_values(&[keyspace, index_name, reader]);
+        let _ = self
+            .cdc_handler_errors_total
             .remove_label_values(&[keyspace, index_name, reader]);
     }
 }
@@ -312,6 +329,28 @@ mod tests {
     }
 
     #[test]
+    fn cdc_handler_errors_total_is_exported() {
+        let metrics = Metrics::new();
+
+        metrics
+            .cdc_handler_errors_total
+            .with_label_values(&["ks", "idx", READER_FINE])
+            .inc();
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains("# TYPE cdc_handler_errors_total counter"),
+            "cdc_handler_errors_total counter missing from export:\n{output}"
+        );
+        assert!(
+            output.contains(
+                r#"cdc_handler_errors_total{index_name="idx",keyspace="ks",reader="fine"} 1"#
+            ),
+            "expected a single observed handler error in export:\n{output}"
+        );
+    }
+
+    #[test]
     fn remove_index_labels_does_not_clear_cdc_reader_metrics() {
         let metrics = Metrics::new();
 
@@ -346,6 +385,10 @@ mod tests {
                 .cdc_reader_up
                 .with_label_values(&["ks", "idx", reader])
                 .set(1.0);
+            metrics
+                .cdc_handler_errors_total
+                .with_label_values(&["ks", "idx", reader])
+                .inc();
         }
 
         metrics.remove_reader_labels("ks", "idx", READER_WIDE);

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -21,6 +21,7 @@ pub struct Metrics {
     pub size: GaugeVec,
     pub modified: CounterVec,
     pub indexing_lag: HistogramVec,
+    pub cdc_reader_up: GaugeVec,
     dirty_indexes: Arc<DashSet<(String, String)>>,
 }
 
@@ -98,10 +99,20 @@ impl Metrics {
         )
         .unwrap();
 
+        let cdc_reader_up = GaugeVec::new(
+            prometheus::Opts::new(
+                "cdc_reader_up",
+                "Whether the CDC reader for an index is currently running (1) or stopped (0)",
+            ),
+            &["keyspace", "index_name", "reader"],
+        )
+        .unwrap();
+
         registry.register(Box::new(latency.clone())).unwrap();
         registry.register(Box::new(size.clone())).unwrap();
         registry.register(Box::new(modified.clone())).unwrap();
         registry.register(Box::new(indexing_lag.clone())).unwrap();
+        registry.register(Box::new(cdc_reader_up.clone())).unwrap();
 
         Self {
             registry,
@@ -109,6 +120,7 @@ impl Metrics {
             size,
             modified,
             indexing_lag,
+            cdc_reader_up,
             dirty_indexes: Arc::new(DashSet::new()),
         }
     }
@@ -144,11 +156,19 @@ impl Metrics {
         self.dirty_indexes
             .remove(&(keyspace.to_owned(), index_name.to_owned()));
     }
+
+    pub fn remove_reader_labels(&self, keyspace: &str, index_name: &str, reader: &str) {
+        let _ = self
+            .cdc_reader_up
+            .remove_label_values(&[keyspace, index_name, reader]);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db_cdc::READER_FINE;
+    use crate::db_cdc::READER_WIDE;
     use prometheus::Encoder;
     use prometheus::TextEncoder;
 
@@ -268,6 +288,76 @@ mod tests {
                 .with_label_values(&["ks", "idx"])
                 .get_sample_count(),
             0
+        );
+    }
+
+    #[test]
+    fn cdc_reader_up_is_exported() {
+        let metrics = Metrics::new();
+
+        metrics
+            .cdc_reader_up
+            .with_label_values(&["ks", "idx", READER_WIDE])
+            .set(1.0);
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains("# TYPE cdc_reader_up gauge"),
+            "cdc_reader_up gauge missing from export:\n{output}"
+        );
+        assert!(
+            output.contains(r#"cdc_reader_up{index_name="idx",keyspace="ks",reader="wide"} 1"#),
+            "expected cdc_reader_up=1 for wide reader in export:\n{output}"
+        );
+    }
+
+    #[test]
+    fn remove_index_labels_does_not_clear_cdc_reader_metrics() {
+        let metrics = Metrics::new();
+
+        // Non-CDC index-scoped metric; must be cleared.
+        metrics.size.with_label_values(&["ks", "idx"]).set(1.0);
+
+        // CDC reader metrics are owned by the CDC actor; remove_index_labels must not touch them.
+        metrics
+            .cdc_reader_up
+            .with_label_values(&["ks", "idx", READER_WIDE])
+            .set(1.0);
+
+        metrics.remove_index_labels("ks", "idx");
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            !output.contains(r#"index_size{index_name="idx",keyspace="ks"}"#),
+            "index_size should be removed, got:\n{output}"
+        );
+        assert!(
+            output.contains(r#"cdc_reader_up{index_name="idx",keyspace="ks",reader="wide"} 1"#),
+            "cdc_reader_up must survive remove_index_labels, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn remove_reader_labels_clears_only_the_given_readers_cdc_metrics() {
+        let metrics = Metrics::new();
+
+        for reader in [READER_WIDE, READER_FINE] {
+            metrics
+                .cdc_reader_up
+                .with_label_values(&["ks", "idx", reader])
+                .set(1.0);
+        }
+
+        metrics.remove_reader_labels("ks", "idx", READER_WIDE);
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            !output.contains(r#"reader="wide""#),
+            "the wide reader's CDC metric series should be removed, got:\n{output}"
+        );
+        assert!(
+            output.contains(r#"reader="fine""#),
+            "the fine reader's CDC metric series must be unaffected, got:\n{output}"
         );
     }
 }

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -133,6 +133,9 @@ impl Metrics {
     pub fn remove_index_labels(&self, keyspace: &str, index_name: &str) {
         let _ = self.latency.remove_label_values(&[keyspace, index_name]);
         let _ = self.size.remove_label_values(&[keyspace, index_name]);
+        let _ = self
+            .indexing_lag
+            .remove_label_values(&[keyspace, index_name]);
         for op in OPERATIONS {
             let _ = self
                 .modified
@@ -168,6 +171,10 @@ mod tests {
             .inc();
         metrics
             .latency
+            .with_label_values(&["ks", "idx"])
+            .observe(0.001);
+        metrics
+            .indexing_lag
             .with_label_values(&["ks", "idx"])
             .observe(0.001);
 

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -86,10 +86,16 @@ async fn setup_fts_store(
     let run = {
         let node_state = node_state.clone();
         async move {
-            let (server, _mtls) =
-                vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-                    .await
-                    .unwrap();
+            let (server, _mtls) = vector_store::run(
+                node_state,
+                db_actor,
+                internals,
+                index_factory,
+                receivers,
+                vector_store::new_metrics(),
+            )
+            .await
+            .unwrap();
             let addr = (*server.address().await.borrow()).unwrap();
 
             (HttpClient::new(addr), server, senders)

--- a/crates/vector-store/tests/integration/https.rs
+++ b/crates/vector-store/tests/integration/https.rs
@@ -38,10 +38,16 @@ async fn run_server(
 
     let (receivers, senders) = create_config_channels(config).await;
 
-    let (server, _mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
 
     let addr = (*server.address().await.borrow()).unwrap();
 

--- a/crates/vector-store/tests/integration/info.rs
+++ b/crates/vector-store/tests/integration/info.rs
@@ -20,10 +20,16 @@ async fn run_vs(
     let (db_actor, _) = db_basic::new(node_state.clone());
 
     let (receivers, senders) = create_config_channels(test_config()).await;
-    let (server, _mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
     let addr = (*server.address().await.borrow()).unwrap();
     (HttpClient::new(addr), server, senders)
 }

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -129,10 +129,16 @@ async fn memory_limit_during_index_build() {
     let index_factory = vector_store::new_index_factory_usearch(receivers.config.clone()).unwrap();
 
     let node_state = node_state.clone();
-    let (server, _mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
     let addr = (*server.address().await.borrow()).unwrap();
 
     let client = HttpClient::new(addr);

--- a/crates/vector-store/tests/integration/mtls.rs
+++ b/crates/vector-store/tests/integration/mtls.rs
@@ -63,10 +63,16 @@ async fn run_server(enable_mtls: bool) -> MtlsTestServer {
     let (receivers, senders) = create_config_channels(config.clone()).await;
     let index_factory = vector_store::new_index_factory_usearch(receivers.config.clone()).unwrap();
 
-    let (server, mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
     let main_addr = (*server.address().await.borrow()).unwrap();
 
     let mtls_addr = if enable_mtls {

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -56,10 +56,16 @@ async fn simple_create_search_delete_index() {
         vector_store::new_index_factory_opensearch(server.base_url(), config_rx_factory).unwrap();
 
     let (receivers, _senders) = create_config_channels(test_config()).await;
-    let (server, _mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
     let addr = (*server.address().await.borrow()).unwrap();
 
     let client = HttpClient::new(addr);

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -89,10 +89,16 @@ async fn setup() -> (HttpClient, DbBasic, impl Sized) {
     let (db_actor, db) = db_basic::new(node_state.clone());
     let (receivers, senders) = create_config_channels(test_config()).await;
     let index_factory = vector_store::new_index_factory_usearch(receivers.config.clone()).unwrap();
-    let (server, _mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
     let addr = (*server.address().await.borrow()).unwrap();
     (HttpClient::new(addr), db, (server, senders))
 }

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -147,10 +147,16 @@ pub(crate) async fn setup_store_with_quantization(
     let run = {
         let node_state = node_state.clone();
         async move {
-            let (server, _mtls) =
-                vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-                    .await
-                    .unwrap();
+            let (server, _mtls) = vector_store::run(
+                node_state,
+                db_actor,
+                internals,
+                index_factory,
+                receivers,
+                vector_store::new_metrics(),
+            )
+            .await
+            .unwrap();
             let addr = (*server.address().await.borrow()).unwrap();
 
             (HttpClient::new(addr), server, senders)
@@ -318,10 +324,16 @@ async fn failed_db_index_create() {
     let index_factory = vector_store::new_index_factory_usearch(rx).unwrap();
 
     let (receivers, _senders) = create_config_channels(test_config()).await;
-    let (server, _mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
     let addr = (*server.address().await.borrow()).unwrap();
 
     let client = HttpClient::new(addr);
@@ -1623,10 +1635,16 @@ async fn similarity_scores_are_decreasing_and_correctly_converted() {
     let (_, rx) = watch::channel(Arc::new(Config::default()));
     let index_factory = vector_store::new_index_factory_usearch(rx).unwrap();
     let (receivers, _senders) = create_config_channels(test_config()).await;
-    let (server, _mtls) =
-        vector_store::run(node_state, db_actor, internals, index_factory, receivers)
-            .await
-            .unwrap();
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
     let addr = (*server.address().await.borrow()).unwrap();
     let client = HttpClient::new(addr);
 


### PR DESCRIPTION
Adds Prometheus metrics for CDC reader health, as a follow-up to a recent
incident where a CDC reader silently stopped processing changes without
any visible signal.

- `cdc_reader_up` - whether each index's CDC reader (wide/fine) is  currently running or stopped.
- `cdc_handler_errors_total` - CDC handler errors per index and reader.
- `cdc_reader_restarts_total` - restart-after-backoff attempts per index  and reader.

Also fixes two issues found while testing this work:
- a pre-existing race in the CDC handler shutdown path that could  orphan the driver's per-stream fetch tasks indefinitely instead of  stopping them.
- a pre-existing leak of `indexing_lag_seconds` series on index  deletion.

Split from: https://github.com/scylladb/vector-store/pull/503 as it kept getting bigger.
This patch will introduce the straightforward metrics that could be supported out of the box.
The latter will include the `cdc_last_processed_timestamp_seconds` metric and a potential refactor of `db_cdc.rs`.

Refs: VECTOR-722
Fixes: VECTOR-739