### PR TITLE
vector-store: diskann basic queries

### DIFF
--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -19,6 +19,7 @@ use crate::table::PrimaryId;
 use crate::table::Table;
 use crate::table::TableSearch;
 use crate::vs_index::actor::AnnR;
+use crate::vs_index::actor::CountR;
 use crate::vs_index::actor::VsIndex;
 use crate::vs_index::factory::VsIndexConfiguration;
 use crate::vs_index::validator;
@@ -164,8 +165,7 @@ fn new(
                             )));
                         }
                         VsIndex::Count { tx, .. } => {
-                            _ = tx
-                                .send(Err(anyhow::anyhow!("DiskANN index is not implemented yet")));
+                            _ = tx.send(state.count());
                         }
                     }
                 }
@@ -351,6 +351,10 @@ impl<T: TableSearch + Send + Sync + 'static> State<T> {
             |it| it.unzip(),
         )?;
         Ok((primary_keys, distances))
+    }
+
+    fn count(&self) -> CountR {
+        Ok(self.id_map.len())
     }
 }
 

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -6,6 +6,10 @@
 use crate::Config;
 use crate::Dimensions;
 use crate::DiskannAlpha;
+use crate::Distance;
+use crate::IndexKey;
+use crate::Limit;
+use crate::PartitionId;
 use crate::SpaceType;
 use crate::Vector;
 use crate::VsIndexFactory;
@@ -13,15 +17,22 @@ use crate::memory::Memory;
 use crate::perf;
 use crate::table::PrimaryId;
 use crate::table::Table;
+use crate::table::TableSearch;
+use crate::vs_index::actor::AnnR;
 use crate::vs_index::actor::VsIndex;
 use crate::vs_index::factory::VsIndexConfiguration;
+use crate::vs_index::validator;
 use anyhow::Context;
 use diskann::graph::Config as DiskannConfig;
 use diskann::graph::DiskANNIndex;
 use diskann::graph::config::Builder;
 use diskann::graph::config::MaxDegree;
 use diskann::graph::config::defaults::ALPHA as DISKANN_DEFAULT_ALPHA;
+use diskann::graph::index::SearchStats;
+use diskann::graph::search::Knn;
 use diskann::graph::strategy::FullPrecision;
+use diskann::neighbor::BackInserter;
+use diskann::neighbor::Neighbor;
 use diskann::provider::DefaultContext;
 use diskann::provider::Delete;
 use diskann_providers::model::graph::provider::async_::FastMemoryVectorProviderAsync;
@@ -32,15 +43,18 @@ use diskann_providers::model::graph::provider::async_::inmem::CreateFullPrecisio
 use diskann_providers::model::graph::provider::async_::inmem::DefaultProvider;
 use diskann_providers::model::graph::provider::async_::inmem::DefaultProviderParameters;
 use diskann_vector::distance::Metric;
+use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
+use tracing::trace;
 use tracing::warn;
 
 const MAX_POINTS: NonZeroUsize = NonZeroUsize::new(1_000_000).unwrap();
@@ -56,7 +70,7 @@ impl VsIndexFactory for DiskannIndexFactory {
     fn create_index(
         &self,
         index: VsIndexConfiguration,
-        _table: Arc<RwLock<Table>>,
+        table: Arc<RwLock<Table>>,
         _memory: mpsc::Sender<Memory>,
     ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
         let params = DiskannParams::new(&index, self.alpha, MAX_POINTS)?;
@@ -75,9 +89,9 @@ impl VsIndexFactory for DiskannIndexFactory {
         )
         .context("failed to create DiskANN provider")?;
 
-        let diskann_index = DiskANNIndex::new(params.config, provider, None);
+        let diskann_index = DiskANNIndex::new(params.config.clone(), provider, None);
 
-        new(index.key, diskann_index)
+        new(index.key, diskann_index, params, table)
     }
 
     fn index_engine_version(&self) -> String {
@@ -98,17 +112,20 @@ pub fn new_diskann(
 }
 
 fn new(
-    index_key: crate::IndexKey,
+    index_key: IndexKey,
     index: DiskANNIndex<DiskannProvider>,
+    params: DiskannParams,
+    table: Arc<RwLock<impl TableSearch + Send + Sync + 'static>>,
 ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
+    let span_key = index_key.clone();
     tokio::spawn(perf::hotpath_async(
         {
             async move {
                 debug!("starting");
 
-                let mut state = State::new(index);
+                let mut state = State::new(index, index_key, params, table);
 
                 while let Some(msg) = rx.recv().await {
                     match msg {
@@ -130,9 +147,21 @@ fn new(
                         VsIndex::RemovePartition { .. } => {
                             warn!("not implemented yet");
                         }
-                        VsIndex::Ann { tx, .. } | VsIndex::FilteredAnn { tx, .. } => {
-                            _ = tx
-                                .send(Err(anyhow::anyhow!("DiskANN index is not implemented yet")));
+                        VsIndex::Ann {
+                            embedding,
+                            limit,
+                            tx,
+                            ..
+                        } => {
+                            if let Some(tx) = validate_dimensions(tx, &embedding, state.params.dim)
+                            {
+                                _ = tx.send(state.ann(embedding, limit).await);
+                            }
+                        }
+                        VsIndex::FilteredAnn { tx, .. } => {
+                            _ = tx.send(Err(anyhow::anyhow!(
+                                "DiskANN index does not support filtered search"
+                            )));
                         }
                         VsIndex::Count { tx, .. } => {
                             _ = tx
@@ -144,7 +173,7 @@ fn new(
                 debug!("finished");
             }
         }
-        .instrument(debug_span!("diskann", "{index_key}")),
+        .instrument(debug_span!("diskann", "{span_key}")),
     ));
 
     Ok(tx)
@@ -193,15 +222,26 @@ impl IdMap {
 }
 
 /// Mutable actor state for the DiskANN index.
-struct State {
+struct State<T: TableSearch + Send + Sync + 'static> {
     index: DiskANNIndex<DiskannProvider>,
+    index_key: IndexKey,
+    params: DiskannParams,
+    table: Arc<RwLock<T>>,
     id_map: IdMap,
 }
 
-impl State {
-    fn new(index: DiskANNIndex<DiskannProvider>) -> Self {
+impl<T: TableSearch + Send + Sync + 'static> State<T> {
+    fn new(
+        index: DiskANNIndex<DiskannProvider>,
+        index_key: IndexKey,
+        params: DiskannParams,
+        table: Arc<RwLock<T>>,
+    ) -> Self {
         Self {
             index,
+            index_key,
+            params,
+            table,
             id_map: IdMap::default(),
         }
     }
@@ -235,14 +275,110 @@ impl State {
 
         self.id_map.remove(&primary_id);
     }
+
+    async fn search(
+        &self,
+        embedding: &Vector,
+        k: usize,
+    ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<(PrimaryId, Distance)>>> {
+        let space_type = self.params.space_type;
+        let dimensions = embedding.dim();
+
+        let l_value = self.params.l_default.get().max(k);
+        let k = k.min(self.params.max_points.get());
+        let params = Knn::new(k, l_value, Some(self.params.beam_width.get()))
+            .context("failed to build DiskANN search parameters")?;
+
+        let mut neighbors = vec![Neighbor::<u32>::default(); params.k_value().get()];
+        let SearchStats { result_count, .. } = self
+            .index
+            .search(
+                params,
+                &FullPrecision,
+                &DefaultContext,
+                embedding.as_slice(),
+                &mut BackInserter::new(neighbors.as_mut_slice()),
+            )
+            .await?;
+
+        neighbors.truncate(result_count as usize);
+        Ok(neighbors.into_iter().filter_map(move |neighbor| {
+            let primary_id = self.id_map.resolve(neighbor.id)?;
+            let raw_distance = match space_type {
+                SpaceType::DotProduct => neighbor.distance + 1.0,
+                _ => neighbor.distance,
+            };
+            Some(
+                Distance::try_from((raw_distance, space_type, dimensions))
+                    .map(|distance| (primary_id, distance)),
+            )
+        }))
+    }
+
+    async fn ann(&self, embedding: Vector, limit: Limit) -> AnnR {
+        let partition_id: PartitionId = {
+            let table = self.table.read().unwrap();
+            if let Some((partition_id, _)) = table.partition_id(&self.index_key, None) {
+                partition_id
+            } else {
+                warn!(
+                    "partition id not found for index key {} during ann",
+                    self.index_key
+                );
+                return Ok((vec![], vec![]));
+            }
+        };
+
+        let matches = self
+            .search(&embedding, limit.0.get())
+            .await
+            .context("ann search failed")?;
+
+        let table = self.table.read().unwrap();
+        let (primary_keys, distances) = itertools::process_results(
+            matches.filter_map_ok(|(primary_id, distance)| {
+                table
+                    .primary_key(partition_id, primary_id)
+                    .or_else(|| {
+                        debug!(
+                            "not defined primary key for partition_id {partition_id:?} \
+                                        and primary_id {primary_id:?}",
+                        );
+                        None
+                    })
+                    .map(|primary_key| (primary_key, distance))
+            }),
+            |it| it.unzip(),
+        )?;
+        Ok((primary_keys, distances))
+    }
+}
+
+#[hotpath::measure]
+fn validate_dimensions(
+    tx_ann: oneshot::Sender<AnnR>,
+    embedding: &Vector,
+    dimensions: Dimensions,
+) -> Option<oneshot::Sender<AnnR>> {
+    if let Err(err) = validator::embedding_dimensions(embedding, dimensions) {
+        tx_ann
+            .send(Err(err))
+            .unwrap_or_else(|_| trace!("validate_dimensions: unable to send response"));
+        None
+    } else {
+        Some(tx_ann)
+    }
 }
 
 #[derive(Clone)]
 struct DiskannParams {
     config: DiskannConfig,
     metric: Metric,
+    space_type: SpaceType,
     dim: Dimensions,
     max_points: NonZeroUsize,
+    l_default: NonZeroUsize,
+    beam_width: NonZeroUsize,
 }
 
 impl DiskannParams {
@@ -266,11 +402,19 @@ impl DiskannParams {
             .build()
             .context("failed to build DiskANN configuration")?;
 
+        let l_default = NonZeroUsize::new(cfg.expansion_search.0)
+            .context("expansion_search (DiskANN query search list size L) must be non-zero")?;
+        let beam_width = NonZeroUsize::new(cfg.expansion_search.0)
+            .context("expansion_search (DiskANN beam width) must be non-zero")?;
+
         Ok(Self {
             config,
             metric,
+            space_type: cfg.space_type,
             dim: cfg.dimensions,
             max_points,
+            l_default,
+            beam_width,
         })
     }
 }
@@ -341,6 +485,9 @@ mod tests {
         assert_eq!(usize::from(params.dim.0), 3);
         assert_eq!(params.config.l_build(), NonZeroUsize::new(64).unwrap());
         assert_eq!(params.metric, Metric::L2);
+        assert_eq!(params.l_default, NonZeroUsize::new(32).unwrap());
+        assert_eq!(params.beam_width, NonZeroUsize::new(32).unwrap());
+        assert_eq!(params.space_type, SpaceType::Euclidean);
     }
 
     #[test]

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -7,9 +7,11 @@ use crate::Config;
 use crate::Dimensions;
 use crate::DiskannAlpha;
 use crate::SpaceType;
+use crate::Vector;
 use crate::VsIndexFactory;
 use crate::memory::Memory;
 use crate::perf;
+use crate::table::PrimaryId;
 use crate::table::Table;
 use crate::vs_index::actor::VsIndex;
 use crate::vs_index::factory::VsIndexConfiguration;
@@ -19,6 +21,9 @@ use diskann::graph::DiskANNIndex;
 use diskann::graph::config::Builder;
 use diskann::graph::config::MaxDegree;
 use diskann::graph::config::defaults::ALPHA as DISKANN_DEFAULT_ALPHA;
+use diskann::graph::strategy::FullPrecision;
+use diskann::provider::DefaultContext;
+use diskann::provider::Delete;
 use diskann_providers::model::graph::provider::async_::FastMemoryVectorProviderAsync;
 use diskann_providers::model::graph::provider::async_::TableDeleteProviderAsync;
 use diskann_providers::model::graph::provider::async_::common::NoStore;
@@ -27,6 +32,7 @@ use diskann_providers::model::graph::provider::async_::inmem::CreateFullPrecisio
 use diskann_providers::model::graph::provider::async_::inmem::DefaultProvider;
 use diskann_providers::model::graph::provider::async_::inmem::DefaultProviderParameters;
 use diskann_vector::distance::Metric;
+use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -102,11 +108,26 @@ fn new(
             async move {
                 debug!("starting");
 
+                let mut state = State::new(index);
+
                 while let Some(msg) = rx.recv().await {
                     match msg {
-                        VsIndex::AddVector { .. }
-                        | VsIndex::RemoveVector { .. }
-                        | VsIndex::RemovePartition { .. } => {
+                        VsIndex::AddVector {
+                            primary_id,
+                            embedding,
+                            in_progress: _in_progress,
+                            ..
+                        } => {
+                            state.add_vector(primary_id, embedding).await;
+                        }
+                        VsIndex::RemoveVector {
+                            primary_id,
+                            in_progress: _in_progress,
+                            ..
+                        } => {
+                            state.remove_vector(primary_id).await;
+                        }
+                        VsIndex::RemovePartition { .. } => {
                             warn!("not implemented yet");
                         }
                         VsIndex::Ann { tx, .. } | VsIndex::FilteredAnn { tx, .. } => {
@@ -119,7 +140,6 @@ fn new(
                         }
                     }
                 }
-                drop(index);
 
                 debug!("finished");
             }
@@ -128,6 +148,93 @@ fn new(
     ));
 
     Ok(tx)
+}
+
+/// Mapping between PrimaryId <-> u32 label used by DiskANN.
+///
+/// The mapping is bidirectional but ids are NOT reused once freed,
+/// because the underlying DiskANN `delete()` is a soft delete
+#[derive(Default)]
+struct IdMap {
+    forward: BTreeMap<PrimaryId, u32>,
+    reverse: BTreeMap<u32, PrimaryId>,
+    next_id: u32,
+}
+
+impl IdMap {
+    fn insert(&mut self, primary_id: PrimaryId) -> Option<u32> {
+        if self.forward.contains_key(&primary_id) {
+            return None;
+        }
+        let id = self.next_id;
+        self.next_id = self.next_id.checked_add(1)?;
+        self.forward.insert(primary_id, id);
+        self.reverse.insert(id, primary_id);
+        Some(id)
+    }
+
+    fn remove(&mut self, primary_id: &PrimaryId) -> Option<u32> {
+        let id = self.forward.remove(primary_id)?;
+        self.reverse.remove(&id);
+        Some(id)
+    }
+
+    fn get(&self, primary_id: &PrimaryId) -> Option<u32> {
+        self.forward.get(primary_id).copied()
+    }
+
+    fn resolve(&self, id: u32) -> Option<PrimaryId> {
+        self.reverse.get(&id).copied()
+    }
+
+    fn len(&self) -> usize {
+        self.forward.len()
+    }
+}
+
+/// Mutable actor state for the DiskANN index.
+struct State {
+    index: DiskANNIndex<DiskannProvider>,
+    id_map: IdMap,
+}
+
+impl State {
+    fn new(index: DiskANNIndex<DiskannProvider>) -> Self {
+        Self {
+            index,
+            id_map: IdMap::default(),
+        }
+    }
+
+    async fn add_vector(&mut self, primary_id: PrimaryId, embedding: Vector) {
+        let Some(id) = self.id_map.insert(primary_id) else {
+            warn!("add_vector: failed to insert primary_id {primary_id:?}");
+            return;
+        };
+
+        if let Err(err) = self
+            .index
+            .insert(&FullPrecision, &DefaultContext, &id, embedding.as_slice())
+            .await
+        {
+            warn!("add_vector: failed to insert vector: {err}");
+            self.id_map.remove(&primary_id);
+        }
+    }
+
+    async fn remove_vector(&mut self, primary_id: PrimaryId) {
+        let Some(id) = self.id_map.get(&primary_id) else {
+            warn!("remove_vector: primary_id {primary_id:?} not found");
+            return;
+        };
+
+        if let Err(err) = self.index.data_provider.delete(&DefaultContext, &id).await {
+            warn!("remove_vector: failed to delete vector: {err}");
+            return;
+        }
+
+        self.id_map.remove(&primary_id);
+    }
 }
 
 #[derive(Clone)]
@@ -234,5 +341,19 @@ mod tests {
         assert_eq!(usize::from(params.dim.0), 3);
         assert_eq!(params.config.l_build(), NonZeroUsize::new(64).unwrap());
         assert_eq!(params.metric, Metric::L2);
+    }
+
+    #[test]
+    fn id_map_insert_remove_resolve_round_trip() {
+        let mut map = IdMap::default();
+        let pid = PrimaryId::from(42u64);
+
+        let id = map.insert(pid).unwrap();
+        assert_eq!(map.resolve(id), Some(pid));
+        assert_eq!(map.len(), 1);
+
+        assert_eq!(map.remove(&pid), Some(id));
+        assert_eq!(map.resolve(id), None);
+        assert_eq!(map.len(), 0);
     }
 }

--- a/crates/vector-store/tests/integration/diskann.rs
+++ b/crates/vector-store/tests/integration/diskann.rs
@@ -1,0 +1,957 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::create_config_channels;
+use crate::db_basic;
+use crate::db_basic::DbBasic;
+use crate::db_basic::ScanFn;
+use crate::db_basic::Table;
+use crate::wait_for;
+use httpapi::IndexNotReadyReason;
+use httpapi::IndexStatus;
+use httpapi::PostIndexAnnFilter;
+use httpapi::PostIndexAnnResponse;
+use httpapi::PostIndexAnnRestriction;
+use httpclient::HttpClient;
+use reqwest::StatusCode;
+use scylla::cluster::metadata::NativeType;
+use scylla::value::CqlValue;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
+use uuid::Uuid;
+use vector_store::ColumnName;
+use vector_store::Config;
+use vector_store::Connectivity;
+use vector_store::DbIndexPartitioning;
+use vector_store::Dimensions;
+use vector_store::ExpansionAdd;
+use vector_store::ExpansionSearch;
+use vector_store::HttpServerExt;
+use vector_store::IndexKind;
+use vector_store::IndexMetadata;
+use vector_store::IndexOptionsVs;
+use vector_store::NonemptyArc;
+use vector_store::NonemptyIteratorExt;
+use vector_store::Percentage;
+use vector_store::Quantization;
+use vector_store::SpaceType;
+use vector_store::Timestamp;
+use vector_store::node_state::NodeState;
+
+pub(crate) fn test_config() -> Config {
+    Config {
+        vector_store_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
+        ..Default::default()
+    }
+}
+
+pub(crate) async fn setup_store(
+    config: Config,
+    partitioning: DbIndexPartitioning,
+    primary_keys: impl IntoIterator<Item = ColumnName>,
+    partition_key_count: usize,
+    columns: impl IntoIterator<Item = (ColumnName, NativeType)>,
+    fullscan_fn: Option<ScanFn>,
+    cdc_fn: Option<ScanFn>,
+) -> (
+    impl std::future::Future<Output = (HttpClient, impl Sized, impl Sized)>,
+    IndexMetadata,
+    DbBasic,
+    Sender<NodeState>,
+) {
+    setup_store_with_quantization(
+        config,
+        partitioning,
+        primary_keys,
+        partition_key_count,
+        columns,
+        fullscan_fn,
+        cdc_fn,
+        Quantization::default(),
+        NonZeroUsize::new(3).unwrap().into(),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn setup_store_with_quantization(
+    config: Config,
+    partitioning: DbIndexPartitioning,
+    primary_keys: impl IntoIterator<Item = ColumnName>,
+    partition_key_count: usize,
+    columns: impl IntoIterator<Item = (ColumnName, NativeType)>,
+    fullscan_fn: Option<ScanFn>,
+    cdc_fn: Option<ScanFn>,
+    quantization: Quantization,
+    dimension: Dimensions,
+) -> (
+    impl std::future::Future<Output = (HttpClient, impl Sized, impl Sized)>,
+    IndexMetadata,
+    DbBasic,
+    Sender<NodeState>,
+) {
+    let node_state = vector_store::new_node_state().await;
+    let internals = vector_store::new_internals();
+
+    let (db_actor, db) = db_basic::new(node_state.clone());
+
+    let primary_keys = primary_keys.into_iter().collect_nonempty_arc().unwrap();
+    let columns: Arc<HashMap<_, _>> = Arc::new(columns.into_iter().collect());
+    let filtering_columns = columns
+        .keys()
+        .filter(|c| !primary_keys.contains(c))
+        .cloned()
+        .collect();
+    let index = IndexMetadata {
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: "ann".into(),
+        primary_key_columns: primary_keys.clone(),
+        partition_key_count: NonZeroUsize::new(partition_key_count).unwrap(),
+        target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+        partitioning,
+        filtering_columns,
+        version: Uuid::new_v4().into(),
+        kind: IndexKind::Vs(IndexOptionsVs {
+            dimensions: dimension,
+            connectivity: Connectivity::default(),
+            expansion_add: ExpansionAdd::default(),
+            expansion_search: ExpansionSearch::default(),
+            space_type: SpaceType::Euclidean,
+            quantization,
+        }),
+    };
+
+    db.add_table(
+        index.keyspace_name.clone(),
+        index.table_name.clone(),
+        Table {
+            primary_keys,
+            partition_key_count,
+            columns,
+            dimensions: [(
+                index.target_columns.first().clone(),
+                index.vs().unwrap().dimensions,
+            )]
+            .into_iter()
+            .collect(),
+        },
+    )
+    .unwrap();
+
+    db.add_index(index.clone(), fullscan_fn, cdc_fn).unwrap();
+
+    let (receivers, senders) = create_config_channels(config).await;
+    let index_factory = vector_store::new_index_factory_diskann(receivers.config.clone()).unwrap();
+
+    let run = {
+        let node_state = node_state.clone();
+        async move {
+            let (server, _mtls) = vector_store::run(
+                node_state,
+                db_actor,
+                internals,
+                index_factory,
+                receivers,
+                vector_store::new_metrics(),
+            )
+            .await
+            .unwrap();
+            let addr = (*server.address().await.borrow()).unwrap();
+
+            (HttpClient::new(addr), server, senders)
+        }
+    };
+
+    (run, index, db, node_state)
+}
+
+pub(crate) async fn setup_store_and_wait_for_index(
+    partitioning: DbIndexPartitioning,
+    primary_keys: impl IntoIterator<Item = ColumnName>,
+    partition_key_count: usize,
+    columns: impl IntoIterator<Item = (ColumnName, NativeType)>,
+    fullscan_fn: Option<ScanFn>,
+    cdc_fn: Option<ScanFn>,
+    expected_count: Option<usize>,
+) -> (
+    IndexMetadata,
+    HttpClient,
+    DbBasic,
+    impl Sized,
+    Sender<NodeState>,
+) {
+    let (run, index, db, node_state) = setup_store(
+        test_config(),
+        partitioning,
+        primary_keys,
+        partition_key_count,
+        columns,
+        fullscan_fn,
+        cdc_fn,
+    )
+    .await;
+    let (client, server, _config_tx) = run.await;
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| {
+                    status.status == IndexStatus::Serving
+                        && expected_count.is_none_or(|count| status.count == count)
+                })
+        },
+        "Waiting for index to be serving",
+    )
+    .await;
+
+    (index, client, db, (server, _config_tx), node_state)
+}
+
+#[tokio::test]
+async fn simple_create_search_delete_index() {
+    crate::enable_tracing();
+
+    let (run, index, db, _node_state) = setup_store(
+        test_config(),
+        DbIndexPartitioning::Global,
+        ["pk".into(), "ck".into()],
+        1,
+        [
+            ("pk".to_string().into(), NativeType::Int),
+            ("ck".to_string().into(), NativeType::Text),
+        ],
+        Some(db_basic::scan_fn_vectors([
+            (
+                [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
+                Some(vec![1., 1., 1.].into()),
+                [].into(),
+                Timestamp::from_millis(10),
+            ),
+            (
+                [CqlValue::Int(2), CqlValue::Text("two".to_string())].into(),
+                Some(vec![2., -2., 2.].into()),
+                [].into(),
+                Timestamp::from_millis(20),
+            ),
+            (
+                [CqlValue::Int(3), CqlValue::Text("three".to_string())].into(),
+                Some(vec![3., 3., 3.].into()),
+                [].into(),
+                Timestamp::from_millis(30),
+            ),
+        ])),
+        None,
+    )
+    .await;
+    let (client, _server, _config_tx) = run.await;
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Serving && status.count == 3)
+        },
+        "Waiting for 3 vectors to be indexed",
+    )
+    .await;
+
+    let indexes = client.indexes().await;
+    assert_eq!(indexes.len(), 1);
+    assert_eq!(indexes[0], httpapi::IndexInfo::new("vector", "ann"));
+
+    let (primary_keys, distances, similarity_scores) = client
+        .ann(
+            &keyspace_name,
+            &index_name,
+            vec![2.1, -2., 2.].into(),
+            None,
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+    assert_eq!(distances.len(), 1);
+    assert_eq!(similarity_scores.len(), 1);
+    let primary_keys_pk = primary_keys.get(&"pk".into()).unwrap();
+    let primary_keys_ck = primary_keys.get(&"ck".into()).unwrap();
+    assert_eq!(distances.len(), primary_keys_pk.len());
+    assert_eq!(distances.len(), primary_keys_ck.len());
+    assert_eq!(similarity_scores.len(), distances.len());
+    assert_eq!(primary_keys_pk.first().unwrap().as_i64().unwrap(), 2);
+    assert_eq!(primary_keys_ck.first().unwrap().as_str().unwrap(), "two");
+
+    db.del_index(&index.keyspace_name, &index.index_name)
+        .unwrap();
+
+    wait_for(
+        || async { client.indexes().await.is_empty() },
+        "Waiting for all indexes to be removed from the store",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn failed_db_index_create() {
+    crate::enable_tracing();
+
+    let node_state = vector_store::new_node_state().await;
+    let internals = vector_store::new_internals();
+    let (db_actor, db) = db_basic::new(node_state.clone());
+
+    let index = IndexMetadata {
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: "ann".into(),
+        primary_key_columns: NonemptyArc::new(["pk", "ck"]).unwrap(),
+        partition_key_count: NonZeroUsize::new(1).unwrap(),
+        target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+        partitioning: DbIndexPartitioning::Global,
+        filtering_columns: Arc::new([]),
+        version: Uuid::new_v4().into(),
+        kind: IndexKind::Vs(IndexOptionsVs {
+            dimensions: NonZeroUsize::new(3).unwrap().into(),
+            connectivity: Default::default(),
+            expansion_add: Default::default(),
+            expansion_search: Default::default(),
+            space_type: Default::default(),
+            quantization: Default::default(),
+        }),
+    };
+
+    let (_, rx) = watch::channel(Arc::new(Config::default()));
+    let index_factory = vector_store::new_index_factory_diskann(rx).unwrap();
+
+    let (receivers, _senders) = create_config_channels(test_config()).await;
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
+    let addr = (*server.address().await.borrow()).unwrap();
+
+    let client = HttpClient::new(addr);
+
+    db.set_next_get_db_index_failed();
+
+    db.add_table(
+        index.keyspace_name.clone(),
+        index.table_name.clone(),
+        Table {
+            primary_keys: NonemptyArc::new(["pk", "ck"]).unwrap(),
+            partition_key_count: 1,
+            columns: Arc::new(
+                [
+                    ("pk".into(), NativeType::Int),
+                    ("ck".into(), NativeType::Text),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            dimensions: [(
+                index.target_columns.first().clone(),
+                index.vs().unwrap().dimensions,
+            )]
+            .into_iter()
+            .collect(),
+        },
+    )
+    .unwrap();
+    db.add_index(index.clone(), None, None).unwrap();
+
+    wait_for(
+        || async { !client.indexes().await.is_empty() },
+        "Waiting for index to be added to the store",
+    )
+    .await;
+
+    db.add_index(
+        IndexMetadata {
+            index_name: "ann2".into(),
+            ..index.clone()
+        },
+        None,
+        None,
+    )
+    .unwrap();
+
+    wait_for(
+        || async { client.indexes().await.len() == 2 },
+        "Waiting for 2nd index to be added to the store",
+    )
+    .await;
+
+    let indexes = client.indexes().await;
+    assert_eq!(indexes.len(), 2);
+    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann")));
+    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann2")));
+
+    db.add_index(
+        IndexMetadata {
+            index_name: "ann3".into(),
+            ..index.clone()
+        },
+        None,
+        None,
+    )
+    .unwrap();
+
+    wait_for(
+        || async { client.indexes().await.len() == 3 },
+        "Waiting for 3rd index to be added to the store",
+    )
+    .await;
+
+    let indexes = client.indexes().await;
+    assert_eq!(indexes.len(), 3);
+    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann")));
+    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann2")));
+    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann3")));
+
+    db.del_index(&index.keyspace_name, &"ann2".into()).unwrap();
+
+    wait_for(
+        || async { client.indexes().await.len() == 2 },
+        "Waiting for index to be removed from the store",
+    )
+    .await;
+
+    let indexes = client.indexes().await;
+    assert_eq!(indexes.len(), 2);
+    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann")));
+    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann3")));
+}
+
+#[tokio::test]
+async fn ann_returns_bad_request_when_provided_vector_size_is_not_eq_index_dimensions() {
+    crate::enable_tracing();
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into(), "ck".into()],
+        1,
+        [
+            ("pk".to_string().into(), NativeType::Int),
+            ("ck".to_string().into(), NativeType::Text),
+        ],
+        Some(db_basic::scan_fn_vectors([(
+            [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
+            Some(vec![1., 1., 1.].into()),
+            [].into(),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+        Some(1),
+    )
+    .await;
+
+    let result = client
+        .post_ann(
+            &index.keyspace_name.into(),
+            &index.index_name.into(),
+            vec![1.0, 2.0].into(), // Only 2 dimensions, should be 3 (index.vs().unwrap().dimensions)
+            None,
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(result.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+async fn ann_returns_bad_request_when_filtering_required_but_not_allowed() {
+    crate::enable_tracing();
+
+    let pk_column: ColumnName = "pk".into();
+    let ck_column: ColumnName = "ck".into();
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        [pk_column.clone(), ck_column.clone()],
+        1,
+        [
+            (pk_column.clone(), NativeType::Int),
+            (ck_column.clone(), NativeType::Int),
+        ],
+        Some(db_basic::scan_fn_vectors([(
+            [CqlValue::Int(1), CqlValue::Int(1)].into(),
+            Some(vec![1., 1., 1.].into()),
+            [].into(),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+        Some(1),
+    )
+    .await;
+
+    let result = client
+        .post_ann(
+            &index.keyspace_name.into(),
+            &index.index_name.into(),
+            vec![1.0, 2.0, 3.0].into(),
+            Some(PostIndexAnnFilter {
+                restrictions: vec![PostIndexAnnRestriction::Eq {
+                    lhs: pk_column.into(),
+                    rhs: 1.into(),
+                }],
+                allow_filtering: false,
+            }),
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(result.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn ann_fail_while_building_when_node_is_bootstrapping() {
+    crate::enable_tracing();
+    let (run, index, db, _node_state) = setup_store(
+        test_config(),
+        DbIndexPartitioning::Global,
+        ["pk".into(), "ck".into()],
+        1,
+        [
+            ("pk".to_string().into(), NativeType::Int),
+            ("ck".to_string().into(), NativeType::Text),
+        ],
+        Some(db_basic::pending_scan_fn()),
+        None,
+    )
+    .await;
+    db.set_next_full_scan_progress(vector_store::Progress::InProgress(
+        Percentage::try_from(33.333).unwrap(),
+    ));
+    let (client, _server, _config_tx) = run.await;
+
+    let keyspace_name = index.keyspace_name.into();
+    let index_name = index.index_name.into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Bootstrapping)
+        },
+        "Waiting for index to be bootstrapping",
+    )
+    .await;
+
+    let result = client
+        .post_ann(
+            &keyspace_name,
+            &index_name,
+            vec![1.0, 2.0, 3.0].into(),
+            None,
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(result.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let reason: IndexNotReadyReason = result.json().await.unwrap();
+    assert_eq!(reason, IndexNotReadyReason::NodeBootstrapping);
+}
+
+#[tokio::test]
+async fn ann_fail_while_building_when_node_is_serving() {
+    crate::enable_tracing();
+
+    let (serving_index, client, db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors([(
+            [CqlValue::Int(1)].into(),
+            Some(vec![1., 1., 1.].into()),
+            [].into(),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+        Some(1),
+    )
+    .await;
+
+    let index: IndexMetadata = IndexMetadata {
+        index_name: "ann_building".into(),
+        target_columns: NonemptyArc::new(["embedding2"]).unwrap(),
+        version: uuid::Uuid::new_v4().into(),
+        ..serving_index
+    };
+    // Add new column to the table so that the new index will be created on a new column.
+    // This allows the routing mechanism to always route to this index.
+    // Otherwise, when both indexes are on the same column, the routing mechanism will always route to the serving index.
+    db.add_vector_column(
+        index.keyspace_name.clone(),
+        index.table_name.clone(),
+        index.target_columns.first().clone(),
+        index.vs().unwrap().dimensions,
+    )
+    .unwrap();
+    // Add second index that is Bootstrapping (pending_scan_fn). So now we have node Serving and this index Bootstrapping - a good state to test desired scenario.
+    db.add_index(index.clone(), Some(db_basic::pending_scan_fn()), None)
+        .unwrap();
+    db.set_next_full_scan_progress(vector_store::Progress::InProgress(
+        Percentage::try_from(75.0).unwrap(),
+    ));
+
+    let keyspace_name: httpapi::KeyspaceName = index.keyspace_name.into();
+    let index_name: httpapi::IndexName = index.index_name.into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Bootstrapping)
+        },
+        "Waiting for index to be bootstrapping",
+    )
+    .await;
+
+    let result = client
+        .post_ann(
+            &keyspace_name,
+            &index_name,
+            vec![1.0, 2.0, 3.0].into(),
+            None,
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(result.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let reason: IndexNotReadyReason = result.json().await.unwrap();
+    let IndexNotReadyReason::IndexBuilding { message } = reason else {
+        panic!("expected IndexBuilding, got {reason:?}");
+    };
+    assert!(
+        message.contains(&format!("{keyspace_name}.{index_name}")),
+        "unexpected message: {message}"
+    );
+    assert!(
+        message.contains("progress: 75.000%"),
+        "unexpected message: {message}"
+    );
+}
+
+#[tokio::test]
+async fn ann_failed_when_wrong_number_of_primary_keys() {
+    crate::enable_tracing();
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        vec!["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors([(
+            [CqlValue::Int(1), CqlValue::Text("one".to_string())].into(),
+            Some(vec![1., 1., 1.].into()),
+            [].into(),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+        Some(1),
+    )
+    .await;
+
+    let keyspace_name = index.keyspace_name.into();
+    let index_name = index.index_name.into();
+    wait_for(
+        || async {
+            let response = client
+                .post_ann(
+                    &keyspace_name,
+                    &index_name,
+                    vec![1.0, 2.0, 3.0].into(),
+                    None,
+                    NonZeroUsize::new(1).unwrap().into(),
+                )
+                .await;
+
+            if response.status() == StatusCode::INTERNAL_SERVER_ERROR {
+                true
+            } else {
+                let response = response.json::<PostIndexAnnResponse>().await.unwrap();
+                assert_eq!(response.distances.len(), 0);
+                false
+            }
+        },
+        "Waiting for index to be return internal server error on ANN",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ntest::timeout(10_000)]
+async fn null_vector_is_not_indexed() {
+    crate::enable_tracing();
+
+    let (run, index, _db, _node_state) = setup_store(
+        test_config(),
+        DbIndexPartitioning::Global,
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors([
+            (
+                [CqlValue::Int(1)].into(),
+                Some(vec![1., 1., 1.].into()),
+                [].into(),
+                Timestamp::from_millis(10),
+            ),
+            (
+                [CqlValue::Int(2)].into(),
+                None,
+                [].into(),
+                Timestamp::from_millis(20),
+            ),
+        ])),
+        None,
+    )
+    .await;
+    let (client, _server, _config_tx) = run.await;
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+    wait_for(
+        || async {
+            let status = client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .expect("failed to get index status");
+            status.status == httpapi::IndexStatus::Serving && status.count == 1
+        },
+        "Waiting for exactly 1 vector to be indexed (null vector must be skipped)",
+    )
+    .await;
+}
+
+// Regression test for the similarity_scores returned by ann(). These need
+// to be similarity scores (decreasing), not distance scores (increasing).
+//
+// This test inserts 3 vectors at different distances from the query and
+// checks that:
+//  1. similarity_scores are in strictly decreasing order (nearest = highest score).
+//  2. For Euclidean distance, the formula similarity = 1/(1+d) is applied
+//     correctly.
+#[tokio::test]
+#[ntest::timeout(10_000)]
+async fn similarity_scores_are_decreasing_and_correctly_converted() {
+    crate::enable_tracing();
+
+    let node_state = vector_store::new_node_state().await;
+    let internals = vector_store::new_internals();
+    let (db_actor, db) = db_basic::new(node_state.clone());
+
+    // Use a 1-D Euclidean index so distances are easy to predict.
+    let index = IndexMetadata {
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: "ann".into(),
+        primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+        partition_key_count: NonZeroUsize::new(1).unwrap(),
+        target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+        partitioning: DbIndexPartitioning::Global,
+        filtering_columns: Arc::new([]),
+        version: Uuid::new_v4().into(),
+        kind: IndexKind::Vs(IndexOptionsVs {
+            dimensions: NonZeroUsize::new(1).unwrap().into(),
+            connectivity: Connectivity::default(),
+            expansion_add: ExpansionAdd::default(),
+            expansion_search: ExpansionSearch::default(),
+            space_type: SpaceType::Euclidean,
+            quantization: Quantization::default(),
+        }),
+    };
+
+    db.add_table(
+        index.keyspace_name.clone(),
+        index.table_name.clone(),
+        Table {
+            primary_keys: NonemptyArc::new(["pk"]).unwrap(),
+            partition_key_count: 1,
+            columns: Arc::new([("pk".into(), NativeType::Int)].into_iter().collect()),
+            dimensions: [(
+                index.target_columns.first().clone(),
+                index.vs().unwrap().dimensions,
+            )]
+            .into_iter()
+            .collect(),
+        },
+    )
+    .unwrap();
+
+    // Three items with 1-D vectors [0.0], [1.0], [3.0].
+    // Query vector is [0.0]. USearch computes squared L2 distance, so the
+    // squared distances are 0, 1, 9 respectively, and expected similarity
+    // scores (using 1/(1+d)) are 1/(1+0)=1.0, 1/(1+1)=0.5, 1/(1+9)=0.1.
+    db.add_index(
+        index.clone(),
+        Some(db_basic::scan_fn_vectors([
+            (
+                [CqlValue::Int(1)].into(),
+                Some(vec![0.0_f32].into()),
+                [].into(),
+                Timestamp::from_millis(10),
+            ),
+            (
+                [CqlValue::Int(2)].into(),
+                Some(vec![1.0_f32].into()),
+                [].into(),
+                Timestamp::from_millis(20),
+            ),
+            (
+                [CqlValue::Int(3)].into(),
+                Some(vec![3.0_f32].into()),
+                [].into(),
+                Timestamp::from_millis(30),
+            ),
+        ])),
+        None,
+    )
+    .unwrap();
+
+    let (_, rx) = watch::channel(Arc::new(Config::default()));
+    let index_factory = vector_store::new_index_factory_diskann(rx).unwrap();
+    let (receivers, _senders) = create_config_channels(test_config()).await;
+    let (server, _mtls) = vector_store::run(
+        node_state,
+        db_actor,
+        internals,
+        index_factory,
+        receivers,
+        vector_store::new_metrics(),
+    )
+    .await
+    .unwrap();
+    let addr = (*server.address().await.borrow()).unwrap();
+    let client = HttpClient::new(addr);
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|s| s.status == IndexStatus::Serving && s.count == 3)
+        },
+        "Waiting for 3 vectors to be indexed",
+    )
+    .await;
+
+    let (_primary_keys, distances, similarity_scores) = client
+        .ann(
+            &keyspace_name,
+            &index_name,
+            vec![0.0_f32].into(),
+            None,
+            NonZeroUsize::new(3).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(similarity_scores.len(), 3);
+    assert_eq!(distances.len(), 3);
+
+    let scores: Vec<f32> = similarity_scores
+        .iter()
+        .map(|s| serde_json::to_value(s).unwrap().as_f64().unwrap() as f32)
+        .collect();
+
+    // Scores must be in strictly decreasing order (nearest item has highest similarity).
+    assert!(
+        scores[0] > scores[1] && scores[1] > scores[2],
+        "similarity_scores must be in decreasing order, got: {scores:?}"
+    );
+
+    // Verify the Euclidean similarity formula 1/(1+d) is correctly applied.
+    let epsilon = 1e-5_f32;
+    assert!(
+        (scores[0] - 1.0).abs() < epsilon,
+        "nearest item (distance=0) should have similarity 1.0, got {}",
+        scores[0]
+    );
+    assert!(
+        (scores[1] - 0.5).abs() < epsilon,
+        "second item (distance=1) should have similarity 0.5, got {}",
+        scores[1]
+    );
+    assert!(
+        (scores[2] - 0.1).abs() < epsilon,
+        "farthest item (squared distance=9) should have similarity 0.1, got {}",
+        scores[2]
+    );
+}
+
+#[tokio::test]
+async fn empty_index_has_zero_count() {
+    crate::enable_tracing();
+
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors(std::iter::empty())),
+        None,
+        Some(0),
+    )
+    .await;
+
+    let status = client
+        .index_status(
+            &index.keyspace_name.clone().into(),
+            &index.index_name.clone().into(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status.status, IndexStatus::Serving);
+    assert_eq!(status.count, 0);
+}
+
+#[tokio::test]
+async fn empty_index_returns_empty_ann_results() {
+    crate::enable_tracing();
+
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        DbIndexPartitioning::Global,
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors(std::iter::empty())),
+        None,
+        Some(0),
+    )
+    .await;
+
+    let (primary_keys, distances, similarity_scores) = client
+        .ann(
+            &index.keyspace_name.clone().into(),
+            &index.index_name.clone().into(),
+            vec![1.0, 1.0, 1.0].into(),
+            None,
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert!(primary_keys.get(&"pk".into()).unwrap().is_empty());
+    assert!(distances.is_empty());
+    assert!(similarity_scores.is_empty());
+}

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -4,6 +4,7 @@
  */
 
 mod db_basic;
+mod diskann;
 mod fts;
 mod https;
 mod info;


### PR DESCRIPTION
This PR focuses on a simple one-by-one actor loop implementation of:
- AddVector
- RemoveVector
- Ann
- Count

The aim is to establish a correctly behaving baseline to build upon. 

Things that are currently beyond the scope of this PR:
- Partitioning
- Dispatching tasks to different workers

Ref: VECTOR-714