### PR TITLE
scripts: pre-create cargo cache dirs before container bind-mount

### DIFF
--- a/scripts/run-with-release-toolchain
+++ b/scripts/run-with-release-toolchain
@@ -15,7 +15,10 @@ user_cargo_home=$CARGO_HOME
 
 docker_cargo_home=$(docker run --rm $image sh -c 'echo $CARGO_HOME')
 
-[[ -n $user_cargo_home ]] && mount_cargo="-v $user_cargo_home/git:$docker_cargo_home/git -v $user_cargo_home/registry:$docker_cargo_home/registry "
+if [[ -n $user_cargo_home ]] ; then
+    mkdir -p "$user_cargo_home/git" "$user_cargo_home/registry"
+    mount_cargo="-v $user_cargo_home/git:$docker_cargo_home/git -v $user_cargo_home/registry:$docker_cargo_home/registry "
+fi
 
 version=$(git describe --dirty) || { echo "error: no annotated tag found"; exit 1; }
 


### PR DESCRIPTION
On a fresh GitHub Actions runner, ~/.cargo/registry already exists but ~/.cargo/git does not, since it is only created on the first git-dependency fetch. Docker auto-creates a missing bind-mount source path as root, so the build container (running as the non-root host user) gets Permission denied when cargo tries to write into it.

This caused the build-docker job to fail in the release.yaml run for 1.9.1 https://github.com/scylladb/vector-store/actions/runs/30000488118/job/89184255041

Ref: https://scylladb.atlassian.net/browse/RELENG-715