### PR TITLE
vector-store: add FTS metrics

### DIFF
--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -14,6 +14,7 @@ use crate::db::Db;
 use crate::db::DbExt;
 use crate::db_index::DbIndex;
 use crate::db_index::DbIndexExt;
+use crate::fts_index::FtsIndex;
 use crate::fts_index::FtsIndexFactory;
 use crate::indexes::Indexes;
 use crate::memory;
@@ -44,6 +45,7 @@ use tracing::trace;
 type GetVsIndexKeysR = Vec<(IndexKey, crate::IndexOptionsVs)>;
 type AddIndexR = anyhow::Result<()>;
 type GetVsIndexR = Option<(mpsc::Sender<VsIndex>, mpsc::Sender<DbIndex>)>;
+type GetFtsIndexR = Option<(mpsc::Sender<FtsIndex>, mpsc::Sender<DbIndex>)>;
 
 pub(crate) enum Engine {
     GetVsIndexKeys {
@@ -60,6 +62,10 @@ pub(crate) enum Engine {
         key: IndexKey,
         tx: oneshot::Sender<GetVsIndexR>,
     },
+    GetFtsIndex {
+        key: IndexKey,
+        tx: oneshot::Sender<GetFtsIndexR>,
+    },
 }
 
 pub(crate) trait EngineExt {
@@ -67,6 +73,7 @@ pub(crate) trait EngineExt {
     async fn add_index(&self, metadata: IndexMetadata) -> AddIndexR;
     async fn del_index(&self, key: IndexKey);
     async fn get_vs_index(&self, key: IndexKey) -> GetVsIndexR;
+    async fn get_fts_index(&self, key: IndexKey) -> GetFtsIndexR;
 }
 
 impl EngineExt for mpsc::Sender<Engine> {
@@ -101,6 +108,15 @@ impl EngineExt for mpsc::Sender<Engine> {
             .expect("EngineExt::get_vs_index: internal actor should receive request");
         rx.await
             .expect("EngineExt::get_vs_index: internal actor should send response")
+    }
+
+    async fn get_fts_index(&self, key: IndexKey) -> GetFtsIndexR {
+        let (tx, rx) = oneshot::channel();
+        self.send(Engine::GetFtsIndex { key, tx })
+            .await
+            .expect("EngineExt::get_fts_index: internal actor should receive request");
+        rx.await
+            .expect("EngineExt::get_fts_index: internal actor should send response")
     }
 }
 
@@ -163,6 +179,10 @@ pub(crate) async fn new(
                             Engine::DelIndex { key } => del_index(key, &indexes, &metrics).await,
 
                             Engine::GetVsIndex { key, tx } => get_vs_index(key, tx, &indexes).await,
+
+                            Engine::GetFtsIndex { key, tx } => {
+                                get_fts_index(key, tx, &indexes).await
+                            }
 
                         }
                     }
@@ -358,6 +378,20 @@ async fn get_vs_index(key: IndexKey, tx: oneshot::Sender<GetVsIndexR>, indexes: 
     );
 }
 
+async fn get_fts_index(
+    key: IndexKey,
+    tx: oneshot::Sender<GetFtsIndexR>,
+    indexes: &RwLock<Indexes>,
+) {
+    _ = tx.send(
+        indexes
+            .read()
+            .unwrap()
+            .get_fts(&key)
+            .map(|entry| (entry.index().clone(), entry.db_index())),
+    );
+}
+
 async fn update_indexes(node_state: &Sender<NodeState>, indexes: &RwLock<Indexes>) {
     let actual_indexes: Vec<_> = {
         let indexes = indexes.read().unwrap();
@@ -428,6 +462,12 @@ pub(crate) mod tests {
             key: IndexKey,
             tx: oneshot::Sender<GetVsIndexR>,
         ) -> impl Future<Output = ()> + Send + 'static;
+
+        fn get_fts_index(
+            &self,
+            key: IndexKey,
+            tx: oneshot::Sender<GetFtsIndexR>,
+        ) -> impl Future<Output = ()> + Send + 'static;
     }
 
     pub(crate) fn new(sim: impl SimEngine + Send + 'static) -> mpsc::Sender<Engine> {
@@ -450,6 +490,7 @@ pub(crate) mod tests {
                         Engine::AddIndex { metadata, tx } => sim.add_index(metadata, tx).await,
                         Engine::DelIndex { key } => sim.del_index(key).await,
                         Engine::GetVsIndex { key, tx } => sim.get_vs_index(key, tx).await,
+                        Engine::GetFtsIndex { key, tx } => sim.get_fts_index(key, tx).await,
                     }
                 }
 

--- a/crates/vector-store/src/fts_index/actor.rs
+++ b/crates/vector-store/src/fts_index/actor.rs
@@ -23,7 +23,6 @@ pub(crate) struct FtsStats {
 
 pub(crate) type FtsStatsR = anyhow::Result<FtsStats>;
 
-#[allow(dead_code)]
 pub(crate) enum FtsIndex {
     AddDocument {
         primary_id: PrimaryId,
@@ -50,7 +49,6 @@ pub(crate) enum FtsIndex {
     },
 }
 
-#[allow(dead_code)]
 pub(crate) trait FtsIndexExt {
     async fn add_document(
         &self,

--- a/crates/vector-store/src/fts_index/actor.rs
+++ b/crates/vector-store/src/fts_index/actor.rs
@@ -14,6 +14,15 @@ use tokio::sync::oneshot;
 
 pub(crate) type FtsSearchR = anyhow::Result<(Vec<PrimaryKey>, Vec<f32>)>;
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FtsStats {
+    pub(crate) num_docs: u64,
+    pub(crate) size_bytes: u64,
+    pub(crate) segment_count: usize,
+}
+
+pub(crate) type FtsStatsR = anyhow::Result<FtsStats>;
+
 #[allow(dead_code)]
 pub(crate) enum FtsIndex {
     AddDocument {
@@ -35,6 +44,10 @@ pub(crate) enum FtsIndex {
         limit: Limit,
         tx: oneshot::Sender<FtsSearchR>,
     },
+    Stats {
+        index_key: IndexKey,
+        tx: oneshot::Sender<FtsStatsR>,
+    },
 }
 
 #[allow(dead_code)]
@@ -48,6 +61,7 @@ pub(crate) trait FtsIndexExt {
     async fn remove_document(&self, primary_id: PrimaryId, in_progress: AsyncInProgress);
     async fn count(&self, index_key: IndexKey) -> CountR;
     async fn search(&self, index_key: IndexKey, query: String, limit: Limit) -> FtsSearchR;
+    async fn stats(&self, index_key: IndexKey) -> FtsStatsR;
 }
 
 impl FtsIndexExt for mpsc::Sender<FtsIndex> {
@@ -90,6 +104,12 @@ impl FtsIndexExt for mpsc::Sender<FtsIndex> {
             tx,
         })
         .await?;
+        rx.await?
+    }
+
+    async fn stats(&self, index_key: IndexKey) -> FtsStatsR {
+        let (tx, rx) = oneshot::channel();
+        self.send(FtsIndex::Stats { index_key, tx }).await?;
         rx.await?
     }
 }

--- a/crates/vector-store/src/fts_index/tantivy.rs
+++ b/crates/vector-store/src/fts_index/tantivy.rs
@@ -48,6 +48,8 @@ use crate::worker::WorkerExt;
 
 use super::actor::FtsIndex;
 use super::actor::FtsSearchR;
+use super::actor::FtsStats;
+use super::actor::FtsStatsR;
 
 pub(crate) struct TantivyIndexFactory {
     worker: async_channel::Sender<Worker>,
@@ -242,6 +244,22 @@ fn handle_search(
     Ok((primary_keys, scores))
 }
 
+fn handle_stats(state: &IndexState) -> FtsStatsR {
+    let searcher = state.reader.searcher();
+    let num_docs = searcher.num_docs();
+    let segment_count = searcher.segment_readers().len();
+    let size_bytes = searcher
+        .space_usage()
+        .map_err(|e| anyhow!("fts: failed to compute space usage: {e}"))?
+        .total()
+        .get_bytes();
+    Ok(FtsStats {
+        num_docs,
+        size_bytes,
+        segment_count,
+    })
+}
+
 fn get_or_create_state<T: TableSearch>(
     states: &mut BTreeMap<IndexId, Arc<IndexState>>,
     table: &RwLock<T>,
@@ -361,6 +379,18 @@ pub(crate) fn new(
                         .spawn_blocking(move || {
                             let result =
                                 handle_search(&state, table.as_ref(), &index_key, &query, limit);
+                            _ = tx.send(result);
+                        })
+                        .await;
+                }
+                FtsIndex::Stats { index_key, tx } => {
+                    let Some(state) = get_state(&states, table.as_ref(), &index_key) else {
+                        _ = tx.send(Ok(FtsStats::default()));
+                        continue;
+                    };
+                    worker
+                        .spawn_blocking(move || {
+                            let result = handle_stats(&state);
                             _ = tx.send(result);
                         })
                         .await;
@@ -590,6 +620,35 @@ mod tests {
 
         assert_eq!(keys.len(), 1);
         assert_eq!(scores.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stats_reflects_doc_count_and_segments() {
+        let table = make_table_with_keys();
+        let sender = make_sender(table);
+
+        add_doc(&sender, 1, "hello world").await;
+        add_doc(&sender, 2, "foo bar").await;
+
+        let key = make_index_key();
+        let stats = sender.stats(key).await.unwrap();
+
+        assert_eq!(stats.num_docs, 2);
+        assert!(stats.segment_count > 0);
+        assert!(stats.size_bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn stats_for_unknown_index_returns_default() {
+        let table = make_table_with_keys();
+        let sender = make_sender(table);
+
+        let key = make_index_key();
+        let stats = sender.stats(key).await.unwrap();
+
+        assert_eq!(stats.num_docs, 0);
+        assert_eq!(stats.segment_count, 0);
+        assert_eq!(stats.size_bytes, 0);
     }
 
     #[tokio::test]

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -761,11 +761,19 @@ async fn post_index_bm25(
         return resp;
     }
 
+    let timer = state
+        .metrics
+        .latency
+        .with_label_values(&[keyspace.as_ref(), index_name.as_ref()])
+        .start_timer();
+
     let index_key = IndexKey::new(&keyspace, &index_name);
 
     let (fts_sender, primary_key_columns) = {
         let indexes = state.indexes.read().unwrap();
         let Some(entry) = indexes.get_fts(&index_key) else {
+            timer.observe_duration();
+
             let msg = format!("missing index: {keyspace}.{index_name}");
             debug!("post_index_bm25: {msg}");
             return (StatusCode::NOT_FOUND, msg).into_response();
@@ -773,6 +781,8 @@ async fn post_index_bm25(
         if entry.status() != crate::node_state::IndexStatus::Serving {
             match entry.progress() {
                 Progress::InProgress(percentage) => {
+                    timer.observe_duration();
+
                     let msg = format!(
                         "Index {keyspace}.{index_name} is not available yet as it is still being constructed, progress: {:.3}%",
                         percentage.get()
@@ -781,6 +791,8 @@ async fn post_index_bm25(
                     return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
                 }
                 Progress::Done => {
+                    timer.observe_duration();
+
                     let msg = format!(
                         "Index {keyspace}.{index_name} is not serving, but full scan did finish."
                     );
@@ -795,6 +807,8 @@ async fn post_index_bm25(
     let search_result = fts_sender
         .search(index_key, request.query, request.limit.into())
         .await;
+
+    timer.observe_duration();
 
     match search_result {
         Err(err) => {

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -5,6 +5,8 @@
 
 use crate::Filter;
 use crate::IndexKey;
+use crate::IndexName;
+use crate::KeyspaceName;
 use crate::Progress;
 use crate::Quantization;
 use crate::Restriction;
@@ -372,23 +374,54 @@ async fn get_index_status(
     }
 }
 
+async fn refresh_index_metrics(
+    state: &RoutesInnerState,
+    keyspace: KeyspaceName,
+    index_name: IndexName,
+) {
+    let key = IndexKey::new(&keyspace, &index_name);
+    let labels = [keyspace.as_ref(), index_name.as_ref()];
+
+    if let Some((index, _)) = state.engine.get_vs_index(key.clone()).await {
+        if let Ok(count) = index.count(key).await {
+            state
+                .metrics
+                .size
+                .with_label_values(&labels)
+                .set(count as f64);
+        }
+        return;
+    }
+
+    if let Some((index, _)) = state.engine.get_fts_index(key.clone()).await
+        && let Ok(stats) = index.stats(key).await
+    {
+        state
+            .metrics
+            .size
+            .with_label_values(&labels)
+            .set(stats.num_docs as f64);
+        state
+            .metrics
+            .fts_index_size_bytes
+            .with_label_values(&labels)
+            .set(stats.size_bytes as f64);
+        state
+            .metrics
+            .fts_segment_count
+            .with_label_values(&labels)
+            .set(stats.segment_count as f64);
+    }
+}
+
 async fn get_metrics(
     State(state): State<RoutesInnerState>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
     for (keyspace_str, index_name_str) in state.metrics.take_dirty_indexes() {
-        let keyspace = crate::KeyspaceName::from(keyspace_str);
-        let index_name = crate::IndexName::from(index_name_str);
-        let key = IndexKey::new(&keyspace, &index_name);
-        if let Some((index, _)) = state.engine.get_vs_index(key.clone()).await
-            && let Ok(count) = index.count(key).await
-        {
-            state
-                .metrics
-                .size
-                .with_label_values(&[keyspace.as_ref(), index_name.as_ref()])
-                .set(count as f64);
-        }
+        let keyspace = KeyspaceName::from(keyspace_str);
+        let index_name = IndexName::from(index_name_str);
+        refresh_index_metrics(&state, keyspace, index_name).await;
     }
     let metric_families = state.metrics.registry.gather();
 

--- a/crates/vector-store/src/metrics.rs
+++ b/crates/vector-store/src/metrics.rs
@@ -25,6 +25,8 @@ pub struct Metrics {
     pub cdc_handler_errors_total: CounterVec,
     pub cdc_reader_restarts_total: CounterVec,
     pub cdc_last_processed_timestamp_seconds: GaugeVec,
+    pub fts_index_size_bytes: GaugeVec,
+    pub fts_segment_count: GaugeVec,
     dirty_indexes: Arc<DashSet<(String, String)>>,
 }
 
@@ -139,6 +141,24 @@ impl Metrics {
         )
         .unwrap();
 
+        let fts_index_size_bytes = GaugeVec::new(
+            prometheus::Opts::new(
+                "fts_index_size_bytes",
+                "Total size of a full-text search index (bytes)",
+            ),
+            &["keyspace", "index_name"],
+        )
+        .unwrap();
+
+        let fts_segment_count = GaugeVec::new(
+            prometheus::Opts::new(
+                "fts_segment_count",
+                "Number of segments in a full-text search index",
+            ),
+            &["keyspace", "index_name"],
+        )
+        .unwrap();
+
         registry.register(Box::new(latency.clone())).unwrap();
         registry.register(Box::new(size.clone())).unwrap();
         registry.register(Box::new(modified.clone())).unwrap();
@@ -153,6 +173,12 @@ impl Metrics {
         registry
             .register(Box::new(cdc_last_processed_timestamp_seconds.clone()))
             .unwrap();
+        registry
+            .register(Box::new(fts_index_size_bytes.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(fts_segment_count.clone()))
+            .unwrap();
 
         Self {
             registry,
@@ -164,6 +190,8 @@ impl Metrics {
             cdc_handler_errors_total,
             cdc_reader_restarts_total,
             cdc_last_processed_timestamp_seconds,
+            fts_index_size_bytes,
+            fts_segment_count,
             dirty_indexes: Arc::new(DashSet::new()),
         }
     }
@@ -190,6 +218,12 @@ impl Metrics {
         let _ = self.size.remove_label_values(&[keyspace, index_name]);
         let _ = self
             .indexing_lag
+            .remove_label_values(&[keyspace, index_name]);
+        let _ = self
+            .fts_index_size_bytes
+            .remove_label_values(&[keyspace, index_name]);
+        let _ = self
+            .fts_segment_count
             .remove_label_values(&[keyspace, index_name]);
         for op in OPERATIONS {
             let _ = self
@@ -488,6 +522,68 @@ mod tests {
         assert!(
             output.contains(r#"reader="fine""#),
             "the fine reader's CDC metric series must be unaffected, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn fts_index_size_bytes_is_exported() {
+        let metrics = Metrics::new();
+
+        metrics
+            .fts_index_size_bytes
+            .with_label_values(&["ks", "idx"])
+            .set(1024.0);
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains("# TYPE fts_index_size_bytes gauge"),
+            "fts_index_size_bytes gauge missing from export:\n{output}"
+        );
+        assert!(
+            output.contains(r#"fts_index_size_bytes{index_name="idx",keyspace="ks"} 1024"#),
+            "expected observed value in export:\n{output}"
+        );
+    }
+
+    #[test]
+    fn fts_segment_count_is_exported() {
+        let metrics = Metrics::new();
+
+        metrics
+            .fts_segment_count
+            .with_label_values(&["ks", "idx"])
+            .set(3.0);
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            output.contains("# TYPE fts_segment_count gauge"),
+            "fts_segment_count gauge missing from export:\n{output}"
+        );
+        assert!(
+            output.contains(r#"fts_segment_count{index_name="idx",keyspace="ks"} 3"#),
+            "expected observed value in export:\n{output}"
+        );
+    }
+
+    #[test]
+    fn remove_index_labels_clears_fts_metrics() {
+        let metrics = Metrics::new();
+
+        metrics
+            .fts_index_size_bytes
+            .with_label_values(&["ks", "idx"])
+            .set(1024.0);
+        metrics
+            .fts_segment_count
+            .with_label_values(&["ks", "idx"])
+            .set(3.0);
+
+        metrics.remove_index_labels("ks", "idx");
+
+        let output = metric_families_text(&metrics);
+        assert!(
+            !output.contains(r#"keyspace="ks""#),
+            "metric output should not contain labels for deleted index, got:\n{output}"
         );
     }
 }

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -149,7 +149,7 @@ async fn fts_index_returns_proper_count() {
     .await;
 }
 
-async fn setup_fts_and_wait(
+pub(crate) async fn setup_fts_and_wait(
     documents: impl IntoIterator<Item = (Vec<CqlValue>, &str, u64)>,
     expected_count: usize,
 ) -> (

--- a/crates/vector-store/tests/integration/metrics.rs
+++ b/crates/vector-store/tests/integration/metrics.rs
@@ -5,6 +5,7 @@
 
 use crate::db_basic;
 use crate::db_basic::DbBasic;
+use crate::fts;
 use crate::usearch;
 use crate::wait_for;
 use httpclient::HttpClient;
@@ -81,6 +82,32 @@ async fn deleted_index_labels_absent_from_metrics_endpoint() {
     wait_for(
         || async { !client.get_metrics_text().await.contains(&expected_labels) },
         "Waiting for deleted index labels to disappear from /metrics",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn fts_index_metrics_present_in_metrics_endpoint() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _hold) = fts::setup_fts_and_wait(
+        [
+            (vec![CqlValue::Int(1)], "hello world", 10),
+            (vec![CqlValue::Int(2)], "foo bar", 20),
+        ],
+        2,
+    )
+    .await;
+
+    let expected_labels = format!(r#"index_name="{index_name}",keyspace="{keyspace_name}""#);
+
+    wait_for(
+        || async {
+            let metrics = client.get_metrics_text().await;
+            metrics.contains(&format!("fts_index_size_bytes{{{expected_labels}}}"))
+                && metrics.contains(&format!("fts_segment_count{{{expected_labels}}}"))
+        },
+        "Waiting for fts index metrics to appear in /metrics",
     )
     .await;
 }


### PR DESCRIPTION
Adds Prometheus metrics for full-text search (FTS) indexes, exposed via the existing `/metrics` endpoint.

New gauges, refreshed on scrape for indexes with pending writes:
- `fts_index_size_bytes` - in-memory size of a Tantivy index.
- `fts_segment_count` - number of tantivy segments in a Tantivy index.

Reused existing, index-type-agnostic instruments instead of duplicating them under an `fts_` prefix:
- `fts_query_latency_seconds` -> `request_latency_seconds` (now also timed around the `bm25` query handler)
- `fts_query_count_total` -> `request_latency_seconds_count` (comes for free with the histogram)
- `fts_index_doc_count` -> `index_size`
- `fts_indexing_rate` -> `index_modified` (raw counter; apply `rate()` in PromQL)
- `fts_indexing_lag_seconds` -> `indexing_lag_seconds` (only recorded for CDC-sourced writes, not full-scan indexing)

Deferred to a follow-up: `fts_merge_duration_seconds`. Tantivy has no completion hook for automatic background merges, so measuring it requires disabling auto-merge and driving/timing merges manually - a bigger, separate
change.

Fixes: VECTOR-629
Follow-up: VECTOR-743
