### PR TITLE
benches,benchmark: refactor for testing search and delete

### DIFF
--- a/crates/benchmark/src/data/fbin.rs
+++ b/crates/benchmark/src/data/fbin.rs
@@ -6,7 +6,6 @@
 use crate::data::Query;
 use futures::StreamExt;
 use futures::stream;
-use futures::stream::BoxStream;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::io::SeekFrom;
@@ -51,9 +50,20 @@ pub(crate) async fn dimension(path: Arc<PathBuf>, config: Arc<Config>) -> usize 
         .dimension as usize
 }
 
-pub(crate) async fn ids_stream(path: Arc<PathBuf>, config: Arc<Config>) -> BoxStream<'static, i64> {
+pub(crate) async fn ids_stream(path: Arc<PathBuf>, config: Arc<Config>) -> mpsc::Receiver<i64> {
     let header = Header::header(&path.join(&config.data_fbin)).await;
-    stream::iter(0..header.count as i64).boxed()
+
+    let workers = Handle::current().metrics().num_workers();
+    const OVERLOAD_FACTOR: usize = 3;
+    let (tx, rx) = mpsc::channel(workers * OVERLOAD_FACTOR);
+    tokio::spawn(async move {
+        for id in 0..header.count as i64 {
+            if tx.send(id).await.is_err() {
+                break;
+            }
+        }
+    });
+    rx
 }
 
 pub(crate) async fn vector_stream(

--- a/crates/benchmark/src/data/mod.rs
+++ b/crates/benchmark/src/data/mod.rs
@@ -20,6 +20,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::io::BufWriter;
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::info;
 
 const DATASET_FILENAME: &str = "dataset.toml";
@@ -84,6 +85,17 @@ impl Data {
         }
     }
 
+    pub(crate) async fn ids_stream(&self) -> mpsc::Receiver<i64> {
+        match &self.format {
+            Format::Parquet(config) => {
+                parquet::ids_stream(Arc::clone(&self.path), Arc::clone(config)).await
+            }
+            Format::Fbin(config) => {
+                fbin::ids_stream(Arc::clone(&self.path), Arc::clone(config)).await
+            }
+        }
+    }
+
     pub(crate) fn buckets(&self) -> Arc<BTreeMap<i64, u8>> {
         Arc::clone(&self.buckets)
     }
@@ -114,12 +126,12 @@ async fn format(path: &Path) -> Format {
 }
 
 async fn build_buckets(path: Arc<PathBuf>, format: &Format) -> BTreeMap<i64, u8> {
-    let stream = match &format {
+    let rx = match &format {
         Format::Parquet(config) => parquet::ids_stream(Arc::clone(&path), Arc::clone(config)).await,
         Format::Fbin(config) => fbin::ids_stream(Arc::clone(&path), Arc::clone(config)).await,
     };
     info!("Building buckets for dataset at {path:?}...");
-    let mut buckets = stream
+    let mut buckets = ReceiverStream::new(rx)
         .map(|id| (id, u8::MAX))
         .collect::<BTreeMap<_, _>>()
         .await;

--- a/crates/benchmark/src/data/parquet.rs
+++ b/crates/benchmark/src/data/parquet.rs
@@ -12,7 +12,6 @@ use arrow_array::types::Int64Type;
 use futures::Stream;
 use futures::StreamExt;
 use futures::stream;
-use futures::stream::BoxStream;
 use itertools::Itertools;
 use parquet::arrow::ProjectionMask;
 use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
@@ -167,8 +166,8 @@ fn extract_embedding(
     ids.zip(embs).collect_vec()
 }
 
-pub(crate) async fn ids_stream(path: Arc<PathBuf>, config: Arc<Config>) -> BoxStream<'static, i64> {
-    train_files(path, Arc::clone(&config))
+pub(crate) async fn ids_stream(path: Arc<PathBuf>, config: Arc<Config>) -> mpsc::Receiver<i64> {
+    let mut stream = train_files(path, Arc::clone(&config))
         .await
         .then({
             let config = Arc::clone(&config);
@@ -202,7 +201,19 @@ pub(crate) async fn ids_stream(path: Arc<PathBuf>, config: Arc<Config>) -> BoxSt
             stream::iter(ids)
         })
         .flatten()
-        .boxed()
+        .boxed();
+
+    let workers = Handle::current().metrics().num_workers();
+    const OVERLOAD_FACTOR: usize = 3;
+    let (tx, rx) = mpsc::channel(workers * OVERLOAD_FACTOR);
+    tokio::spawn(async move {
+        while let Some(id) = stream.next().await {
+            if tx.send(id).await.is_err() {
+                return;
+            }
+        }
+    });
+    rx
 }
 
 pub(crate) async fn vector_stream(

--- a/crates/benchmark/src/data/parquet.rs
+++ b/crates/benchmark/src/data/parquet.rs
@@ -14,7 +14,10 @@ use futures::StreamExt;
 use futures::stream;
 use itertools::Itertools;
 use parquet::arrow::ProjectionMask;
+use parquet::arrow::arrow_reader::ArrowReaderMetadata;
+use parquet::arrow::arrow_reader::ArrowReaderOptions;
 use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
+use parquet::file::metadata::ParquetMetaDataReader;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -24,6 +27,7 @@ use tap::Pipe;
 use tokio::fs;
 use tokio::fs::File;
 use tokio::runtime::Handle;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReadDirStream;
 
@@ -220,66 +224,94 @@ pub(crate) async fn vector_stream(
     path: Arc<PathBuf>,
     config: Arc<Config>,
 ) -> mpsc::Receiver<(i64, Box<[f32]>)> {
-    let mut stream = train_files(path, Arc::clone(&config))
-        .await
-        .then({
+    let workers = Handle::current().metrics().num_workers();
+    const OVERLOAD_FACTOR: usize = 3;
+    let (tx, rx) = mpsc::channel(workers * OVERLOAD_FACTOR);
+    const BUFFER_SIZE: usize = 2;
+    let semaphore = Arc::new(Semaphore::new(BUFFER_SIZE));
+    tokio::spawn(async move {
+        let mut stream = std::pin::pin!(train_files(path, Arc::clone(&config)).await);
+        while let Some(path) = stream.next().await {
             let config = Arc::clone(&config);
-            move |path| {
+            let tx = tx.clone();
+            let semaphore = Arc::clone(&semaphore);
+            let mut file = File::open(&path).await.unwrap();
+            let file_size = file.metadata().await.unwrap().len();
+            let metadata = Arc::new(
+                ParquetMetaDataReader::new()
+                    .load_and_finish(&mut file, file_size)
+                    .await
+                    .unwrap(),
+            );
+            let reader_metadata =
+                ArrowReaderMetadata::try_new(Arc::clone(&metadata), ArrowReaderOptions::new())
+                    .unwrap();
+            for row_group_idx in 0..metadata.row_groups().len() {
+                tracing::info!("Processing {row_group_idx} row_group for {path:?}");
                 let config = Arc::clone(&config);
-                async move {
-                    ParquetRecordBatchStreamBuilder::new(File::open(path).await.unwrap())
-                        .await
-                        .unwrap()
+                let tx = tx.clone();
+                let reader_metadata = reader_metadata.clone();
+                let file = file.try_clone().await.unwrap();
+                let mut stream =
+                    ParquetRecordBatchStreamBuilder::new_with_metadata(file, reader_metadata)
                         .pipe(|builder| {
                             let mask = ProjectionMask::columns(
                                 builder.parquet_schema(),
                                 [&*config.id_column, &*config.embedding_column],
                             );
-                            builder.with_projection(mask)
+                            builder
+                                .with_projection(mask)
+                                .with_row_groups(vec![row_group_idx])
                         })
                         .build()
                         .unwrap()
-                }
-            }
-        })
-        .flatten()
-        .map(move |batch| batch.unwrap())
-        .map(move |batch| {
-            let ids = batch
-                .column_by_name(&config.id_column)
-                .unwrap()
-                .as_primitive::<Int64Type>();
-            let ids = ids.iter().map(|id| id.unwrap());
+                        .map(move |batch| batch.unwrap())
+                        .map(move |batch| {
+                            let ids = batch
+                                .column_by_name(&config.id_column)
+                                .unwrap()
+                                .as_primitive::<Int64Type>();
+                            let ids = ids.iter().map(|id| id.unwrap());
 
-            let ids_embs = if let Some(embs) = batch
-                .column_by_name(&config.embedding_column)
-                .unwrap()
-                .as_list_opt::<i32>()
-            {
-                extract_embedding(ids, embs.iter())
-            } else {
-                extract_embedding(
-                    ids,
-                    batch
-                        .column_by_name(&config.embedding_column)
-                        .unwrap()
-                        .as_list::<i64>()
-                        .iter(),
-                )
-            };
+                            if let Some(embs) = batch
+                                .column_by_name(&config.embedding_column)
+                                .unwrap()
+                                .as_list_opt::<i32>()
+                            {
+                                extract_embedding(ids, embs.iter())
+                            } else {
+                                extract_embedding(
+                                    ids,
+                                    batch
+                                        .column_by_name(&config.embedding_column)
+                                        .unwrap()
+                                        .as_list::<i64>()
+                                        .iter(),
+                                )
+                            }
+                        })
+                        .boxed();
 
-            stream::iter(ids_embs)
-        })
-        .flatten()
-        .boxed();
+                let Some(ids_embs) = stream.next().await else {
+                    continue;
+                };
 
-    let workers = Handle::current().metrics().num_workers();
-    const OVERLOAD_FACTOR: usize = 3;
-    let (tx, rx) = mpsc::channel(workers * OVERLOAD_FACTOR);
-    tokio::spawn(async move {
-        while let Some(id_emb) = stream.next().await {
-            if tx.send(id_emb).await.is_err() {
-                return;
+                let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+                tokio::spawn(async move {
+                    for (id, emb) in ids_embs {
+                        if tx.send((id, emb)).await.is_err() {
+                            break;
+                        }
+                    }
+                    while let Some(ids_embs) = stream.next().await {
+                        for (id, emb) in ids_embs {
+                            if tx.send((id, emb)).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                    drop(permit);
+                });
             }
         }
     });

--- a/crates/benchmark/src/db.rs
+++ b/crates/benchmark/src/db.rs
@@ -219,6 +219,50 @@ impl Scylla {
         _ = semaphore.acquire_many(concurrency as u32).await.unwrap();
     }
 
+    pub(crate) async fn delete_rows(
+        &self,
+        keyspace: &str,
+        table: &str,
+        buckets: Arc<BTreeMap<i64, u8>>,
+        mut rx: mpsc::Receiver<i64>,
+        concurrency: usize,
+    ) {
+        let mut st_delete = self
+            .0
+            .session
+            .prepare(format!(
+                "DELETE FROM {keyspace}.{table} WHERE {BUCKET} = ? AND {VECTOR_ID} = ?"
+            ))
+            .await
+            .unwrap();
+        st_delete.set_consistency(Consistency::Any);
+
+        let semaphore = Arc::new(Semaphore::new(concurrency));
+
+        let mut count = 0;
+        while let Some(vector_id) = rx.recv().await {
+            let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+            let scylla = Arc::clone(&self.0);
+            let st_delete = st_delete.clone();
+
+            count += 1;
+            if count % 1_000_000 == 0 {
+                info!("Deleting vector {}M", count / 1_000_000);
+            }
+
+            let bucket = *buckets.get(&vector_id).unwrap_or(&u8::MAX) as i64;
+            tokio::spawn(async move {
+                scylla
+                    .session
+                    .execute_unpaged(&st_delete, (bucket, vector_id))
+                    .await
+                    .unwrap();
+                drop(permit);
+            });
+        }
+        _ = semaphore.acquire_many(concurrency as u32).await.unwrap();
+    }
+
     pub(crate) async fn search(&self, bucket: Option<u8>, query: &Query) -> f64 {
         let found = if let Some(bucket) = bucket {
             time::timeout(Duration::from_secs(10), async move {

--- a/crates/benchmark/src/main.rs
+++ b/crates/benchmark/src/main.rs
@@ -143,6 +143,29 @@ enum Command {
         index: String,
     },
 
+    DeleteRows {
+        #[clap(long)]
+        data_dir: PathBuf,
+
+        #[clap(long)]
+        scylla: SocketAddr,
+
+        #[clap(long)]
+        user: Option<String>,
+
+        #[clap(long)]
+        passwd_path: Option<PathBuf>,
+
+        #[clap(long, default_value = KEYSPACE)]
+        keyspace: String,
+
+        #[clap(long, default_value = TABLE)]
+        table: String,
+
+        #[clap(long, value_parser = clap::value_parser!(u32).range(1..=1_000_000))]
+        concurrency: u32,
+    },
+
     SearchCql {
         #[clap(long)]
         data_dir: PathBuf,
@@ -311,6 +334,32 @@ async fn main() {
             })
             .await;
             info!("Drop Index took {duration:.2?}");
+        }
+
+        Command::DeleteRows {
+            data_dir,
+            scylla,
+            user,
+            passwd_path,
+            keyspace,
+            table,
+            concurrency,
+        } => {
+            let dataset = data::new(data_dir).await;
+            let scylla = Scylla::new(scylla, user, passwd_path, &keyspace, &table).await;
+            let (duration, _) = measure_duration(async move {
+                scylla
+                    .delete_rows(
+                        &keyspace,
+                        &table,
+                        dataset.buckets(),
+                        dataset.ids_stream().await,
+                        concurrency as usize,
+                    )
+                    .await;
+            })
+            .await;
+            info!("Delete rows took {duration:.2?}");
         }
 
         Command::SearchCql {

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -362,7 +362,7 @@ fn fullscan_add(c: &mut Criterion) {
                             let request = (
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
                                 Some(vec![it as f32; DIMENSIONS].into()),
-                                Timestamp::from_millis(0),
+                                Timestamp::from_millis(1),
                                 AsyncInProgress::Fullscan(tx_in_progress),
                             );
                             let start = Instant::now();
@@ -432,7 +432,7 @@ fn search(c: &mut Criterion) {
                     tx.send((
                         [(CqlValue::BigInt(it))].into_iter().collect(),
                         Some(vec![it as f32; DIMENSIONS].into()),
-                        Timestamp::from_millis(0),
+                        Timestamp::from_millis(1),
                         AsyncInProgress::Fullscan(tx_in_progress.clone()),
                     ))
                     .await
@@ -567,7 +567,7 @@ fn cdc_add(c: &mut Criterion) {
                             let request = (
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
                                 Some(vec![it as f32; DIMENSIONS].into()),
-                                Timestamp::from_millis(0),
+                                Timestamp::from_millis(1),
                                 AsyncInProgress::Fullscan(tx_in_progress),
                             );
                             let start = Instant::now();
@@ -644,7 +644,7 @@ fn cdc_update(c: &mut Criterion) {
                         .send((
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
-                            Timestamp::from_millis(0),
+                            Timestamp::from_millis(1),
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
@@ -667,7 +667,8 @@ fn cdc_update(c: &mut Criterion) {
         RefCell::new(Some((runtime, notify_stop, db, client, tx_cdc)))
     });
 
-    let next_timestamp = Arc::new(AtomicU64::new(0));
+    // We start the next timestamp at 2, because the fullscan inserts used timestamp 1.
+    let next_timestamp = Arc::new(AtomicU64::new(2));
     group.bench_with_input(
         BenchmarkId::new("cdc-update", concurrency),
         &concurrency,
@@ -795,7 +796,7 @@ fn search_while_updating(c: &mut Criterion) {
                         .send((
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
-                            Timestamp::from_millis(0),
+                            Timestamp::from_millis(1),
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
@@ -804,7 +805,7 @@ fn search_while_updating(c: &mut Criterion) {
                         .send((
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
-                            Timestamp::from_millis(0),
+                            Timestamp::from_millis(1),
                             AsyncInProgress::Fullscan(tx_in_progress.clone()),
                         ))
                         .await
@@ -1022,7 +1023,7 @@ fn search_while_inserting(c: &mut Criterion) {
                     while Arc::clone(&notify_stop).notified().now_or_never().is_none() {
                         let pk = pk.fetch_add(1, Ordering::Relaxed);
                         let vector = vec![pk as f32; DIMENSIONS].into();
-                        let timestamp = Timestamp::from_millis(0);
+                        let timestamp = Timestamp::from_millis(1);
                         if tx_cdc
                             .send((
                                 [(CqlValue::BigInt(pk))].into_iter().collect(),
@@ -1049,7 +1050,7 @@ fn search_while_inserting(c: &mut Criterion) {
                         while Arc::clone(&stop_bg).notified().now_or_never().is_none() {
                             let pk = pk.fetch_add(1, Ordering::Relaxed);
                             let vector = vec![pk as f32; DIMENSIONS].into();
-                            let timestamp = Timestamp::from_millis(0);
+                            let timestamp = Timestamp::from_millis(1);
                             if tx_cdc_bg
                                 .send((
                                     [(CqlValue::BigInt(pk))].into_iter().collect(),

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -27,6 +27,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Once;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
@@ -40,6 +41,7 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 use vector_store::AsyncInProgress;
 use vector_store::ColumnName;
@@ -733,11 +735,6 @@ fn search_while_updating(c: &mut Criterion) {
     const INDEX_SIZE: usize = 100000;
     let concurrency = default_concurrency();
     let index_metadata = default_index_metadata(["id".into()], 1, DIMENSIONS);
-    let index_metadata_bg = IndexMetadata {
-        table_name: "tbl_bg".into(),
-        index_name: "idx_bg".into(),
-        ..default_index_metadata(["id".into()], 1, DIMENSIONS)
-    };
     let limit = NonZeroUsize::new(1).unwrap().into();
 
     let mut group = c.benchmark_group("pipeline");
@@ -749,12 +746,10 @@ fn search_while_updating(c: &mut Criterion) {
         let (tx_fixture, rx_fixture) = oneshot::channel();
         let (tx_fullscan, rx_fullscan) = mpsc::channel(runtime.metrics().num_workers() * 3);
         let (tx_cdc, rx_cdc) = mpsc::channel(runtime.metrics().num_workers() * 3);
-        let (tx_fullscan_bg, rx_fullscan_bg) = mpsc::channel(runtime.metrics().num_workers() * 3);
-        let (tx_cdc_bg, rx_cdc_bg) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let bg_concurrency = runtime.metrics().num_workers() * 3;
         runtime.spawn({
             let notify_stop = notify_stop.clone();
             let index_metadata = index_metadata.clone();
-            let index_metadata_bg = index_metadata_bg.clone();
             async move {
                 let node_state = vector_store::new_node_state().await;
                 let (db_actor, db) = db_basic::new(node_state.clone());
@@ -773,35 +768,12 @@ fn search_while_updating(c: &mut Criterion) {
                     Some(scan_fn_mpsc(rx_cdc)),
                 );
 
-                setup_table(
-                    &db,
-                    &index_metadata_bg,
-                    ["id".into()],
-                    1,
-                    [("id".into(), NativeType::BigInt)],
-                );
-                setup_index(
-                    &db,
-                    index_metadata_bg.clone(),
-                    Some(scan_fn_mpsc(rx_fullscan_bg)),
-                    Some(scan_fn_mpsc(rx_cdc_bg)),
-                );
-
                 let (config_tx, config_rx) = watch::channel(default_config().await);
                 let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
 
                 let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
                 for it in 0..INDEX_SIZE {
                     tx_fullscan
-                        .send((
-                            [(CqlValue::BigInt(it as i64))].into_iter().collect(),
-                            Some(vec![it as f32; DIMENSIONS].into()),
-                            Timestamp::from_millis(1),
-                            AsyncInProgress::Fullscan(tx_in_progress.clone()),
-                        ))
-                        .await
-                        .unwrap();
-                    tx_fullscan_bg
                         .send((
                             [(CqlValue::BigInt(it as i64))].into_iter().collect(),
                             Some(vec![it as f32; DIMENSIONS].into()),
@@ -817,13 +789,9 @@ fn search_while_updating(c: &mut Criterion) {
 
                 let keyspace_name = index_metadata.keyspace_name.clone().into();
                 let index_name = index_metadata.index_name.clone().into();
-                let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
-                let index_name_bg = index_metadata_bg.index_name.clone().into();
 
                 drop(tx_fullscan);
                 wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
-                drop(tx_fullscan_bg);
-                wait_until_index_is_ready(&client, &keyspace_name_bg, &index_name_bg).await;
 
                 // run updates in the background while searching
                 let cdc_task = tokio::spawn(async move {
@@ -851,42 +819,14 @@ fn search_while_updating(c: &mut Criterion) {
                     drop(tx_in_progress);
                     while rx_in_progress.recv().await.is_some() {}
                 });
-                let stop_bg = Arc::new(Notify::new());
-                let cdc_task_bg = tokio::spawn({
-                    let stop_bg = Arc::clone(&stop_bg);
-                    async move {
-                        let mut next_timestamp = 0;
-                        let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
-                        while Arc::clone(&stop_bg).notified().now_or_never().is_none() {
-                            let id = rand::random_range(0..INDEX_SIZE) as i64;
-                            let vector = vec![next_timestamp as f32; DIMENSIONS].into();
-                            let timestamp = next_timestamp;
-                            next_timestamp += 1;
-                            if tx_cdc_bg
-                                .send((
-                                    [(CqlValue::BigInt(id))].into_iter().collect(),
-                                    Some(vector),
-                                    Timestamp::from_millis(timestamp),
-                                    AsyncInProgress::Fullscan(tx_in_progress.clone()),
-                                ))
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
-                        }
-                        // wait until all in-progress markers are dropped
-                        drop(tx_in_progress);
-                        while rx_in_progress.recv().await.is_some() {}
-                    }
-                });
+                let (bg_task, bg_stop) =
+                    run_search_in_background(db.clone(), client.clone(), bg_concurrency).await;
                 tx_fixture.send((client, config_tx)).unwrap();
 
                 cdc_task.await.unwrap();
-                stop_bg.notify_one();
-                cdc_task_bg.await.unwrap();
+                bg_stop.store(true, Ordering::Relaxed);
+                bg_task.await.unwrap();
                 delete_index(&db, &index_metadata);
-                delete_index(&db, &index_metadata_bg);
             }
         });
         let (client, config_tx) = rx_fixture.blocking_recv().unwrap();
@@ -929,17 +869,10 @@ fn search_while_updating(c: &mut Criterion) {
         notify_stop.notify_one();
         let keyspace_name = index_metadata.keyspace_name.clone().into();
         let index_name = index_metadata.index_name.clone().into();
-        let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
-        let index_name_bg = index_metadata_bg.index_name.clone().into();
         runtime.block_on(wait_until_index_is_removed(
             &client,
             &keyspace_name,
             &index_name,
-        ));
-        runtime.block_on(wait_until_index_is_removed(
-            &client,
-            &keyspace_name_bg,
-            &index_name_bg,
         ));
         drop(client);
         drop(config_tx);
@@ -953,11 +886,6 @@ fn search_while_inserting(c: &mut Criterion) {
     const DIMENSIONS: usize = 1536;
     let concurrency = default_concurrency();
     let index_metadata = default_index_metadata(["id".into()], 1, DIMENSIONS);
-    let index_metadata_bg = IndexMetadata {
-        table_name: "tbl_bg".into(),
-        index_name: "idx_bg".into(),
-        ..default_index_metadata(["id".into()], 1, DIMENSIONS)
-    };
     let limit = NonZeroUsize::new(1).unwrap().into();
 
     let mut group = c.benchmark_group("pipeline");
@@ -968,11 +896,10 @@ fn search_while_inserting(c: &mut Criterion) {
         let notify_stop = Arc::new(Notify::new());
         let (tx_fixture, rx_fixture) = oneshot::channel();
         let (tx_cdc, rx_cdc) = mpsc::channel(runtime.metrics().num_workers() * 3);
-        let (tx_cdc_bg, rx_cdc_bg) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let bg_concurrency = runtime.metrics().num_workers() * 3;
         runtime.spawn({
             let notify_stop = notify_stop.clone();
             let index_metadata = index_metadata.clone();
-            let index_metadata_bg = index_metadata_bg.clone();
             async move {
                 let node_state = vector_store::new_node_state().await;
                 let (db_actor, db) = db_basic::new(node_state.clone());
@@ -991,30 +918,13 @@ fn search_while_inserting(c: &mut Criterion) {
                     Some(scan_fn_mpsc(rx_cdc)),
                 );
 
-                setup_table(
-                    &db,
-                    &index_metadata_bg,
-                    ["id".into()],
-                    1,
-                    [("id".into(), NativeType::BigInt)],
-                );
-                setup_index(
-                    &db,
-                    index_metadata_bg.clone(),
-                    None,
-                    Some(scan_fn_mpsc(rx_cdc_bg)),
-                );
-
                 let (config_tx, config_rx) = watch::channel(default_config().await);
                 let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
 
                 let keyspace_name = index_metadata.keyspace_name.clone().into();
                 let index_name = index_metadata.index_name.clone().into();
-                let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
-                let index_name_bg = index_metadata_bg.index_name.clone().into();
 
                 wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
-                wait_until_index_is_ready(&client, &keyspace_name_bg, &index_name_bg).await;
 
                 // run inserts in the background while searching
                 let cdc_task = tokio::spawn(async move {
@@ -1041,41 +951,14 @@ fn search_while_inserting(c: &mut Criterion) {
                     drop(tx_in_progress);
                     while rx_in_progress.recv().await.is_some() {}
                 });
-                let stop_bg = Arc::new(Notify::new());
-                let cdc_task_bg = tokio::spawn({
-                    let stop_bg = Arc::clone(&stop_bg);
-                    async move {
-                        let pk = Arc::new(AtomicI64::new(0));
-                        let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
-                        while Arc::clone(&stop_bg).notified().now_or_never().is_none() {
-                            let pk = pk.fetch_add(1, Ordering::Relaxed);
-                            let vector = vec![pk as f32; DIMENSIONS].into();
-                            let timestamp = Timestamp::from_millis(1);
-                            if tx_cdc_bg
-                                .send((
-                                    [(CqlValue::BigInt(pk))].into_iter().collect(),
-                                    Some(vector),
-                                    timestamp,
-                                    AsyncInProgress::Fullscan(tx_in_progress.clone()),
-                                ))
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
-                        }
-                        // wait until all in-progress markers are dropped
-                        drop(tx_in_progress);
-                        while rx_in_progress.recv().await.is_some() {}
-                    }
-                });
+                let (bg_task, bg_stop) =
+                    run_search_in_background(db.clone(), client.clone(), bg_concurrency).await;
                 tx_fixture.send((client, config_tx)).unwrap();
 
                 cdc_task.await.unwrap();
-                stop_bg.notify_one();
-                cdc_task_bg.await.unwrap();
+                bg_stop.store(true, Ordering::Relaxed);
+                bg_task.await.unwrap();
                 delete_index(&db, &index_metadata);
-                delete_index(&db, &index_metadata_bg);
             }
         });
         let (client, config_tx) = rx_fixture.blocking_recv().unwrap();
@@ -1118,17 +1001,10 @@ fn search_while_inserting(c: &mut Criterion) {
         notify_stop.notify_one();
         let keyspace_name = index_metadata.keyspace_name.clone().into();
         let index_name = index_metadata.index_name.clone().into();
-        let keyspace_name_bg = index_metadata_bg.keyspace_name.clone().into();
-        let index_name_bg = index_metadata_bg.index_name.clone().into();
         runtime.block_on(wait_until_index_is_removed(
             &client,
             &keyspace_name,
             &index_name,
-        ));
-        runtime.block_on(wait_until_index_is_removed(
-            &client,
-            &keyspace_name_bg,
-            &index_name_bg,
         ));
         drop(client);
         drop(config_tx);
@@ -1165,6 +1041,89 @@ where
         .then(|task| async move { task.await.unwrap() })
         .fold(Duration::ZERO, |acc, x| async move { acc + x })
         .await
+}
+
+async fn run_search_in_background(
+    db: DbBasic,
+    client: Arc<TestClient>,
+    concurrency: usize,
+) -> (JoinHandle<()>, Arc<AtomicBool>) {
+    const DIMENSIONS: usize = 1536;
+    let index_metadata = IndexMetadata {
+        table_name: "tbl_bg".into(),
+        index_name: "idx_bg".into(),
+        ..default_index_metadata(["id".into()], 1, DIMENSIONS)
+    };
+    let (tx_fullscan, rx_fullscan) = mpsc::channel(concurrency);
+
+    setup_table(
+        &db,
+        &index_metadata,
+        ["id".into()],
+        1,
+        [("id".into(), NativeType::BigInt)],
+    );
+    setup_index(
+        &db,
+        index_metadata.clone(),
+        Some(scan_fn_mpsc(rx_fullscan)),
+        None,
+    );
+
+    let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+    tx_fullscan
+        .send((
+            [(CqlValue::BigInt(1i64))].into_iter().collect(),
+            Some(vec![1.0f32; DIMENSIONS].into()),
+            Timestamp::from_millis(1),
+            AsyncInProgress::Fullscan(tx_in_progress),
+        ))
+        .await
+        .unwrap();
+    // wait until all in-progress markers are dropped
+    while rx_in_progress.recv().await.is_some() {}
+
+    let keyspace_name = index_metadata.keyspace_name.clone().into();
+    let index_name = index_metadata.index_name.clone().into();
+    drop(tx_fullscan);
+    wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let task = tokio::spawn({
+        let stop = Arc::clone(&stop);
+        let client = client.clone();
+        let limit = NonZeroUsize::new(1).unwrap().into();
+        async move {
+            let tasks = (0..concurrency)
+                .map(|_| {
+                    let stop = Arc::clone(&stop);
+                    let client = client.clone();
+                    let keyspace_name = keyspace_name.clone();
+                    let index_name = index_name.clone();
+                    tokio::spawn(async move {
+                        let vector = vec![1.0f32; DIMENSIONS];
+                        while !stop.load(Ordering::Relaxed) {
+                            _ = client
+                                .ann(
+                                    &keyspace_name,
+                                    &index_name,
+                                    vector.clone().into(),
+                                    None,
+                                    limit,
+                                )
+                                .await;
+                        }
+                    })
+                })
+                .collect_vec();
+            for task in tasks.into_iter() {
+                task.await.unwrap();
+            }
+            delete_index(&db, &index_metadata);
+            wait_until_index_is_removed(&client, &keyspace_name, &index_name).await;
+        }
+    });
+    (task, stop)
 }
 
 criterion_group!(

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -298,7 +298,7 @@ fn scan_fn_mpsc(
     })
 }
 
-fn fullscan_add(c: &mut Criterion) {
+fn fullscan_insert(c: &mut Criterion) {
     init();
 
     const DIMENSIONS: usize = 128;
@@ -345,7 +345,7 @@ fn fullscan_add(c: &mut Criterion) {
 
     let next_pk = Arc::new(AtomicI64::new(0));
     group.bench_with_input(
-        BenchmarkId::new("fullscan-add", concurrency),
+        BenchmarkId::new("fullscan-insert", concurrency),
         &concurrency,
         |b, concurrency| {
             let fixture = fixture.borrow();
@@ -503,7 +503,7 @@ fn search(c: &mut Criterion) {
     }
 }
 
-fn cdc_add(c: &mut Criterion) {
+fn cdc_insert(c: &mut Criterion) {
     init();
 
     const DIMENSIONS: usize = 128;
@@ -550,7 +550,7 @@ fn cdc_add(c: &mut Criterion) {
 
     let next_pk = Arc::new(AtomicI64::new(0));
     group.bench_with_input(
-        BenchmarkId::new("cdc-add", concurrency),
+        BenchmarkId::new("cdc-insert", concurrency),
         &concurrency,
         |b, concurrency| {
             let fixture = fixture.borrow();
@@ -1169,9 +1169,9 @@ where
 
 criterion_group!(
     benches,
-    fullscan_add,
+    fullscan_insert,
     search,
-    cdc_add,
+    cdc_insert,
     cdc_update,
     search_while_updating,
     search_while_inserting,

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -143,7 +143,12 @@ fn default_index_metadata(
 
 async fn default_config() -> Arc<Config> {
     fn env(key: &str) -> anyhow::Result<String> {
-        Ok(dotenvy::var(key)?)
+        Ok(match key {
+            "VECTOR_STORE_USEARCH_SIMULATOR" => {
+                dotenvy::var(key).unwrap_or("1us:1us:1us".to_string())
+            }
+            _ => dotenvy::var(key)?,
+        })
     }
     Arc::new(vector_store::load_config(env).await.unwrap())
 }

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -728,6 +728,132 @@ fn cdc_update(c: &mut Criterion) {
     }
 }
 
+fn cdc_delete(c: &mut Criterion) {
+    init();
+
+    const DIMENSIONS: usize = 1536;
+    const INDEX_SIZE: usize = 1000000;
+    let concurrency = default_concurrency();
+    let index_metadata = default_index_metadata(["id".into()], 1, DIMENSIONS);
+
+    let mut group = c.benchmark_group("pipeline");
+    group.throughput(criterion::Throughput::Elements(concurrency as u64));
+
+    let fixture = LazyLock::new(|| {
+        let runtime = default_runtime();
+        let notify_stop = Arc::new(Notify::new());
+        let (tx_fixture, rx_fixture) = oneshot::channel();
+        let (tx_fullscan, rx_fullscan) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let (tx_cdc, rx_cdc) = mpsc::channel(concurrency);
+        runtime.spawn({
+            let notify_stop = notify_stop.clone();
+            let index_metadata = index_metadata.clone();
+            async move {
+                let node_state = vector_store::new_node_state().await;
+                let (db_actor, db) = db_basic::new(node_state.clone());
+                setup_table(
+                    &db,
+                    &index_metadata,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                setup_index(
+                    &db,
+                    index_metadata.clone(),
+                    Some(scan_fn_mpsc(rx_fullscan)),
+                    Some(scan_fn_mpsc(rx_cdc)),
+                );
+                let (_config_tx, config_rx) = watch::channel(default_config().await);
+                let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
+
+                let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                for it in 0..INDEX_SIZE {
+                    tx_fullscan
+                        .send((
+                            [(CqlValue::BigInt(it as i64))].into_iter().collect(),
+                            Some(vec![it as f32; DIMENSIONS].into()),
+                            Timestamp::from_millis(1),
+                            AsyncInProgress::Fullscan(tx_in_progress.clone()),
+                        ))
+                        .await
+                        .unwrap();
+                }
+                // wait until all in-progress markers are dropped
+                drop(tx_in_progress);
+                while rx_in_progress.recv().await.is_some() {}
+
+                drop(tx_fullscan);
+                let keyspace_name = index_metadata.keyspace_name.clone().into();
+                let index_name = index_metadata.index_name.clone().into();
+                wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
+
+                tx_fixture.send((db, client)).unwrap();
+                notify_stop.notified().await;
+            }
+        });
+        let (db, client) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, db, client, tx_cdc)))
+    });
+
+    // We start the next timestamp at 2, because the fullscan inserts used timestamp 1.
+    let next_timestamp = Arc::new(AtomicU64::new(2));
+    group.bench_with_input(
+        BenchmarkId::new("cdc-delete", concurrency),
+        &concurrency,
+        |b, concurrency| {
+            let fixture = fixture.borrow();
+            let (runtime, _, _, _, tx_cdc) = fixture.as_ref().unwrap();
+            let next_timestamp = Arc::clone(&next_timestamp);
+            b.to_async(runtime).iter_custom(|iters| {
+                let next_timestamp = Arc::clone(&next_timestamp);
+                let tx_cdc = tx_cdc.clone();
+                async move {
+                    run_with_concurrency(*concurrency, iters, move |_| {
+                        let next_timestamp = Arc::clone(&next_timestamp);
+                        let tx_cdc = tx_cdc.clone();
+                        async move {
+                            let timestamp = next_timestamp.fetch_add(1, Ordering::Relaxed);
+                            let id = timestamp as i64;
+                            let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                            let start = Instant::now();
+                            tx_cdc
+                                .send((
+                                    [(CqlValue::BigInt(id))].into_iter().collect(),
+                                    None,
+                                    Timestamp::from_millis(timestamp),
+                                    AsyncInProgress::Fullscan(tx_in_progress.clone()),
+                                ))
+                                .await
+                                .unwrap();
+                            // wait until the in-progress marker is dropped
+                            drop(tx_in_progress);
+                            while rx_in_progress.recv().await.is_some() {}
+                            start.elapsed()
+                        }
+                    })
+                    .await
+                }
+            })
+        },
+    );
+
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, db, client, _) = fixture.take().unwrap();
+        delete_index(&db, &index_metadata);
+        let keyspace_name = index_metadata.keyspace_name.clone().into();
+        let index_name = index_metadata.index_name.clone().into();
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name,
+            &index_name,
+        ));
+        notify_stop.notify_one();
+        drop(client);
+        wait_until_all_tasks_finished(&runtime);
+    }
+}
+
 fn search_while_updating(c: &mut Criterion) {
     init();
 
@@ -1012,6 +1138,158 @@ fn search_while_inserting(c: &mut Criterion) {
     }
 }
 
+fn search_while_deleting(c: &mut Criterion) {
+    init();
+
+    const DIMENSIONS: usize = 1536;
+    const INDEX_SIZE: usize = 1000000;
+    let concurrency = default_concurrency();
+    let index_metadata = default_index_metadata(["id".into()], 1, DIMENSIONS);
+    let limit = NonZeroUsize::new(1).unwrap().into();
+
+    let mut group = c.benchmark_group("pipeline");
+    group.throughput(criterion::Throughput::Elements(concurrency as u64));
+
+    let fixture = LazyLock::new(|| {
+        let runtime = default_runtime();
+        let notify_stop = Arc::new(Notify::new());
+        let (tx_fixture, rx_fixture) = oneshot::channel();
+        let (tx_fullscan, rx_fullscan) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let (tx_cdc, rx_cdc) = mpsc::channel(runtime.metrics().num_workers() * 3);
+        let bg_concurrency = runtime.metrics().num_workers() * 3;
+        runtime.spawn({
+            let notify_stop = notify_stop.clone();
+            let index_metadata = index_metadata.clone();
+            async move {
+                let node_state = vector_store::new_node_state().await;
+                let (db_actor, db) = db_basic::new(node_state.clone());
+
+                setup_table(
+                    &db,
+                    &index_metadata,
+                    ["id".into()],
+                    1,
+                    [("id".into(), NativeType::BigInt)],
+                );
+                setup_index(
+                    &db,
+                    index_metadata.clone(),
+                    Some(scan_fn_mpsc(rx_fullscan)),
+                    Some(scan_fn_mpsc(rx_cdc)),
+                );
+
+                let (config_tx, config_rx) = watch::channel(default_config().await);
+                let (_server, client) = run_vector_store(config_rx, node_state, db_actor).await;
+
+                // build the index with a fullscan before starting the benchmark
+                let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                for it in 0..INDEX_SIZE {
+                    tx_fullscan
+                        .send((
+                            [(CqlValue::BigInt(it as i64))].into_iter().collect(),
+                            Some(vec![it as f32; DIMENSIONS].into()),
+                            Timestamp::from_millis(1),
+                            AsyncInProgress::Fullscan(tx_in_progress.clone()),
+                        ))
+                        .await
+                        .unwrap();
+                }
+                // wait until all in-progress markers are dropped
+                drop(tx_in_progress);
+                while rx_in_progress.recv().await.is_some() {}
+
+                let keyspace_name = index_metadata.keyspace_name.clone().into();
+                let index_name = index_metadata.index_name.clone().into();
+
+                drop(tx_fullscan);
+                wait_until_index_is_ready(&client, &keyspace_name, &index_name).await;
+
+                // run removes in the background while searching
+                let cdc_task = tokio::spawn(async move {
+                    let mut next_timestamp = 2;
+                    let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                    while Arc::clone(&notify_stop).notified().now_or_never().is_none() {
+                        let id = rand::random_range(0..INDEX_SIZE) as i64;
+                        let timestamp = next_timestamp;
+                        next_timestamp += 1;
+                        if tx_cdc
+                            .send((
+                                [(CqlValue::BigInt(id))].into_iter().collect(),
+                                None,
+                                Timestamp::from_millis(timestamp),
+                                AsyncInProgress::Fullscan(tx_in_progress.clone()),
+                            ))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    // wait until all in-progress markers are dropped
+                    drop(tx_in_progress);
+                    while rx_in_progress.recv().await.is_some() {}
+                });
+                let (bg_task, bg_stop) =
+                    run_search_in_background(db.clone(), client.clone(), bg_concurrency).await;
+                tx_fixture.send((client, config_tx)).unwrap();
+
+                cdc_task.await.unwrap();
+                bg_stop.store(true, Ordering::Relaxed);
+                bg_task.await.unwrap();
+                delete_index(&db, &index_metadata);
+            }
+        });
+        let (client, config_tx) = rx_fixture.blocking_recv().unwrap();
+        RefCell::new(Some((runtime, notify_stop, client, config_tx)))
+    });
+
+    group.bench_with_input(
+        BenchmarkId::new("search-while-deleting", concurrency),
+        &concurrency,
+        |b, concurrency| {
+            let fixture = fixture.borrow();
+            let (runtime, _, client, _) = fixture.as_ref().unwrap();
+            let index_metadata = index_metadata.clone();
+            let client = client.clone();
+            b.to_async(runtime).iter_custom(|iters| {
+                let index_metadata = index_metadata.clone();
+                let client = client.clone();
+                async move {
+                    run_with_concurrency(*concurrency, iters, move |it| {
+                        let keyspace_name = index_metadata.keyspace_name.clone().into();
+                        let index_name = index_metadata.index_name.clone().into();
+                        let client = client.clone();
+                        async move {
+                            let vector = vec![it as f32; DIMENSIONS];
+                            let start = Instant::now();
+                            _ = client
+                                .ann(&keyspace_name, &index_name, vector.into(), None, limit)
+                                .await;
+                            start.elapsed()
+                        }
+                    })
+                    .await
+                }
+            });
+        },
+    );
+
+    if let Some(fixture) = LazyLock::get(&fixture) {
+        let (runtime, notify_stop, client, config_tx) = fixture.take().unwrap();
+        notify_stop.notify_one();
+        let keyspace_name = index_metadata.keyspace_name.clone().into();
+        let index_name = index_metadata.index_name.clone().into();
+        runtime.block_on(wait_until_index_is_removed(
+            &client,
+            &keyspace_name,
+            &index_name,
+        ));
+        drop(client);
+        drop(config_tx);
+        wait_until_all_tasks_finished(&runtime);
+    }
+}
+
 #[hotpath::measure]
 async fn run_with_concurrency<F, Fut>(concurrency: usize, iters: u64, f: F) -> Duration
 where
@@ -1132,8 +1410,10 @@ criterion_group!(
     search,
     cdc_insert,
     cdc_update,
+    cdc_delete,
     search_while_updating,
     search_while_inserting,
+    search_while_deleting,
 );
 
 #[hotpath::main]


### PR DESCRIPTION
We need performance tests for benchmarking parallel search and delete operations.

This PR refactors benches and introduces new tests: cdc-delete and search-while-deleting.

Additionally this PR adds new benchmark command delete-rows to be able to simulate massive deletion from table.

For faster benchmark testing this PR refactors loading data from parquet file by running reading from disk parallel to the uploading data to scylladb.

Fixes: VECTOR-781