### PR TITLE
vector-store: create an in memory diskann provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,7 +1221,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1793,6 +1802,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "diskann-providers"
+version = "0.55.0"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+dependencies = [
+ "arc-swap",
+ "bincode",
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "diskann",
+ "diskann-quantization",
+ "diskann-utils",
+ "diskann-vector",
+ "diskann-wide",
+ "futures-util",
+ "half",
+ "hashbrown 0.16.0",
+ "num-traits",
+ "prost",
+ "rand 0.9.4",
+ "rand_distr",
+ "rayon",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "diskann-quantization"
+version = "0.55.0"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "diskann-utils",
+ "diskann-vector",
+ "diskann-wide",
+ "half",
+ "rand 0.9.4",
+ "rayon",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "diskann-utils"
 version = "0.55.0"
 source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
@@ -1804,6 +1858,7 @@ dependencies = [
  "half",
  "rand 0.9.4",
  "rand_distr",
+ "rayon",
  "thiserror 2.0.18",
 ]
 
@@ -2021,7 +2076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2747,7 +2802,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2971,7 +3026,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3514,7 +3569,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4148,7 +4203,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4185,9 +4240,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4556,7 +4611,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5309,7 +5364,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6102,6 +6157,8 @@ dependencies = [
  "dashmap 6.1.0",
  "derive_more",
  "diskann",
+ "diskann-providers",
+ "diskann-vector",
  "dotenvy",
  "futures",
  "hotpath",
@@ -6347,7 +6404,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
 diskann = { git = "https://github.com/microsoft/DiskANN.git", rev = "541472a8d0bbfa4d458ec1b909e1d41a18adaabc" }
+diskann-providers = { git = "https://github.com/microsoft/DiskANN.git", rev = "541472a8d0bbfa4d458ec1b909e1d41a18adaabc" }
+diskann-vector = { git = "https://github.com/microsoft/DiskANN.git", rev = "541472a8d0bbfa4d458ec1b909e1d41a18adaabc" }
 dotenvy = "0.15.7"
 e2etest = "0.2.0"
 e2etest-dns = "0.1.0"

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -41,6 +41,8 @@ console-subscriber = {workspace = true, optional = true}
 dashmap.workspace = true
 derive_more.workspace = true
 diskann.workspace = true
+diskann-providers.workspace = true
+diskann-vector.workspace = true
 dotenvy.workspace = true
 futures.workspace = true
 hotpath.workspace = true

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -4,12 +4,30 @@
  */
 
 use crate::Config;
+use crate::Dimensions;
+use crate::DiskannAlpha;
+use crate::SpaceType;
 use crate::VsIndexFactory;
 use crate::memory::Memory;
 use crate::perf;
 use crate::table::Table;
 use crate::vs_index::actor::VsIndex;
 use crate::vs_index::factory::VsIndexConfiguration;
+use anyhow::Context;
+use diskann::graph::Config as DiskannConfig;
+use diskann::graph::DiskANNIndex;
+use diskann::graph::config::Builder;
+use diskann::graph::config::MaxDegree;
+use diskann::graph::config::defaults::ALPHA as DISKANN_DEFAULT_ALPHA;
+use diskann_providers::model::graph::provider::async_::FastMemoryVectorProviderAsync;
+use diskann_providers::model::graph::provider::async_::TableDeleteProviderAsync;
+use diskann_providers::model::graph::provider::async_::common::NoStore;
+use diskann_providers::model::graph::provider::async_::common::TableBasedDeletes;
+use diskann_providers::model::graph::provider::async_::inmem::CreateFullPrecision;
+use diskann_providers::model::graph::provider::async_::inmem::DefaultProvider;
+use diskann_providers::model::graph::provider::async_::inmem::DefaultProviderParameters;
+use diskann_vector::distance::Metric;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tokio::sync::mpsc;
@@ -19,7 +37,14 @@ use tracing::debug;
 use tracing::debug_span;
 use tracing::warn;
 
-pub struct DiskannIndexFactory;
+const MAX_POINTS: NonZeroUsize = NonZeroUsize::new(1_000_000).unwrap();
+
+type DiskannProvider =
+    DefaultProvider<FastMemoryVectorProviderAsync<f32>, NoStore, TableDeleteProviderAsync>;
+
+pub struct DiskannIndexFactory {
+    alpha: DiskannAlpha,
+}
 
 impl VsIndexFactory for DiskannIndexFactory {
     fn create_index(
@@ -28,7 +53,25 @@ impl VsIndexFactory for DiskannIndexFactory {
         _table: Arc<RwLock<Table>>,
         _memory: mpsc::Sender<Memory>,
     ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
-        new(index.key)
+        let params = DiskannParams::new(&index, self.alpha, MAX_POINTS)?;
+        let provider_params = DefaultProviderParameters::simple(
+            usize::from(params.max_points),
+            usize::from(params.dim.0),
+            params.metric,
+            u32::from(params.config.max_degree_u32()),
+        );
+
+        let provider: DiskannProvider = DefaultProvider::new_empty(
+            provider_params,
+            CreateFullPrecision::<f32>::new(usize::from(params.dim.0), None),
+            NoStore,
+            TableBasedDeletes,
+        )
+        .context("failed to create DiskANN provider")?;
+
+        let diskann_index = DiskANNIndex::new(params.config, provider, None);
+
+        new(index.key, diskann_index)
     }
 
     fn index_engine_version(&self) -> String {
@@ -37,12 +80,21 @@ impl VsIndexFactory for DiskannIndexFactory {
 }
 
 pub fn new_diskann(
-    _config_rx: watch::Receiver<Arc<Config>>,
+    mut config_rx: watch::Receiver<Arc<Config>>,
 ) -> anyhow::Result<DiskannIndexFactory> {
-    Ok(DiskannIndexFactory)
+    let config = config_rx.borrow_and_update();
+
+    Ok(DiskannIndexFactory {
+        alpha: config
+            .diskann_alpha
+            .unwrap_or(DiskannAlpha::new(DISKANN_DEFAULT_ALPHA).unwrap()),
+    })
 }
 
-fn new(index_key: crate::IndexKey) -> anyhow::Result<mpsc::Sender<VsIndex>> {
+fn new(
+    index_key: crate::IndexKey,
+    index: DiskANNIndex<DiskannProvider>,
+) -> anyhow::Result<mpsc::Sender<VsIndex>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
     tokio::spawn(perf::hotpath_async(
@@ -67,6 +119,7 @@ fn new(index_key: crate::IndexKey) -> anyhow::Result<mpsc::Sender<VsIndex>> {
                         }
                     }
                 }
+                drop(index);
 
                 debug!("finished");
             }
@@ -75,4 +128,111 @@ fn new(index_key: crate::IndexKey) -> anyhow::Result<mpsc::Sender<VsIndex>> {
     ));
 
     Ok(tx)
+}
+
+#[derive(Clone)]
+struct DiskannParams {
+    config: DiskannConfig,
+    metric: Metric,
+    dim: Dimensions,
+    max_points: NonZeroUsize,
+}
+
+impl DiskannParams {
+    fn new(
+        cfg: &VsIndexConfiguration,
+        alpha: DiskannAlpha,
+        max_points: NonZeroUsize,
+    ) -> anyhow::Result<Self> {
+        let metric: Metric = cfg.space_type.try_into()?;
+
+        let mut builder = Builder::new(
+            cfg.connectivity.0,
+            MaxDegree::default_slack(),
+            cfg.expansion_add.0,
+            metric.into(),
+        );
+
+        builder.alpha(alpha.get());
+
+        let config = builder
+            .build()
+            .context("failed to build DiskANN configuration")?;
+
+        Ok(Self {
+            config,
+            metric,
+            dim: cfg.dimensions,
+            max_points,
+        })
+    }
+}
+
+impl TryFrom<SpaceType> for Metric {
+    type Error = anyhow::Error;
+
+    fn try_from(space_type: SpaceType) -> anyhow::Result<Self> {
+        match space_type {
+            SpaceType::Euclidean => Ok(Self::L2),
+            SpaceType::Cosine => Ok(Self::Cosine),
+            SpaceType::DotProduct => Ok(Self::InnerProduct),
+            SpaceType::Hamming => {
+                anyhow::bail!("DiskANN does not support Hamming space type")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Connectivity;
+    use crate::ExpansionAdd;
+    use crate::ExpansionSearch;
+    use crate::IndexKey;
+    use crate::IndexName;
+    use crate::KeyspaceName;
+    use crate::Quantization;
+
+    #[test]
+    fn diskann_metric_try_from_space_type() {
+        assert_eq!(Metric::try_from(SpaceType::Euclidean).unwrap(), Metric::L2);
+        assert_eq!(Metric::try_from(SpaceType::Cosine).unwrap(), Metric::Cosine);
+        assert_eq!(
+            Metric::try_from(SpaceType::DotProduct).unwrap(),
+            Metric::InnerProduct
+        );
+        assert!(Metric::try_from(SpaceType::Hamming).is_err());
+    }
+
+    #[test]
+    fn diskann_params_try_from_index_configuration() {
+        let vs_config = VsIndexConfiguration {
+            key: IndexKey::new(
+                &KeyspaceName::from("ks".to_string()),
+                &IndexName::from("tbl".to_string()),
+            ),
+            dimensions: NonZeroUsize::new(3).unwrap().into(),
+            connectivity: Connectivity(16),
+            expansion_add: ExpansionAdd(64),
+            expansion_search: ExpansionSearch(32),
+            space_type: SpaceType::Euclidean,
+            quantization: Quantization::F32,
+        };
+
+        let params = DiskannParams::new(
+            &vs_config,
+            DiskannAlpha::new(DISKANN_DEFAULT_ALPHA).unwrap(),
+            MAX_POINTS,
+        )
+        .unwrap();
+
+        assert_eq!(
+            params.config.pruned_degree(),
+            NonZeroUsize::new(16).unwrap()
+        );
+        assert_eq!(usize::from(params.dim.0), 3);
+        assert_eq!(params.config.l_build(), NonZeroUsize::new(64).unwrap());
+        assert_eq!(params.metric, Metric::L2);
+    }
 }


### PR DESCRIPTION
In this PR a DiskANNIndex is created in a in-memory `DefaultProvider` mode using the parameters mapped from `VsIndexConfiguration`

Fixes: VECTOR-717