### PR TITLE
vector-store: distinguish 503 from ann/bm25 when node is bootstrapping

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -122,14 +122,7 @@
             }
           },
           "503": {
-            "description": "Service Unavailable. Indicates that a full scan of the index is in progress and the search cannot be performed at this time.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorMessage"
-                }
-              }
-            }
+            "$ref": "#/components/responses/IndexNotReadyResponse"
           }
         }
       }
@@ -223,14 +216,7 @@
             }
           },
           "503": {
-            "description": "Service Unavailable. Indicates that a full scan of the index is in progress and the search cannot be performed at this time.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorMessage"
-                }
-              }
-            }
+            "$ref": "#/components/responses/IndexNotReadyResponse"
           }
         }
       }
@@ -395,6 +381,42 @@
       "IndexName": {
         "type": "string",
         "description": "A name of the vector index in a db."
+      },
+      "IndexNotReadyReason": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "NODE_BOOTSTRAPPING"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "message",
+              "reason"
+            ],
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "INDEX_BUILDING"
+                ]
+              }
+            }
+          }
+        ]
       },
       "IndexStatus": {
         "type": "string",
@@ -931,6 +953,18 @@
           "format": "float"
         },
         "description": "The vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index."
+      }
+    },
+    "responses": {
+      "IndexNotReadyResponse": {
+        "description": "Service Unavailable. The index is not ready to serve requests. The body is a JSON object with a 'reason' field: 'NODE_BOOTSTRAPPING' when the node has not yet finished its startup sequence; 'INDEX_BUILDING' (with a 'message' field) when the node is healthy but this index is still being constructed.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/IndexNotReadyReason"
+            }
+          }
+        }
       }
     }
   },

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -151,6 +151,25 @@ pub struct IndexStatusResponse {
     pub count: usize,
 }
 
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+#[serde(tag = "reason", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum IndexNotReadyReason {
+    NodeBootstrapping,
+    IndexBuilding { message: String },
+}
+
+/// The 503 response shared by the ANN and BM25 search endpoints when the index
+/// is not ready to serve requests.
+#[derive(utoipa::ToResponse)]
+#[response(
+    description = "Service Unavailable. The index is not ready to serve requests. \
+The body is a JSON object with a 'reason' field: \
+'NODE_BOOTSTRAPPING' when the node has not yet finished its startup sequence; \
+'INDEX_BUILDING' (with a 'message' field) when the node is healthy but this index is still being constructed.",
+    content_type = "application/json"
+)]
+pub struct IndexNotReadyResponse(#[allow(dead_code)] IndexNotReadyReason);
+
 #[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 pub struct InfoResponse {
     /// Information about the underlying search engine.

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -107,7 +107,11 @@ use utoipa_swagger_ui::SwaggerUi;
     components(
         schemas(
             httpapi::KeyspaceName,
-            httpapi::IndexName
+            httpapi::IndexName,
+            httpapi::IndexNotReadyReason
+        ),
+        responses(
+            httpapi::IndexNotReadyResponse
         )
     ),
 )]
@@ -544,9 +548,7 @@ If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
         ),
         (
             status = 503,
-            description = "Service Unavailable. Indicates that a full scan of the index is in progress and the search cannot be performed at this time.",
-            content_type = "application/json",
-            body = ErrorMessage
+            response = httpapi::IndexNotReadyResponse
         )
     )
 )]
@@ -574,12 +576,14 @@ async fn post_index_ann(
         let index_key = IndexKey::new(&keyspace, &index_name);
         let (equality_cols, range_cols) = restriction_columns(&request.filter);
         let allow_filtering = request.filter.as_ref().is_some_and(|f| f.allow_filtering);
-        let (routed_key, index, primary_key_columns, filtering_columns, table_columns) = match state
-            .indexes
-            .read()
-            .unwrap()
-            .best_index(&index_key, &equality_cols, &range_cols)
-        {
+        let best_index_state =
+            state
+                .indexes
+                .read()
+                .unwrap()
+                .best_index(&index_key, &equality_cols, &range_cols);
+        let (routed_key, index, primary_key_columns, filtering_columns, table_columns) =
+            match best_index_state {
             indexes::BestIndexState::Serving {
                 key: routed_key,
                 index,
@@ -620,13 +624,18 @@ async fn post_index_ann(
 
                 match progress {
                     Progress::InProgress(percentage) => {
-                        let msg = format!(
-                            "Index {keyspace}.{index_name} is not available yet \
-                            as it is still being constructed, progress: {:.3}%",
-                            percentage.get()
+                        let reason = index_not_ready_reason(
+                            &state.node_state,
+                            &keyspace,
+                            &index_name,
+                            percentage,
+                        )
+                        .await;
+                        debug!(
+                            "post_index_ann: index {keyspace}.{index_name} not ready: {reason:?}"
                         );
-                        debug!("post_index_ann: {msg}");
-                        return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
+                        return (StatusCode::SERVICE_UNAVAILABLE, response::Json(reason))
+                            .into_response();
                     }
                     Progress::Done => {
                         let msg = format!(
@@ -783,9 +792,7 @@ If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
         ),
         (
             status = 503,
-            description = "Service Unavailable. Indicates that a full scan of the index is in progress and the search cannot be performed at this time.",
-            content_type = "application/json",
-            body = ErrorMessage
+            response = httpapi::IndexNotReadyResponse
         )
     )
 )]
@@ -809,7 +816,7 @@ async fn post_index_bm25(
 
     let index_key = IndexKey::new(&keyspace, &index_name);
 
-    let (fts_sender, primary_key_columns) = {
+    let serving_or_progress = {
         let indexes = state.indexes.read().unwrap();
         let Some(entry) = indexes.get_fts(&index_key) else {
             timer.observe_duration();
@@ -818,30 +825,31 @@ async fn post_index_bm25(
             debug!("post_index_bm25: {msg}");
             return (StatusCode::NOT_FOUND, msg).into_response();
         };
-        if entry.status() != crate::node_state::IndexStatus::Serving {
-            match entry.progress() {
-                Progress::InProgress(percentage) => {
-                    timer.observe_duration();
-
-                    let msg = format!(
-                        "Index {keyspace}.{index_name} is not available yet as it is still being constructed, progress: {:.3}%",
-                        percentage.get()
-                    );
-                    debug!("post_index_bm25: {msg}");
-                    return (StatusCode::SERVICE_UNAVAILABLE, msg).into_response();
-                }
-                Progress::Done => {
-                    timer.observe_duration();
-
-                    let msg = format!(
-                        "Index {keyspace}.{index_name} is not serving, but full scan did finish."
-                    );
-                    debug!("post_index_bm25: {msg}");
-                    return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
-                }
-            }
+        if entry.status() == crate::node_state::IndexStatus::Serving {
+            Ok((entry.index().clone(), entry.primary_key_columns().clone()))
+        } else {
+            Err(entry.progress())
         }
-        (entry.index().clone(), entry.primary_key_columns().clone())
+    };
+
+    let (fts_sender, primary_key_columns) = match serving_or_progress {
+        Ok(serving) => serving,
+        Err(Progress::InProgress(percentage)) => {
+            timer.observe_duration();
+
+            let reason =
+                index_not_ready_reason(&state.node_state, &keyspace, &index_name, percentage).await;
+            debug!("post_index_bm25: index {keyspace}.{index_name} not ready: {reason:?}");
+            return (StatusCode::SERVICE_UNAVAILABLE, response::Json(reason)).into_response();
+        }
+        Err(Progress::Done) => {
+            timer.observe_duration();
+
+            let msg =
+                format!("Index {keyspace}.{index_name} is not serving, but full scan did finish.");
+            debug!("post_index_bm25: {msg}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
+        }
     };
 
     let search_result = fts_sender
@@ -1358,6 +1366,25 @@ async fn get_status(State(state): State<RoutesInnerState>) -> Response {
         )),
     )
         .into_response()
+}
+
+async fn index_not_ready_reason(
+    node_state: &Sender<NodeState>,
+    keyspace: &crate::KeyspaceName,
+    index_name: &crate::IndexName,
+    percentage: crate::Percentage,
+) -> httpapi::IndexNotReadyReason {
+    if node_state.get_status().await == crate::node_state::NodeStatus::Serving {
+        httpapi::IndexNotReadyReason::IndexBuilding {
+            message: format!(
+                "Index {keyspace}.{index_name} is not available yet \
+                as it is still being constructed, progress: {:.3}%",
+                percentage.get()
+            ),
+        }
+    } else {
+        httpapi::IndexNotReadyReason::NodeBootstrapping
+    }
 }
 
 fn new_internals() -> Router<RoutesInnerState> {

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -68,6 +68,10 @@ fn make_scan_fn(rows: impl Iterator<Item = DbIndexedRow> + Send + Sync + 'static
     })
 }
 
+pub(crate) fn pending_scan_fn() -> ScanFn {
+    Box::new(|_tx| std::future::pending::<()>().boxed())
+}
+
 pub(crate) fn scan_fn_vectors<I>(items: I) -> ScanFn
 where
     I: IntoIterator<
@@ -207,6 +211,26 @@ impl DbBasic {
             bail!("a table {table_name} already exists in a keyspace");
         }
         keyspace.tables.insert(table_name, table);
+
+        db.create_new_schema_version();
+        Ok(())
+    }
+
+    pub(crate) fn add_vector_column(
+        &self,
+        keyspace_name: KeyspaceName,
+        table_name: TableName,
+        column_name: ColumnName,
+        dimensions: Dimensions,
+    ) -> anyhow::Result<()> {
+        let mut db = self.0.write().unwrap();
+
+        let table = db
+            .keyspaces
+            .get_mut(&keyspace_name)
+            .and_then(|keyspace| keyspace.tables.get_mut(&table_name))
+            .ok_or_else(|| anyhow!("a table {table_name} does not exist"))?;
+        table.dimensions.insert(column_name, dimensions);
 
         db.create_new_schema_version();
         Ok(())

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -9,6 +9,7 @@ use crate::db_basic::DbBasic;
 use crate::db_basic::ScanFn;
 use crate::db_basic::Table;
 use crate::wait_for;
+use httpapi::IndexNotReadyReason;
 use httpapi::IndexStatus;
 use httpclient::HttpClient;
 use reqwest::StatusCode;
@@ -29,8 +30,22 @@ use vector_store::IndexMetadata;
 use vector_store::IndexOptionsFts;
 use vector_store::NonemptyArc;
 use vector_store::NonemptyIteratorExt;
+use vector_store::Percentage;
 use vector_store::Timestamp;
 use vector_store::node_state::NodeState;
+
+fn fts_index_metadata(filtering_columns: impl IntoIterator<Item = ColumnName>) -> IndexMetadata {
+    IndexMetadata {
+        keyspace_name: "fts_ks".into(),
+        table_name: "documents".into(),
+        index_name: "fts_idx".into(),
+        target_columns: NonemptyArc::new(["content"]).unwrap(),
+        partitioning: DbIndexPartitioning::Global,
+        filtering_columns: filtering_columns.into_iter().collect(),
+        version: Uuid::new_v4().into(),
+        kind: IndexKind::Fts(IndexOptionsFts {}),
+    }
+}
 
 async fn setup_fts_store(
     primary_keys: impl IntoIterator<Item = ColumnName>,
@@ -55,16 +70,7 @@ async fn setup_fts_store(
     let (db_actor, db) = db_basic::new(node_state.clone());
 
     let columns: Arc<HashMap<_, _>> = Arc::new(columns.into_iter().collect());
-    let index = IndexMetadata {
-        keyspace_name: "fts_ks".into(),
-        table_name: "documents".into(),
-        index_name: "fts_idx".into(),
-        target_columns: NonemptyArc::new(["content"]).unwrap(),
-        partitioning: DbIndexPartitioning::Global,
-        filtering_columns: columns.keys().cloned().collect(),
-        version: Uuid::new_v4().into(),
-        kind: IndexKind::Fts(IndexOptionsFts {}),
-    };
+    let index = fts_index_metadata(columns.keys().cloned());
 
     db.add_table(
         index.keyspace_name.clone(),
@@ -156,6 +162,7 @@ pub(crate) async fn setup_fts_and_wait(
     HttpClient,
     httpapi::KeyspaceName,
     httpapi::IndexName,
+    DbBasic,
     impl Sized,
 ) {
     let docs: Vec<_> = documents
@@ -199,7 +206,8 @@ pub(crate) async fn setup_fts_and_wait(
         client,
         keyspace_name,
         index_name,
-        (server, config_tx, db, node_state),
+        db,
+        (server, config_tx, node_state),
     )
 }
 
@@ -207,7 +215,7 @@ pub(crate) async fn setup_fts_and_wait(
 async fn fts_bm25_search_returns_matching_docs() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait(
+    let (client, keyspace_name, index_name, _db, _hold) = setup_fts_and_wait(
         [
             (vec![CqlValue::Int(1)], "the quick brown fox", 10),
             (vec![CqlValue::Int(2)], "lazy dog sleeps all day", 20),
@@ -238,7 +246,7 @@ async fn fts_bm25_search_returns_matching_docs() {
 async fn fts_bm25_search_returns_empty_for_no_match() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) =
+    let (client, keyspace_name, index_name, _db, _hold) =
         setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
 
     let (primary_keys, scores) = client
@@ -258,7 +266,7 @@ async fn fts_bm25_search_returns_empty_for_no_match() {
 async fn fts_bm25_search_respects_limit() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait(
+    let (client, keyspace_name, index_name, _db, _hold) = setup_fts_and_wait(
         [
             (vec![CqlValue::Int(1)], "rust programming language", 10),
             (vec![CqlValue::Int(2)], "rust systems programming", 20),
@@ -287,7 +295,7 @@ async fn fts_bm25_search_respects_limit() {
 async fn fts_bm25_search_not_found_returns_404() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) =
+    let (client, keyspace_name, index_name, _db, _hold) =
         setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
 
     let _ = (keyspace_name, index_name);
@@ -304,28 +312,22 @@ async fn fts_bm25_search_not_found_returns_404() {
 }
 
 #[tokio::test]
-async fn fts_bm25_search_not_serving_returns_503() {
+async fn fts_bm25_search_returns_503_and_node_bootstrapping_reason_when_index_is_building_during_node_bootstrapping()
+ {
     crate::enable_tracing();
 
-    let fullscan_fn = |_| {
-        use futures::FutureExt;
-        async move {
-            // wait indefinitely to simulate a long-running indexing operation (Bootstrapping)
-            std::future::pending::<()>().await;
-        }
-        .boxed()
-    };
     let (run, index, _db, _node_state) = setup_fts_store(
         ["pk".into()],
         1,
         [("pk".to_string().into(), NativeType::Int)],
-        Some(Box::new(fullscan_fn)),
+        Some(db_basic::pending_scan_fn()),
         None,
     )
     .await;
     let (client, _server, _config_tx) = run.await;
-    let keyspace_name: httpapi::KeyspaceName = index.keyspace_name.clone().into();
-    let index_name: httpapi::IndexName = index.index_name.clone().into();
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
 
     wait_for(
         || async {
@@ -348,13 +350,73 @@ async fn fts_bm25_search_not_serving_returns_503() {
         .await;
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let reason: IndexNotReadyReason = response.json().await.unwrap();
+    assert_eq!(reason, IndexNotReadyReason::NodeBootstrapping);
+}
+
+#[tokio::test]
+async fn fts_bm25_search_returns_503_and_index_building_reason_when_index_is_building_while_node_is_serving()
+ {
+    crate::enable_tracing();
+
+    let (client, _keyspace_name, _index_name, db, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
+
+    // The node is already serving its first index. A second index added now is
+    // non-initial, so it stays bootstrapping while the node keeps serving.
+    let index = IndexMetadata {
+        index_name: "fts_idx_building".into(),
+        ..fts_index_metadata([ColumnName::from("pk")])
+    };
+    db.add_index(index.clone(), Some(db_basic::pending_scan_fn()), None)
+        .unwrap();
+    db.set_next_full_scan_progress(vector_store::Progress::InProgress(
+        Percentage::try_from(75.0).unwrap(),
+    ));
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Bootstrapping)
+        },
+        "Waiting for FTS index to be bootstrapping",
+    )
+    .await;
+
+    let response = client
+        .post_bm25(
+            &keyspace_name,
+            &index_name,
+            "hello".into(),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let reason: IndexNotReadyReason = response.json().await.unwrap();
+    let IndexNotReadyReason::IndexBuilding { message } = reason else {
+        panic!("expected IndexBuilding, got {reason:?}");
+    };
+    assert!(
+        message.contains(&format!("{keyspace_name}.{index_name}")),
+        "unexpected message: {message}"
+    );
+    assert!(
+        message.contains("progress: 75.000%"),
+        "unexpected message: {message}"
+    );
 }
 
 #[tokio::test]
 async fn fts_empty_index_has_zero_count() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait([], 0).await;
+    let (client, keyspace_name, index_name, _db, _hold) = setup_fts_and_wait([], 0).await;
 
     let status = client
         .index_status(&keyspace_name, &index_name)
@@ -369,7 +431,7 @@ async fn fts_empty_index_has_zero_count() {
 async fn fts_empty_index_returns_empty_bm25_results() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) = setup_fts_and_wait([], 0).await;
+    let (client, keyspace_name, index_name, _db, _hold) = setup_fts_and_wait([], 0).await;
 
     let (primary_keys, scores) = client
         .bm25(
@@ -388,7 +450,7 @@ async fn fts_empty_index_returns_empty_bm25_results() {
 async fn fts_index_appears_in_indexes_list() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) =
+    let (client, keyspace_name, index_name, _db, _hold) =
         setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
 
     let indexes = client.indexes().await;

--- a/crates/vector-store/tests/integration/metrics.rs
+++ b/crates/vector-store/tests/integration/metrics.rs
@@ -91,7 +91,7 @@ async fn deleted_index_labels_absent_from_metrics_endpoint() {
 async fn fts_index_metrics_present_in_metrics_endpoint() {
     crate::enable_tracing();
 
-    let (client, keyspace_name, index_name, _hold) = fts::setup_fts_and_wait(
+    let (client, keyspace_name, index_name, _db, _hold) = fts::setup_fts_and_wait(
         [
             (vec![CqlValue::Int(1)], "hello world", 10),
             (vec![CqlValue::Int(2)], "foo bar", 20),

--- a/crates/vector-store/tests/integration/usearch.rs
+++ b/crates/vector-store/tests/integration/usearch.rs
@@ -11,6 +11,7 @@ use crate::db_basic::ScanFn;
 use crate::db_basic::Table;
 use crate::wait_for;
 use crate::wait_for_value;
+use httpapi::IndexNotReadyReason;
 use httpapi::IndexStatus;
 use httpapi::PostIndexAnnFilter;
 use httpapi::PostIndexAnnResponse;
@@ -518,7 +519,7 @@ async fn ann_returns_bad_request_when_filtering_required_but_not_allowed() {
 }
 
 #[tokio::test]
-async fn ann_fail_while_building() {
+async fn ann_fail_while_building_when_node_is_bootstrapping() {
     crate::enable_tracing();
     let (run, index, db, _node_state) = setup_store(
         test_config(),
@@ -529,9 +530,7 @@ async fn ann_fail_while_building() {
             ("pk".to_string().into(), NativeType::Int),
             ("ck".to_string().into(), NativeType::Text),
         ],
-        Some(Box::new(|_tx| {
-            futures::FutureExt::boxed(std::future::pending::<()>())
-        })),
+        Some(db_basic::pending_scan_fn()),
         None,
     )
     .await;
@@ -565,9 +564,89 @@ async fn ann_fail_while_building() {
         .await;
 
     assert_eq!(result.status(), StatusCode::SERVICE_UNAVAILABLE);
-    assert_eq!(
-        result.text().await.unwrap(),
-        "Index vector.ann is not available yet as it is still being constructed, progress: 33.333%"
+    let reason: IndexNotReadyReason = result.json().await.unwrap();
+    assert_eq!(reason, IndexNotReadyReason::NodeBootstrapping);
+}
+
+#[tokio::test]
+async fn ann_fail_while_building_when_node_is_serving() {
+    crate::enable_tracing();
+
+    let (serving_index, client, db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors([(
+            [CqlValue::Int(1)].into(),
+            Some(vec![1., 1., 1.].into()),
+            [].into(),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+        Some(1),
+    )
+    .await;
+
+    let index: IndexMetadata = IndexMetadata {
+        index_name: "ann_building".into(),
+        target_columns: NonemptyArc::new(["embedding2"]).unwrap(),
+        version: uuid::Uuid::new_v4().into(),
+        ..serving_index
+    };
+    // Add new column to the table so that the new index will be created on a new column.
+    // This allows the routing mechanism to always route to this index.
+    // Otherwise, when both indexes are on the same column, the routing mechanism will always route to the serving index.
+    db.add_vector_column(
+        index.keyspace_name.clone(),
+        index.table_name.clone(),
+        index.target_columns.first().clone(),
+        index.vs().unwrap().dimensions,
+    )
+    .unwrap();
+    // Add second index that is Bootstrapping (pending_scan_fn). So now we have node Serving and this index Bootstrapping - a good state to test desired scenario.
+    db.add_index(index.clone(), Some(db_basic::pending_scan_fn()), None)
+        .unwrap();
+    db.set_next_full_scan_progress(vector_store::Progress::InProgress(
+        Percentage::try_from(75.0).unwrap(),
+    ));
+
+    let keyspace_name: httpapi::KeyspaceName = index.keyspace_name.into();
+    let index_name: httpapi::IndexName = index.index_name.into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Bootstrapping)
+        },
+        "Waiting for index to be bootstrapping",
+    )
+    .await;
+
+    let result = client
+        .post_ann(
+            &keyspace_name,
+            &index_name,
+            vec![1.0, 2.0, 3.0].into(),
+            None,
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(result.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let reason: IndexNotReadyReason = result.json().await.unwrap();
+    let IndexNotReadyReason::IndexBuilding { message } = reason else {
+        panic!("expected IndexBuilding, got {reason:?}");
+    };
+    assert!(
+        message.contains(&format!("{keyspace_name}.{index_name}")),
+        "unexpected message: {message}"
+    );
+    assert!(
+        message.contains("progress: 75.000%"),
+        "unexpected message: {message}"
     );
 }
 


### PR DESCRIPTION
When an ANN or BM25 request is made while the index is not yet serving, the 503 response body now contains a JSON object with a 'reason' field that lets clients differentiate between two distinct cases without making a separate /api/v1/status call (which would introduce a TOCTOU race condition):

  {"reason":"NODE_BOOTSTRAPPING"}
    The whole node has not finished its startup sequence and is not
    ready to serve any traffic. Clients should treat this as a
    node-level outage and trigger high-availability failover.

  {"reason":"INDEX_BUILDING","progress":P}
    The node is healthy (SERVING) but this specific index is still
    being constructed after creation. Clients should surface this
    error to the caller rather than failing over.

Reference: SCYLLADB-3209