### PR TITLE
chore: update Rust to 1.97.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt", "cargo"]


### PR DESCRIPTION
As 1.97.1 "fixes a miscompilation in an LLVM optimization" it seems a good idea to update the toolchain.