### PR TITLE
docs: bump docker compose examples to ScyllaDB 2026.2.2 and Vector St…

### DIFF
--- a/docs/examples/docker/docker-compose-alternator.yml
+++ b/docs/examples/docker/docker-compose-alternator.yml
@@ -7,7 +7,7 @@
 
 services:
   scylla:
-    image: scylladb/scylla:2026.2.0-rc3
+    image: scylladb/scylla:2026.2.2
     container_name: scylla-alternator
     command: >
       --smp 2
@@ -28,7 +28,7 @@ services:
       - vector-net
 
   vector-store:
-    image: scylladb/vector-store:1.8.0
+    image: scylladb/vector-store:1.9.1
     container_name: vector-store
     environment:
       VECTOR_STORE_URI: "0.0.0.0:6080"

--- a/docs/examples/docker/docker-compose.yml
+++ b/docs/examples/docker/docker-compose.yml
@@ -4,7 +4,7 @@
 
 services:
   scylla:
-    image: scylladb/scylla:2026.1.4
+    image: scylladb/scylla:2026.2.2
     container_name: scylla
     command: >
       --smp 2
@@ -22,7 +22,7 @@ services:
       - vector-net
 
   vector-store:
-    image: scylladb/vector-store:1.6.0
+    image: scylladb/vector-store:1.9.1
     container_name: vector-store
     environment:
       VECTOR_STORE_URI: "0.0.0.0:6080"


### PR DESCRIPTION
Update the example docker-compose.yml and docker-compose-alternator.yml in docs/examples/docker to pin the latest ScyllaDB (2026.2.2) and Vector Store (1.9.1) images.