### PR TITLE
vector-store: using new inmem provider in diskann

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,15 +903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,51 +1819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diskann-providers"
-version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
-dependencies = [
- "arc-swap",
- "bincode",
- "bytemuck",
- "byteorder",
- "cfg-if",
- "diskann",
- "diskann-quantization",
- "diskann-utils",
- "diskann-vector",
- "diskann-wide",
- "futures-util",
- "half",
- "hashbrown 0.16.0",
- "num-traits",
- "prost",
- "rand 0.9.4",
- "rand_distr",
- "rayon",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "diskann-quantization"
-version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
-dependencies = [
- "bytemuck",
- "cfg-if",
- "diskann-utils",
- "diskann-vector",
- "diskann-wide",
- "half",
- "rand 0.9.4",
- "rayon",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "diskann-utils"
 version = "0.55.0"
 source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
@@ -1884,7 +1830,6 @@ dependencies = [
  "half",
  "rand 0.9.4",
  "rand_distr",
- "rayon",
  "thiserror 2.0.18",
 ]
 
@@ -6161,7 +6106,6 @@ dependencies = [
  "derive_more",
  "diskann",
  "diskann-inmem",
- "diskann-providers",
  "diskann-vector",
  "dotenvy",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "diskann"
 version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1802,9 +1811,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "diskann-inmem"
+version = "0.55.0"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
+dependencies = [
+ "bytemuck",
+ "crossbeam-queue",
+ "dashmap 6.1.0",
+ "diskann",
+ "diskann-utils",
+ "diskann-vector",
+ "diskann-wide",
+ "half",
+ "parking_lot",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "diskann-providers"
 version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1833,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "diskann-quantization"
 version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1849,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "diskann-utils"
 version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1865,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "diskann-vector"
 version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
 dependencies = [
  "cfg-if",
  "diskann-wide",
@@ -1875,7 +1901,7 @@ dependencies = [
 [[package]]
 name = "diskann-wide"
 version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=541472a8d0bbfa4d458ec1b909e1d41a18adaabc#541472a8d0bbfa4d458ec1b909e1d41a18adaabc"
+source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
 dependencies = [
  "cfg-if",
  "half",
@@ -4117,7 +4143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6134,6 +6160,7 @@ dependencies = [
  "dashmap 6.1.0",
  "derive_more",
  "diskann",
+ "diskann-inmem",
  "diskann-providers",
  "diskann-vector",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,10 @@ console-subscriber = "0.5.0"
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
-diskann = { git = "https://github.com/microsoft/DiskANN.git", rev = "541472a8d0bbfa4d458ec1b909e1d41a18adaabc" }
-diskann-providers = { git = "https://github.com/microsoft/DiskANN.git", rev = "541472a8d0bbfa4d458ec1b909e1d41a18adaabc" }
-diskann-vector = { git = "https://github.com/microsoft/DiskANN.git", rev = "541472a8d0bbfa4d458ec1b909e1d41a18adaabc" }
+diskann = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
+diskann-providers = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
+diskann-vector = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
+diskann-inmem = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
 dotenvy = "0.15.7"
 e2etest = "0.2.0"
 e2etest-dns = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
 diskann = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
-diskann-providers = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
 diskann-vector = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
 diskann-inmem = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
 dotenvy = "0.15.7"

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -43,6 +43,7 @@ derive_more.workspace = true
 diskann.workspace = true
 diskann-providers.workspace = true
 diskann-vector.workspace = true
+diskann-inmem.workspace = true
 dotenvy.workspace = true
 futures.workspace = true
 hotpath.workspace = true

--- a/crates/vector-store/Cargo.toml
+++ b/crates/vector-store/Cargo.toml
@@ -41,7 +41,6 @@ console-subscriber = {workspace = true, optional = true}
 dashmap.workspace = true
 derive_more.workspace = true
 diskann.workspace = true
-diskann-providers.workspace = true
 diskann-vector.workspace = true
 diskann-inmem.workspace = true
 dotenvy.workspace = true

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -6,7 +6,9 @@
 use crate::Config;
 use crate::Dimensions;
 use crate::DiskannAlpha;
+use crate::Distance;
 use crate::IndexKey;
+use crate::Limit;
 use crate::PartitionId;
 use crate::PrimaryId;
 use crate::SpaceType;
@@ -17,8 +19,11 @@ use crate::memory::Memory;
 use crate::memory::MemoryExt;
 use crate::perf;
 use crate::table::Table;
+use crate::table::TableSearch;
+use crate::vs_index::actor::AnnR;
 use crate::vs_index::actor::VsIndex;
 use crate::vs_index::factory::VsIndexConfiguration;
+use crate::vs_index::validator;
 use crate::worker::Worker;
 use anyhow::Context;
 use diskann::graph::Config as DiskannConfig;
@@ -27,23 +32,29 @@ use diskann::graph::InplaceDeleteMethod;
 use diskann::graph::config::Builder;
 use diskann::graph::config::MaxDegree;
 use diskann::graph::config::defaults::ALPHA as DISKANN_DEFAULT_ALPHA;
+use diskann::graph::index::SearchStats;
+use diskann::graph::search::Knn;
+use diskann::neighbor::Neighbor;
 use diskann_inmem::Context as InmemContext;
 use diskann_inmem::Provider as InmemProvider;
 use diskann_inmem::Strategy as InmemStrategy;
 use diskann_inmem::layers::Full;
 use diskann_inmem::provider::Config as InmemProviderConfig;
 use diskann_vector::distance::Metric;
+use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
 use tracing::error;
+use tracing::trace;
 use tracing::warn;
 
 const MAX_POINTS: NonZeroUsize = NonZeroUsize::new(1_000_000).unwrap();
@@ -62,12 +73,12 @@ impl VsIndexFactory for DiskannIndexFactory {
     fn create_index(
         &self,
         index: VsIndexConfiguration,
-        _table: Arc<RwLock<Table>>,
+        table: Arc<RwLock<Table>>,
     ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
         let params = DiskannParams::new(&index, self.alpha, MAX_POINTS)
             .context("failed to create DiskANN parameters")?;
 
-        new(index.key, self.memory.clone(), params)
+        new(index.key, self.memory.clone(), table, params)
     }
 
     fn index_engine_version(&self) -> String {
@@ -94,6 +105,7 @@ pub fn new_diskann(
 fn new(
     index_key: IndexKey,
     memory: mpsc::Sender<Memory>,
+    table: Arc<RwLock<impl TableSearch + Send + Sync + 'static>>,
     params: DiskannParams,
 ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
@@ -105,7 +117,7 @@ fn new(
             async move {
                 debug!("starting");
 
-                let mut state = State::new(params);
+                let mut state = State::new(table, params);
 
                 let mut allocate_prev = Allocate::Can;
                 let allocate_rx = memory.subscribe_allocate().await;
@@ -135,9 +147,21 @@ fn new(
                         VsIndex::RemovePartition { .. } => {
                             warn!("not implemented yet");
                         }
-                        VsIndex::Ann { tx, .. } | VsIndex::FilteredAnn { tx, .. } => {
-                            _ = tx
-                                .send(Err(anyhow::anyhow!("DiskANN index is not implemented yet")));
+                        VsIndex::Ann {
+                            index_key,
+                            embedding,
+                            limit,
+                            tx,
+                        } => {
+                            if let Some(tx) = validate_dimensions(tx, &embedding, state.params.dim)
+                            {
+                                _ = tx.send(state.ann(index_key, embedding, limit).await);
+                            }
+                        }
+                        VsIndex::FilteredAnn { tx, .. } => {
+                            _ = tx.send(Err(anyhow::anyhow!(
+                                "DiskANN index does not support filtered search"
+                            )));
                         }
                         VsIndex::Count { tx, .. } => {
                             _ = tx
@@ -174,15 +198,23 @@ struct Partition {
     index: DiskANNIndex<DiskannProvider>,
 }
 
-struct State {
+struct State<T>
+where
+    T: TableSearch + Send + Sync + 'static,
+{
     partitions: BTreeMap<PartitionId, Partition>,
+    table: Arc<RwLock<T>>,
     params: DiskannParams,
 }
 
-impl State {
-    fn new(params: DiskannParams) -> Self {
+impl<T> State<T>
+where
+    T: TableSearch + Send + Sync + 'static,
+{
+    fn new(table: Arc<RwLock<T>>, params: DiskannParams) -> Self {
         Self {
             partitions: BTreeMap::new(),
+            table,
             params,
         }
     }
@@ -251,6 +283,101 @@ impl State {
             warn!("remove_vector: failed to delete vector: {err}");
         }
     }
+
+    async fn search(
+        &self,
+        embedding: &Vector,
+        k: usize,
+        partition: &Partition,
+    ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<(PrimaryId, Distance)>>> {
+        let space_type = self.params.space_type;
+        let dimensions = embedding.dim();
+
+        let k = k.min(self.params.max_points.get());
+        let l_value = self.params.l_default.get().max(k);
+        let params = Knn::new(k, l_value, Some(self.params.beam_width.get()))
+            .context("failed to build DiskANN search parameters")?;
+
+        let mut neighbors: Vec<Neighbor<PrimaryId>> = Vec::with_capacity(params.k_value().get());
+        let SearchStats { result_count, .. } = partition
+            .index
+            .search(
+                params,
+                &InmemStrategy,
+                &InmemContext,
+                embedding.as_slice(),
+                &mut neighbors,
+            )
+            .await?;
+
+        neighbors.truncate((result_count as usize).min(k));
+        Ok(neighbors.into_iter().map(move |neighbor| {
+            let raw_distance = match space_type {
+                SpaceType::DotProduct => neighbor.distance() + 1.0,
+                _ => neighbor.distance(),
+            };
+            Distance::try_from((raw_distance, space_type, dimensions))
+                .map(|distance| (*neighbor.id(), distance))
+        }))
+    }
+
+    async fn ann(&self, index_key: IndexKey, embedding: Vector, limit: Limit) -> AnnR {
+        let partition_id: PartitionId = {
+            let table = self.table.read().unwrap();
+            if let Some((partition_id, _)) = table.partition_id(&index_key, None) {
+                partition_id
+            } else {
+                warn!(
+                    "partition id not found for index key {} during ann",
+                    index_key
+                );
+                return Ok((vec![], vec![]));
+            }
+        };
+
+        let Some(partition) = self.partitions.get(&partition_id) else {
+            return Ok((vec![], vec![]));
+        };
+
+        let matches = self
+            .search(&embedding, limit.0.get(), partition)
+            .await
+            .context("ann search failed")?;
+
+        let table = self.table.read().unwrap();
+        let (primary_keys, distances) = itertools::process_results(
+            matches.filter_map_ok(|(primary_id, distance)| {
+                table
+                    .primary_key(partition_id, primary_id)
+                    .or_else(|| {
+                        debug!(
+                            "not defined primary key for partition_id {partition_id:?} \
+                                        and primary_id {primary_id:?}",
+                        );
+                        None
+                    })
+                    .map(|primary_key| (primary_key, distance))
+            }),
+            |it| it.unzip(),
+        )?;
+        Ok((primary_keys, distances))
+    }
+}
+
+#[hotpath::measure]
+fn validate_dimensions(
+    tx_ann: oneshot::Sender<AnnR>,
+    embedding: &Vector,
+    dimensions: Dimensions,
+) -> Option<oneshot::Sender<AnnR>> {
+    if let Err(err) = validator::embedding_dimensions(embedding, dimensions) {
+        tx_ann
+            .send(Err(err))
+            .unwrap_or_else(|_| trace!("validate_dimensions: unable to send response"));
+        None
+    } else {
+        Some(tx_ann)
+    }
 }
 
 #[hotpath::measure]
@@ -279,8 +406,11 @@ fn check_memory_allocation(
 struct DiskannParams {
     config: DiskannConfig,
     metric: Metric,
+    space_type: SpaceType,
     dim: Dimensions,
     max_points: NonZeroUsize,
+    l_default: NonZeroUsize,
+    beam_width: NonZeroUsize,
 }
 
 impl DiskannParams {
@@ -304,11 +434,19 @@ impl DiskannParams {
             .build()
             .context("failed to build DiskANN configuration")?;
 
+        let l_default = NonZeroUsize::new(cfg.expansion_search.0)
+            .context("expansion_search (DiskANN query search list size L) must be non-zero")?;
+        let beam_width = NonZeroUsize::new(cfg.expansion_search.0)
+            .context("expansion_search (DiskANN beam width) must be non-zero")?;
+
         Ok(Self {
             config,
             metric,
+            space_type: cfg.space_type,
             dim: cfg.dimensions,
             max_points,
+            l_default,
+            beam_width,
         })
     }
 }
@@ -379,5 +517,8 @@ mod tests {
         assert_eq!(usize::from(params.dim.0), 3);
         assert_eq!(params.config.l_build(), NonZeroUsize::new(64).unwrap());
         assert_eq!(params.metric, Metric::L2);
+        assert_eq!(params.l_default, NonZeroUsize::new(32).unwrap());
+        assert_eq!(params.beam_width, NonZeroUsize::new(32).unwrap());
+        assert_eq!(params.space_type, SpaceType::Euclidean);
     }
 }

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -146,8 +146,8 @@ fn new(
                         } => {
                             state.remove_vector(partition_id, primary_id).await;
                         }
-                        VsIndex::RemovePartition { .. } => {
-                            warn!("not implemented yet");
+                        VsIndex::RemovePartition { partition_id } => {
+                            state.remove_partition(partition_id);
                         }
                         VsIndex::Ann {
                             index_key,
@@ -372,6 +372,12 @@ where
             |it| it.unzip(),
         )?;
         Ok((primary_keys, distances))
+    }
+
+    fn remove_partition(&mut self, partition_id: PartitionId) {
+        if self.partitions.remove(&partition_id).is_none() {
+            debug!("remove_partition: partition {partition_id:?} not found");
+        }
     }
 
     fn count(&self, index_key: &IndexKey) -> CountR {

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -7,8 +7,10 @@ use crate::Config;
 use crate::Dimensions;
 use crate::DiskannAlpha;
 use crate::IndexKey;
+use crate::PartitionId;
 use crate::PrimaryId;
 use crate::SpaceType;
+use crate::Vector;
 use crate::VsIndexFactory;
 use crate::memory::Allocate;
 use crate::memory::Memory;
@@ -21,13 +23,18 @@ use crate::worker::Worker;
 use anyhow::Context;
 use diskann::graph::Config as DiskannConfig;
 use diskann::graph::DiskANNIndex;
+use diskann::graph::InplaceDeleteMethod;
 use diskann::graph::config::Builder;
 use diskann::graph::config::MaxDegree;
 use diskann::graph::config::defaults::ALPHA as DISKANN_DEFAULT_ALPHA;
+use diskann_inmem::Context as InmemContext;
 use diskann_inmem::Provider as InmemProvider;
+use diskann_inmem::Strategy as InmemStrategy;
 use diskann_inmem::layers::Full;
 use diskann_inmem::provider::Config as InmemProviderConfig;
 use diskann_vector::distance::Metric;
+use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -43,6 +50,8 @@ const MAX_POINTS: NonZeroUsize = NonZeroUsize::new(1_000_000).unwrap();
 
 type DiskannProvider = InmemProvider<Full<f32>, PrimaryId>;
 
+type DiskannIndex = DiskANNIndex<DiskannProvider>;
+
 pub struct DiskannIndexFactory {
     _worker: async_channel::Sender<Worker>,
     memory: mpsc::Sender<Memory>,
@@ -55,17 +64,10 @@ impl VsIndexFactory for DiskannIndexFactory {
         index: VsIndexConfiguration,
         _table: Arc<RwLock<Table>>,
     ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
-        let params = DiskannParams::new(&index, self.alpha, MAX_POINTS)?;
-        let layer = Full::<f32>::new(usize::from(params.dim.0), params.metric);
-        let cfg = InmemProviderConfig::new(
-            usize::from(params.max_points),
-            params.config.max_degree().get(),
-        );
-        let provider = InmemProvider::<_, PrimaryId>::new(layer, cfg, vec![])
-            .context("failed to create InmemProvider")?;
-        let diskann_index = DiskANNIndex::new(params.config, provider, None);
+        let params = DiskannParams::new(&index, self.alpha, MAX_POINTS)
+            .context("failed to create DiskANN parameters")?;
 
-        new(index.key, diskann_index, self.memory.clone())
+        new(index.key, self.memory.clone(), params)
     }
 
     fn index_engine_version(&self) -> String {
@@ -90,9 +92,9 @@ pub fn new_diskann(
 }
 
 fn new(
-    index_key: crate::IndexKey,
-    index: DiskANNIndex<DiskannProvider>,
+    index_key: IndexKey,
     memory: mpsc::Sender<Memory>,
+    params: DiskannParams,
 ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
 
@@ -102,6 +104,8 @@ fn new(
         {
             async move {
                 debug!("starting");
+
+                let mut state = State::new(params);
 
                 let mut allocate_prev = Allocate::Can;
                 let allocate_rx = memory.subscribe_allocate().await;
@@ -113,9 +117,22 @@ fn new(
                     }
 
                     match msg {
-                        VsIndex::AddVector { .. }
-                        | VsIndex::RemoveVector { .. }
-                        | VsIndex::RemovePartition { .. } => {
+                        VsIndex::AddVector {
+                            partition_id,
+                            primary_id,
+                            embedding,
+                            in_progress: _in_progress,
+                        } => {
+                            state.add_vector(partition_id, primary_id, embedding).await;
+                        }
+                        VsIndex::RemoveVector {
+                            partition_id,
+                            primary_id,
+                            in_progress: _in_progress,
+                        } => {
+                            state.remove_vector(partition_id, primary_id).await;
+                        }
+                        VsIndex::RemovePartition { .. } => {
                             warn!("not implemented yet");
                         }
                         VsIndex::Ann { tx, .. } | VsIndex::FilteredAnn { tx, .. } => {
@@ -128,7 +145,6 @@ fn new(
                         }
                     }
                 }
-                drop(index);
 
                 debug!("finished");
             }
@@ -137,6 +153,104 @@ fn new(
     ));
 
     Ok(tx)
+}
+
+fn create_diskann_index(
+    params: &DiskannParams,
+    start_point: Option<&[f32]>,
+) -> anyhow::Result<DiskannIndex> {
+    let layer = Full::<f32>::new(usize::from(params.dim.0), params.metric);
+    let cfg = InmemProviderConfig::new(
+        usize::from(params.max_points),
+        params.config.max_degree().get(),
+    );
+    let start_points: Vec<&[f32]> = start_point.into_iter().collect();
+    let provider = InmemProvider::<_, PrimaryId>::new(layer, cfg, start_points)
+        .context("failed to create InmemProvider")?;
+    Ok(DiskANNIndex::new(params.config.clone(), provider, None))
+}
+
+struct Partition {
+    index: DiskANNIndex<DiskannProvider>,
+}
+
+struct State {
+    partitions: BTreeMap<PartitionId, Partition>,
+    params: DiskannParams,
+}
+
+impl State {
+    fn new(params: DiskannParams) -> Self {
+        Self {
+            partitions: BTreeMap::new(),
+            params,
+        }
+    }
+
+    fn get_or_create_partition(
+        &mut self,
+        partition_id: &PartitionId,
+        start_point: Option<&[f32]>,
+    ) -> anyhow::Result<&mut Partition> {
+        match self.partitions.entry(*partition_id) {
+            Entry::Occupied(entry) => Ok(entry.into_mut()),
+            Entry::Vacant(entry) => {
+                let index = create_diskann_index(&self.params, start_point).context(format!(
+                    "failed to create index for partition {partition_id:?}"
+                ))?;
+
+                Ok(entry.insert(Partition { index }))
+            }
+        }
+    }
+
+    async fn add_vector(
+        &mut self,
+        partition_id: PartitionId,
+        primary_id: PrimaryId,
+        embedding: Vector,
+    ) {
+        let partition =
+            match self.get_or_create_partition(&partition_id, Some(embedding.as_slice())) {
+                Ok(partition) => partition,
+                Err(err) => {
+                    warn!("add_vector failed: {err}");
+                    return;
+                }
+            };
+        if let Err(err) = partition
+            .index
+            .insert(
+                &InmemStrategy,
+                &InmemContext,
+                &primary_id,
+                embedding.as_slice(),
+            )
+            .await
+        {
+            warn!("add_vector: failed to insert vector: {err}");
+        }
+    }
+
+    async fn remove_vector(&mut self, partition_id: PartitionId, primary_id: PrimaryId) {
+        let Some(partition) = self.partitions.get_mut(&partition_id) else {
+            debug!("remove_vector: partition {partition_id:?} not found");
+            return;
+        };
+        if let Err(err) = partition
+            .index
+            .inplace_delete(
+                InmemStrategy,
+                &InmemContext,
+                &primary_id,
+                self.params.config.pruned_degree().get(),
+                InplaceDeleteMethod::OneHop,
+            )
+            .await
+        {
+            warn!("remove_vector: failed to delete vector: {err}");
+        }
+    }
 }
 
 #[hotpath::measure]

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -6,10 +6,13 @@
 use crate::Config;
 use crate::Dimensions;
 use crate::DiskannAlpha;
+use crate::IndexKey;
 use crate::PrimaryId;
 use crate::SpaceType;
 use crate::VsIndexFactory;
+use crate::memory::Allocate;
 use crate::memory::Memory;
+use crate::memory::MemoryExt;
 use crate::perf;
 use crate::table::Table;
 use crate::vs_index::actor::VsIndex;
@@ -33,6 +36,7 @@ use tokio::sync::watch;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::debug_span;
+use tracing::error;
 use tracing::warn;
 
 const MAX_POINTS: NonZeroUsize = NonZeroUsize::new(1_000_000).unwrap();
@@ -41,7 +45,7 @@ type DiskannProvider = InmemProvider<Full<f32>, PrimaryId>;
 
 pub struct DiskannIndexFactory {
     _worker: async_channel::Sender<Worker>,
-    _memory: mpsc::Sender<Memory>,
+    memory: mpsc::Sender<Memory>,
     alpha: DiskannAlpha,
 }
 
@@ -61,7 +65,7 @@ impl VsIndexFactory for DiskannIndexFactory {
             .context("failed to create InmemProvider")?;
         let diskann_index = DiskANNIndex::new(params.config, provider, None);
 
-        new(index.key, diskann_index)
+        new(index.key, diskann_index, self.memory.clone())
     }
 
     fn index_engine_version(&self) -> String {
@@ -78,7 +82,7 @@ pub fn new_diskann(
 
     Ok(DiskannIndexFactory {
         _worker: worker,
-        _memory: memory,
+        memory,
         alpha: config
             .diskann_alpha
             .unwrap_or(DiskannAlpha::new(DISKANN_DEFAULT_ALPHA).unwrap()),
@@ -88,15 +92,26 @@ pub fn new_diskann(
 fn new(
     index_key: crate::IndexKey,
     index: DiskANNIndex<DiskannProvider>,
+    memory: mpsc::Sender<Memory>,
 ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
     let (tx, mut rx) = mpsc::channel(perf::channel_size().into());
+
+    let span_key = index_key.clone();
 
     tokio::spawn(perf::hotpath_async(
         {
             async move {
                 debug!("starting");
 
+                let mut allocate_prev = Allocate::Can;
+                let allocate_rx = memory.subscribe_allocate().await;
+
                 while let Some(msg) = rx.recv().await {
+                    if !check_memory_allocation(&msg, &allocate_rx, &mut allocate_prev, &index_key)
+                    {
+                        continue;
+                    }
+
                     match msg {
                         VsIndex::AddVector { .. }
                         | VsIndex::RemoveVector { .. }
@@ -118,12 +133,34 @@ fn new(
                 debug!("finished");
             }
         }
-        .instrument(debug_span!("diskann", "{index_key}")),
+        .instrument(debug_span!("diskann", "{span_key}")),
     ));
 
     Ok(tx)
 }
 
+#[hotpath::measure]
+fn check_memory_allocation(
+    msg: &VsIndex,
+    rx_allocate: &watch::Receiver<Allocate>,
+    allocate_prev: &mut Allocate,
+    key: &IndexKey,
+) -> bool {
+    if !matches!(msg, VsIndex::AddVector { .. }) {
+        return true;
+    }
+
+    let allocate = *rx_allocate.borrow();
+    if allocate == Allocate::Cannot {
+        if *allocate_prev == Allocate::Can {
+            error!("Unable to add vector for index {key}: not enough memory to reserve more space");
+        }
+        *allocate_prev = allocate;
+        return false;
+    }
+    *allocate_prev = allocate;
+    true
+}
 #[derive(Clone)]
 struct DiskannParams {
     config: DiskannConfig,

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -6,6 +6,7 @@
 use crate::Config;
 use crate::Dimensions;
 use crate::DiskannAlpha;
+use crate::PrimaryId;
 use crate::SpaceType;
 use crate::VsIndexFactory;
 use crate::memory::Memory;
@@ -20,13 +21,9 @@ use diskann::graph::DiskANNIndex;
 use diskann::graph::config::Builder;
 use diskann::graph::config::MaxDegree;
 use diskann::graph::config::defaults::ALPHA as DISKANN_DEFAULT_ALPHA;
-use diskann_providers::model::graph::provider::async_::FastMemoryVectorProviderAsync;
-use diskann_providers::model::graph::provider::async_::TableDeleteProviderAsync;
-use diskann_providers::model::graph::provider::async_::common::NoStore;
-use diskann_providers::model::graph::provider::async_::common::TableBasedDeletes;
-use diskann_providers::model::graph::provider::async_::inmem::CreateFullPrecision;
-use diskann_providers::model::graph::provider::async_::inmem::DefaultProvider;
-use diskann_providers::model::graph::provider::async_::inmem::DefaultProviderParameters;
+use diskann_inmem::Provider as InmemProvider;
+use diskann_inmem::layers::Full;
+use diskann_inmem::provider::Config as InmemProviderConfig;
 use diskann_vector::distance::Metric;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -40,8 +37,7 @@ use tracing::warn;
 
 const MAX_POINTS: NonZeroUsize = NonZeroUsize::new(1_000_000).unwrap();
 
-type DiskannProvider =
-    DefaultProvider<FastMemoryVectorProviderAsync<f32>, NoStore, TableDeleteProviderAsync>;
+type DiskannProvider = InmemProvider<Full<f32>, PrimaryId>;
 
 pub struct DiskannIndexFactory {
     _worker: async_channel::Sender<Worker>,
@@ -56,21 +52,13 @@ impl VsIndexFactory for DiskannIndexFactory {
         _table: Arc<RwLock<Table>>,
     ) -> anyhow::Result<mpsc::Sender<VsIndex>> {
         let params = DiskannParams::new(&index, self.alpha, MAX_POINTS)?;
-        let provider_params = DefaultProviderParameters::simple(
+        let layer = Full::<f32>::new(usize::from(params.dim.0), params.metric);
+        let cfg = InmemProviderConfig::new(
             usize::from(params.max_points),
-            usize::from(params.dim.0),
-            params.metric,
-            u32::from(params.config.max_degree_u32()),
+            params.config.max_degree().get(),
         );
-
-        let provider: DiskannProvider = DefaultProvider::new_empty(
-            provider_params,
-            CreateFullPrecision::<f32>::new(usize::from(params.dim.0), None),
-            NoStore,
-            TableBasedDeletes,
-        )
-        .context("failed to create DiskANN provider")?;
-
+        let provider = InmemProvider::<_, PrimaryId>::new(layer, cfg, vec![])
+            .context("failed to create InmemProvider")?;
         let diskann_index = DiskANNIndex::new(params.config, provider, None);
 
         new(index.key, diskann_index)

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -18,9 +18,11 @@ use crate::memory::Allocate;
 use crate::memory::Memory;
 use crate::memory::MemoryExt;
 use crate::perf;
+use crate::table::IndexId;
 use crate::table::Table;
 use crate::table::TableSearch;
 use crate::vs_index::actor::AnnR;
+use crate::vs_index::actor::CountR;
 use crate::vs_index::actor::VsIndex;
 use crate::vs_index::factory::VsIndexConfiguration;
 use crate::vs_index::validator;
@@ -163,9 +165,8 @@ fn new(
                                 "DiskANN index does not support filtered search"
                             )));
                         }
-                        VsIndex::Count { tx, .. } => {
-                            _ = tx
-                                .send(Err(anyhow::anyhow!("DiskANN index is not implemented yet")));
+                        VsIndex::Count { index_key, tx } => {
+                            _ = tx.send(state.count(&index_key));
                         }
                     }
                 }
@@ -203,6 +204,7 @@ where
     T: TableSearch + Send + Sync + 'static,
 {
     partitions: BTreeMap<PartitionId, Partition>,
+    sizes: BTreeMap<IndexId, usize>,
     table: Arc<RwLock<T>>,
     params: DiskannParams,
 }
@@ -214,6 +216,7 @@ where
     fn new(table: Arc<RwLock<T>>, params: DiskannParams) -> Self {
         Self {
             partitions: BTreeMap::new(),
+            sizes: BTreeMap::new(),
             table,
             params,
         }
@@ -230,6 +233,8 @@ where
                 let index = create_diskann_index(&self.params, start_point).context(format!(
                     "failed to create index for partition {partition_id:?}"
                 ))?;
+
+                self.sizes.entry(partition_id.index_id()).or_insert(0);
 
                 Ok(entry.insert(Partition { index }))
             }
@@ -261,6 +266,9 @@ where
             .await
         {
             warn!("add_vector: failed to insert vector: {err}");
+        } else {
+            let size = self.sizes.entry(partition_id.index_id()).or_insert(0);
+            *size = size.saturating_add(1);
         }
     }
 
@@ -281,6 +289,9 @@ where
             .await
         {
             warn!("remove_vector: failed to delete vector: {err}");
+        } else {
+            let size = self.sizes.entry(partition_id.index_id()).or_insert(0);
+            *size = size.saturating_sub(1);
         }
     }
 
@@ -361,6 +372,18 @@ where
             |it| it.unzip(),
         )?;
         Ok((primary_keys, distances))
+    }
+
+    fn count(&self, index_key: &IndexKey) -> CountR {
+        let index_id = {
+            let table = self.table.read().unwrap();
+            let Some(index_id) = table.index_id(index_key) else {
+                anyhow::bail!("index id not found for index key {index_key}");
+            };
+            index_id
+        };
+
+        Ok(self.sizes.get(&index_id).copied().unwrap_or(0))
     }
 }
 


### PR DESCRIPTION
This PR is an alternative to #535 with the newly merged Diskann In Mem 2.0 provider.
It is more convenient to use because of arbitrary ids but it is still experimental and likely to require fixes from the DiskANN team. I think it's better to try and incorporate it rather than relying on the old provider. 

Fixes: VECTOR-714