### PR TITLE
chore: update Rust to 1.97.0

### DIFF
--- a/crates/benchmark/src/data/mod.rs
+++ b/crates/benchmark/src/data/mod.rs
@@ -175,10 +175,7 @@ async fn read_buckets(path: &Path) -> BTreeMap<i64, u8> {
     };
     let mut buckets_reader = BufReader::new(file);
     let mut buckets = BTreeMap::new();
-    loop {
-        let Ok(id) = buckets_reader.read_i64().await else {
-            break;
-        };
+    while let Ok(id) = buckets_reader.read_i64().await {
         let Ok(bucket) = buckets_reader.read_u8().await else {
             break;
         };

--- a/crates/benchmark/src/data/parquet.rs
+++ b/crates/benchmark/src/data/parquet.rs
@@ -101,10 +101,7 @@ pub(crate) async fn dimension(path: Arc<PathBuf>, config: Arc<Config>) -> usize 
     .await
     .unwrap()
     .pipe(|builder| {
-        let mask = ProjectionMask::columns(
-            builder.parquet_schema(),
-            [&*config.embedding_column].into_iter(),
-        );
+        let mask = ProjectionMask::columns(builder.parquet_schema(), [&*config.embedding_column]);
         builder.with_projection(mask)
     })
     .build()
@@ -184,7 +181,7 @@ pub(crate) async fn ids_stream(path: Arc<PathBuf>, config: Arc<Config>) -> BoxSt
                         .pipe(|builder| {
                             let mask = ProjectionMask::columns(
                                 builder.parquet_schema(),
-                                [&*config.id_column].into_iter(),
+                                [&*config.id_column],
                             );
                             builder.with_projection(mask)
                         })
@@ -225,7 +222,7 @@ pub(crate) async fn vector_stream(
                         .pipe(|builder| {
                             let mask = ProjectionMask::columns(
                                 builder.parquet_schema(),
-                                [&*config.id_column, &*config.embedding_column].into_iter(),
+                                [&*config.id_column, &*config.embedding_column],
                             );
                             builder.with_projection(mask)
                         })
@@ -292,7 +289,7 @@ pub(crate) async fn queries(
     .pipe(|builder| {
         let mask = ProjectionMask::columns(
             builder.parquet_schema(),
-            [&*config.id_column, &*config.embedding_column].into_iter(),
+            [&*config.id_column, &*config.embedding_column],
         );
         builder.with_projection(mask)
     })
@@ -340,7 +337,7 @@ pub(crate) async fn queries(
     .pipe(|builder| {
         let mask = ProjectionMask::columns(
             builder.parquet_schema(),
-            [&*config.id_column, &*config.neighbors_id_column].into_iter(),
+            [&*config.id_column, &*config.neighbors_id_column],
         );
         builder.with_projection(mask)
     })

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -1156,7 +1156,7 @@ where
             })
         })
         .collect_vec();
-    stream::iter(tasks.into_iter())
+    stream::iter(tasks)
         .then(|task| async move { task.await.unwrap() })
         .fold(Duration::ZERO, |acc, x| async move { acc + x })
         .await

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.97.0"
 components = ["clippy", "rustfmt", "cargo"]


### PR DESCRIPTION
Update Rust dependency in toolchain from 1.94.0 to 1.97.0, the latest stable version.

Fixes: VECTOR-746