### PR TITLE
httpapi: vector-store: expose index creation options via API endpoints

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -226,13 +226,13 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Retrieves the current operational status and vector count for a specific vector index. The response includes the index's state and the total number of vectors currently indexed (excluding tombstoned or deleted entries). This endpoint enables clients to monitor index readiness and data availability for search operations.",
+        "description": "Retrieves the current operational status and item count for a specific index. The response includes the index's state and the total number of items currently indexed (excluding tombstoned or deleted entries). This endpoint enables clients to monitor index readiness and data availability for search operations.",
         "operationId": "get_index_status",
         "parameters": [
           {
             "name": "keyspace",
             "in": "path",
-            "description": "The name of the ScyllaDB keyspace containing the vector index.",
+            "description": "The name of the ScyllaDB keyspace containing the index.",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/KeyspaceName"
@@ -241,7 +241,7 @@
           {
             "name": "index",
             "in": "path",
-            "description": "The name of the ScyllaDB vector index within the specified keyspace to check status of.",
+            "description": "The name of the ScyllaDB index within the specified keyspace to check status of.",
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/IndexName"
@@ -257,6 +257,7 @@
                   "$ref": "#/components/schemas/IndexStatusResponse"
                 },
                 "example": {
+                  "build_progress": 100.0,
                   "count": 12345,
                   "status": "SERVING"
                 }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "LicenseRef-ScyllaDB-Source-Available-1.0"
     },
-    "version": "2.1.0"
+    "version": "3.0.0"
   },
   "paths": {
     "/api/v1/indexes": {
@@ -26,7 +26,31 @@
                   "items": {
                     "$ref": "#/components/schemas/IndexInfo"
                   }
-                }
+                },
+                "example": [
+                  {
+                    "index": "my_vector_index",
+                    "keyspace": "my_keyspace",
+                    "options": {
+                      "construction_beam_width": 128,
+                      "dimensions": 384,
+                      "maximum_node_connections": 16,
+                      "quantization": "F32",
+                      "search_beam_width": 64,
+                      "similarity_function": "COSINE",
+                      "type": "vector"
+                    }
+                  },
+                  {
+                    "index": "my_fulltext_index",
+                    "keyspace": "my_keyspace",
+                    "options": {
+                      "analyzer": "standard",
+                      "positions": true,
+                      "type": "fulltext"
+                    }
+                  }
+                ]
               }
             }
           }
@@ -356,28 +380,43 @@
         "type": "string",
         "description": "A human-readable description of the error that occurred."
       },
-      "IndexInfo": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/IndexType"
-          },
-          {
-            "type": "object",
-            "required": [
-              "keyspace",
-              "index"
-            ],
-            "properties": {
-              "index": {
-                "$ref": "#/components/schemas/IndexName"
-              },
-              "keyspace": {
-                "$ref": "#/components/schemas/KeyspaceName"
-              }
-            }
-          }
+      "FulltextIndexOptions": {
+        "type": "object",
+        "description": "Options a full-text index was created with.",
+        "required": [
+          "analyzer",
+          "positions"
         ],
-        "description": "Information about an index, such as keyspace, name and type."
+        "properties": {
+          "analyzer": {
+            "type": "string",
+            "description": "Text analyzer used for tokenization."
+          },
+          "positions": {
+            "type": "boolean",
+            "description": "Whether token positions are stored, enabling phrase queries."
+          }
+        }
+      },
+      "IndexInfo": {
+        "type": "object",
+        "description": "Information about an index, such as keyspace, name, and creation options.",
+        "required": [
+          "keyspace",
+          "index",
+          "options"
+        ],
+        "properties": {
+          "index": {
+            "$ref": "#/components/schemas/IndexName"
+          },
+          "keyspace": {
+            "$ref": "#/components/schemas/KeyspaceName"
+          },
+          "options": {
+            "$ref": "#/components/schemas/IndexOptions"
+          }
+        }
       },
       "IndexName": {
         "type": "string",
@@ -419,6 +458,57 @@
           }
         ]
       },
+      "IndexOptions": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VectorIndexOptions",
+                "description": "Vector search index options."
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "vector"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Vector search index options."
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FulltextIndexOptions",
+                "description": "Full-text search index options."
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fulltext"
+                    ]
+                  }
+                }
+              }
+            ],
+            "description": "Full-text search index options."
+          }
+        ],
+        "description": "Options an index was created with, tagged with the index's type."
+      },
       "IndexStatus": {
         "type": "string",
         "description": "Operational status of the vector index.",
@@ -455,45 +545,6 @@
             "$ref": "#/components/schemas/IndexStatus"
           }
         }
-      },
-      "IndexType": {
-        "oneOf": [
-          {
-            "type": "object",
-            "description": "Vector search index with its associated data type.",
-            "required": [
-              "data_type",
-              "type"
-            ],
-            "properties": {
-              "data_type": {
-                "$ref": "#/components/schemas/DataType"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "vector"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "description": "Fulltext search index.",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "fulltext"
-                ]
-              }
-            }
-          }
-        ],
-        "description": "Type of index, distinguishing between vector search and fulltext search indexes."
       },
       "InfoResponse": {
         "type": "object",
@@ -949,6 +1000,16 @@
           }
         }
       },
+      "SimilarityFunction": {
+        "type": "string",
+        "description": "Similarity function used to compare vectors, as set at index creation.",
+        "enum": [
+          "EUCLIDEAN",
+          "COSINE",
+          "DOT_PRODUCT",
+          "HAMMING"
+        ]
+      },
       "SimilarityScore": {
         "type": "number",
         "format": "float",
@@ -961,6 +1022,48 @@
           "format": "float"
         },
         "description": "The vector to use for the Approximate Nearest Neighbor search. The format of data must match the data_type of the index."
+      },
+      "VectorIndexOptions": {
+        "type": "object",
+        "description": "Options a vector index was created with.",
+        "required": [
+          "dimensions",
+          "maximum_node_connections",
+          "construction_beam_width",
+          "search_beam_width",
+          "similarity_function",
+          "quantization"
+        ],
+        "properties": {
+          "construction_beam_width": {
+            "type": "integer",
+            "description": "Beam width used while building the index.",
+            "minimum": 0
+          },
+          "dimensions": {
+            "type": "integer",
+            "description": "Dimensionality of the indexed vectors.",
+            "minimum": 0
+          },
+          "maximum_node_connections": {
+            "type": "integer",
+            "description": "Maximum number of neighbor connections per graph node.",
+            "minimum": 0
+          },
+          "quantization": {
+            "$ref": "#/components/schemas/DataType",
+            "description": "Quantization applied to stored vectors."
+          },
+          "search_beam_width": {
+            "type": "integer",
+            "description": "Beam width used while searching.",
+            "minimum": 0
+          },
+          "similarity_function": {
+            "$ref": "#/components/schemas/SimilarityFunction",
+            "description": "Similarity function used to compare vectors."
+          }
+        }
       }
     },
     "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -57,6 +57,70 @@
         }
       }
     },
+    "/api/v1/indexes/{keyspace}/{index}": {
+      "get": {
+        "tags": [
+          "scylla-vector-store-index"
+        ],
+        "description": "Retrieves information about a specific index, including its search type and the options it was created with. This is the same information reported per-entry by the `/api/v1/indexes` listing, scoped to a single index.",
+        "operationId": "get_index_info",
+        "parameters": [
+          {
+            "name": "keyspace",
+            "in": "path",
+            "description": "The name of the ScyllaDB keyspace containing the index.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/KeyspaceName"
+            }
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "description": "The name of the ScyllaDB index within the specified keyspace.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IndexName"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful operation. Returns the index's type and creation options.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexInfo"
+                },
+                "example": {
+                  "index": "my_vector_index",
+                  "keyspace": "my_keyspace",
+                  "options": {
+                    "construction_beam_width": 128,
+                    "dimensions": 384,
+                    "maximum_node_connections": 16,
+                    "quantization": "F32",
+                    "search_beam_width": 64,
+                    "similarity_function": "COSINE",
+                    "type": "vector"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/indexes/{keyspace}/{index}/ann": {
       "post": {
         "tags": [

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -56,16 +56,6 @@ pub enum DataType {
     B1,
 }
 
-#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
-#[serde(tag = "type", rename_all = "lowercase")]
-/// Type of index, distinguishing between vector search and fulltext search indexes.
-pub enum IndexType {
-    /// Vector search index with its associated data type.
-    Vector { data_type: DataType },
-    /// Fulltext search index.
-    Fulltext,
-}
-
 #[derive(
     Copy,
     Clone,
@@ -92,12 +82,11 @@ impl Serialize for Distance {
 }
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
-/// Information about an index, such as keyspace, name and type.
+/// Information about an index, such as keyspace, name, and creation options.
 pub struct IndexInfo {
     pub keyspace: KeyspaceName,
     pub index: IndexName,
-    #[serde(flatten)]
-    pub index_type: IndexType,
+    pub options: IndexOptions,
 }
 
 impl IndexInfo {
@@ -105,9 +94,14 @@ impl IndexInfo {
         IndexInfo {
             keyspace: String::from(keyspace).into(),
             index: String::from(index).into(),
-            index_type: IndexType::Vector {
-                data_type: DataType::F32,
-            },
+            options: IndexOptions::Vector(VectorIndexOptions {
+                dimensions: 3,
+                maximum_node_connections: 16,
+                construction_beam_width: 128,
+                search_beam_width: 64,
+                similarity_function: SimilarityFunction::Euclidean,
+                quantization: DataType::F32,
+            }),
         }
     }
 }
@@ -143,6 +137,56 @@ pub enum IndexStatus {
     Bootstrapping,
     /// The index has completed the initial table scan. It is now monitoring the database for changes.
     Serving,
+}
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+/// Similarity function used to compare vectors, as set at index creation.
+pub enum SimilarityFunction {
+    /// Euclidean (L2) distance.
+    Euclidean,
+    /// Cosine similarity.
+    Cosine,
+    /// Dot product.
+    DotProduct,
+    /// Hamming distance.
+    Hamming,
+}
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+/// Options a vector index was created with.
+pub struct VectorIndexOptions {
+    /// Dimensionality of the indexed vectors.
+    pub dimensions: usize,
+    /// Maximum number of neighbor connections per graph node.
+    pub maximum_node_connections: usize,
+    /// Beam width used while building the index.
+    pub construction_beam_width: usize,
+    /// Beam width used while searching.
+    pub search_beam_width: usize,
+    /// Similarity function used to compare vectors.
+    pub similarity_function: SimilarityFunction,
+    /// Quantization applied to stored vectors.
+    pub quantization: DataType,
+}
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+/// Options a full-text index was created with.
+pub struct FulltextIndexOptions {
+    /// Text analyzer used for tokenization.
+    pub analyzer: String,
+    /// Whether token positions are stored, enabling phrase queries.
+    pub positions: bool,
+}
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+#[serde(tag = "type", rename_all = "lowercase")]
+/// Options an index was created with, tagged with the index's type.
+pub enum IndexOptions {
+    /// Vector search index options.
+    Vector(VectorIndexOptions),
+    /// Full-text search index options.
+    Fulltext(FulltextIndexOptions),
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]

--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -170,6 +170,29 @@ impl HttpClient {
         }
     }
 
+    pub async fn index_info(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+    ) -> anyhow::Result<IndexInfo> {
+        let response = self
+            .client
+            .get(format!(
+                "{}/indexes/{}/{}",
+                self.url_api, keyspace_name, index_name
+            ))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            Ok(response.json::<IndexInfo>().await?)
+        } else {
+            let status = response.status();
+            let error_text = response.text().await?;
+            Err(anyhow::anyhow!("HTTP {status}: {error_text}"))
+        }
+    }
+
     pub async fn info(&self) -> InfoResponse {
         self.client
             .get(format!("{}/info", self.url_api))

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -39,15 +39,12 @@ use tracing::debug_span;
 use tracing::info;
 use tracing::trace;
 
-type GetVsIndexKeysR = Vec<(IndexKey, crate::IndexOptionsVs)>;
 type AddIndexR = anyhow::Result<()>;
 type GetVsIndexR = Option<(mpsc::Sender<VsIndex>, mpsc::Sender<DbIndex>)>;
 type GetFtsIndexR = Option<(mpsc::Sender<FtsIndex>, mpsc::Sender<DbIndex>)>;
 
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum Engine {
-    GetVsIndexKeys {
-        tx: oneshot::Sender<GetVsIndexKeysR>,
-    },
     AddIndex {
         metadata: IndexMetadata,
         tx: oneshot::Sender<AddIndexR>,
@@ -66,7 +63,6 @@ pub(crate) enum Engine {
 }
 
 pub(crate) trait EngineExt {
-    async fn get_vs_index_keys(&self) -> GetVsIndexKeysR;
     async fn add_index(&self, metadata: IndexMetadata) -> AddIndexR;
     async fn del_index(&self, key: IndexKey);
     async fn get_vs_index(&self, key: IndexKey) -> GetVsIndexR;
@@ -74,15 +70,6 @@ pub(crate) trait EngineExt {
 }
 
 impl EngineExt for mpsc::Sender<Engine> {
-    async fn get_vs_index_keys(&self) -> GetVsIndexKeysR {
-        let (tx, rx) = oneshot::channel();
-        self.send(Engine::GetVsIndexKeys { tx })
-            .await
-            .expect("EngineExt::get_vs_index_keys: internal actor should receive request");
-        rx.await
-            .expect("EngineExt::get_vs_index_keys: internal actor should send response")
-    }
-
     async fn add_index(&self, metadata: IndexMetadata) -> AddIndexR {
         let (tx, rx) = oneshot::channel();
         self.send(Engine::AddIndex { metadata, tx })
@@ -156,8 +143,6 @@ pub(crate) async fn new(
                             break;
                         };
                         match msg {
-                            Engine::GetVsIndexKeys { tx } => get_vs_index_keys(tx, &indexes).await,
-
                             Engine::AddIndex { metadata, tx } => {
                                 add_index(
                                     metadata,
@@ -192,17 +177,6 @@ pub(crate) async fn new(
     );
 
     Ok(tx)
-}
-
-async fn get_vs_index_keys(tx: oneshot::Sender<GetVsIndexKeysR>, indexes: &RwLock<Indexes>) {
-    let keys = indexes
-        .read()
-        .unwrap()
-        .iter_vs()
-        .map(|(key, entry)| (key.clone(), entry.options().clone()))
-        .collect();
-    tx.send(keys)
-        .unwrap_or_else(|_| trace!("Engine::GetVsIndexKeys: unable to send response"));
 }
 
 async fn add_index(
@@ -435,11 +409,6 @@ pub(crate) mod tests {
 
     #[automock]
     pub(crate) trait SimEngine {
-        fn get_vs_index_keys(
-            &self,
-            tx: oneshot::Sender<GetVsIndexKeysR>,
-        ) -> impl Future<Output = ()> + Send + 'static;
-
         fn add_index(
             &self,
             metadata: IndexMetadata,
@@ -477,7 +446,6 @@ pub(crate) mod tests {
 
                 while let Some(msg) = rx.recv().await {
                     match msg {
-                        Engine::GetVsIndexKeys { tx } => sim.get_vs_index_keys(tx).await,
                         Engine::AddIndex { metadata, tx } => sim.add_index(metadata, tx).await,
                         Engine::DelIndex { key } => sim.del_index(key).await,
                         Engine::GetVsIndex { key, tx } => sim.get_vs_index(key, tx).await,

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -321,7 +321,7 @@ async fn add_index_fts(ctx: AddIndexContext<'_>) -> anyhow::Result<()> {
 
     let entry =
         crate::indexes::FtsIndexEntry::new(ctx.metadata, fts_sender, monitor_actor, ctx.db_index)
-            .await;
+            .await?;
     ctx.indexes.write().unwrap().insert_fts(ctx.key, entry);
     Ok(())
 }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -258,19 +258,18 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
 )]
 
 async fn get_indexes(State(state): State<RoutesInnerState>) -> Response {
-    let vs_indexes = state.engine.get_vs_index_keys().await;
-    let fts_guard = state.indexes.read().unwrap();
+    let indexes_guard = state.indexes.read().unwrap();
 
-    let indexes: Vec<_> = vs_indexes
-        .iter()
-        .map(|(key, vs)| IndexInfo {
+    let indexes: Vec<_> = indexes_guard
+        .iter_vs()
+        .map(|(key, entry)| IndexInfo {
             keyspace: key.keyspace().into(),
             index: key.index().into(),
             index_type: IndexType::Vector {
-                data_type: vs.quantization.into(),
+                data_type: entry.options().quantization.into(),
             },
         })
-        .chain(fts_guard.iter_fts().map(|(key, _)| IndexInfo {
+        .chain(indexes_guard.iter_fts().map(|(key, _)| IndexInfo {
             keyspace: key.keyspace().into(),
             index: key.index().into(),
             index_type: IndexType::Fulltext,

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -173,6 +173,7 @@ fn new_open_api_router() -> (Router<RoutesInnerState>, utoipa::openapi::OpenApi)
             OpenApiRouter::new()
                 .routes(routes!(get_indexes))
                 .routes(routes!(get_index_status))
+                .routes(routes!(get_index_info))
                 .routes(routes!(post_index_ann))
                 .routes(routes!(post_index_bm25))
                 .routes(routes!(get_info))
@@ -451,6 +452,75 @@ async fn get_index_status(
         )
             .into_response(),
     }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/indexes/{keyspace}/{index}",
+    tag = "scylla-vector-store-index",
+    description = "Retrieves information about a specific index, including its search type and the options \
+    it was created with. This is the same information reported per-entry by the `/api/v1/indexes` listing, \
+    scoped to a single index.",
+    params(
+        ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the index."),
+        ("index" = httpapi::IndexName, Path, description = "The name of the ScyllaDB index within the specified keyspace.")
+    ),
+    responses(
+        (
+            status = 200,
+            description = "Successful operation. Returns the index's type and creation options.",
+            body = IndexInfo,
+            content_type = "application/json",
+            example = json!({
+                "keyspace": "my_keyspace",
+                "index": "my_vector_index",
+                "options": {
+                    "type": "vector",
+                    "dimensions": 384,
+                    "maximum_node_connections": 16,
+                    "construction_beam_width": 128,
+                    "search_beam_width": 64,
+                    "similarity_function": "COSINE",
+                    "quantization": "F32"
+                }
+            })
+        ),
+        (
+            status = 404,
+            description = "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            content_type = "application/json",
+            body = ErrorMessage
+        )
+    )
+)]
+async fn get_index_info(
+    State(state): State<RoutesInnerState>,
+    Path((keyspace_name, index_name)): Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
+) -> Response {
+    let keyspace_name: crate::KeyspaceName = keyspace_name.into();
+    let index_name: crate::IndexName = index_name.into();
+    let index_key = IndexKey::new(&keyspace_name, &index_name);
+
+    let indexes = state.indexes.read().unwrap();
+    let info = if let Some(entry) = indexes.get_vs(&index_key) {
+        IndexInfo {
+            keyspace: keyspace_name.into(),
+            index: index_name.into(),
+            options: IndexOptions::Vector(entry.options().into()),
+        }
+    } else if let Some(entry) = indexes.get_fts(&index_key) {
+        IndexInfo {
+            keyspace: keyspace_name.into(),
+            index: index_name.into(),
+            options: IndexOptions::Fulltext(entry.options().into()),
+        }
+    } else {
+        let msg = format!("missing index: {keyspace_name}.{index_name}");
+        debug!("get_index_info: {msg}");
+        return (StatusCode::NOT_FOUND, msg).into_response();
+    };
+
+    (StatusCode::OK, response::Json(info)).into_response()
 }
 
 async fn refresh_index_metrics(

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -298,12 +298,12 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
     get,
     path = "/api/v1/indexes/{keyspace}/{index}/status",
     tag = "scylla-vector-store-index",
-    description = "Retrieves the current operational status and vector count for a specific vector index. \
-    The response includes the index's state and the total number of vectors currently indexed (excluding tombstoned or deleted entries). \
+    description = "Retrieves the current operational status and item count for a specific index. \
+    The response includes the index's state and the total number of items currently indexed (excluding tombstoned or deleted entries). \
     This endpoint enables clients to monitor index readiness and data availability for search operations.",
     params(
-        ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the vector index."),
-        ("index" = httpapi::IndexName, Path, description = "The name of the ScyllaDB vector index within the specified keyspace to check status of.")
+        ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the index."),
+        ("index" = httpapi::IndexName, Path, description = "The name of the ScyllaDB index within the specified keyspace to check status of.")
     ),
     responses(
         (
@@ -314,7 +314,8 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
             content_type = "application/json",
             example = json!({
                 "status": "SERVING",
-                "count": 12345
+                "count": 12345,
+                "build_progress": 100.0
             })
         ),
         (

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -6,11 +6,14 @@
 use crate::Filter;
 use crate::IndexKey;
 use crate::IndexName;
+use crate::IndexOptionsFts;
+use crate::IndexOptionsVs;
 use crate::KeyspaceName;
 use crate::Progress;
 use crate::Quantization;
 use crate::Restriction;
 use crate::SimilarityScore;
+use crate::SpaceType;
 use crate::distance;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
@@ -46,8 +49,11 @@ use axum::routing::put;
 use axum_server_dual_protocol::Protocol;
 use bigdecimal::BigDecimal;
 use httpapi::DataType;
+use httpapi::FulltextIndexOptions;
 use httpapi::IndexInfo;
-use httpapi::IndexType;
+use httpapi::IndexOptions;
+use httpapi::SimilarityFunction;
+use httpapi::VectorIndexOptions;
 use itertools::Itertools;
 use num_bigint::BigInt;
 use prometheus::Encoder;
@@ -91,7 +97,7 @@ use utoipa_swagger_ui::SwaggerUi;
             name = "LicenseRef-ScyllaDB-Source-Available-1.0"
         ),
         // version should be updated manually when there are changes in API
-        version = "2.1.0"
+        version = "3.0.0"
     ),
     tags(
         (
@@ -223,6 +229,43 @@ impl From<Quantization> for DataType {
     }
 }
 
+impl From<SpaceType> for SimilarityFunction {
+    fn from(space_type: SpaceType) -> Self {
+        match space_type {
+            SpaceType::Euclidean => SimilarityFunction::Euclidean,
+            SpaceType::Cosine => SimilarityFunction::Cosine,
+            SpaceType::DotProduct => SimilarityFunction::DotProduct,
+            SpaceType::Hamming => SimilarityFunction::Hamming,
+        }
+    }
+}
+
+impl From<&IndexOptionsVs> for VectorIndexOptions {
+    fn from(options: &IndexOptionsVs) -> Self {
+        VectorIndexOptions {
+            dimensions: options.dimensions.as_ref().get(),
+            maximum_node_connections: *options.connectivity.as_ref(),
+            construction_beam_width: *options.expansion_add.as_ref(),
+            search_beam_width: *options.expansion_search.as_ref(),
+            similarity_function: options.space_type.into(),
+            quantization: options.quantization.into(),
+        }
+    }
+}
+
+impl From<&IndexOptionsFts> for FulltextIndexOptions {
+    fn from(_options: &IndexOptionsFts) -> Self {
+        // The service does not yet track per-index full-text options,
+        // and the full-text backend applies a fixed "standard" analyzer with
+        // token positions enabled.
+        // Report those defaults until the options are modeled.
+        FulltextIndexOptions {
+            analyzer: "standard".to_string(),
+            positions: true,
+        }
+    }
+}
+
 impl From<httpapi::Limit> for crate::Limit {
     fn from(limit: httpapi::Limit) -> Self {
         Self::from(<httpapi::Limit as Into<NonZeroUsize>>::into(limit))
@@ -252,7 +295,32 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
         (
             status = 200,
             description = "Successful operation. Returns an array of index information representing all indexes managed by the Vector Store.",
-            body = [IndexInfo]
+            body = [IndexInfo],
+            content_type = "application/json",
+            example = json!([
+                {
+                    "keyspace": "my_keyspace",
+                    "index": "my_vector_index",
+                    "options": {
+                        "type": "vector",
+                        "dimensions": 384,
+                        "maximum_node_connections": 16,
+                        "construction_beam_width": 128,
+                        "search_beam_width": 64,
+                        "similarity_function": "COSINE",
+                        "quantization": "F32"
+                    }
+                },
+                {
+                    "keyspace": "my_keyspace",
+                    "index": "my_fulltext_index",
+                    "options": {
+                        "type": "fulltext",
+                        "analyzer": "standard",
+                        "positions": true
+                    }
+                }
+            ])
         )
     )
 )]
@@ -265,14 +333,12 @@ async fn get_indexes(State(state): State<RoutesInnerState>) -> Response {
         .map(|(key, entry)| IndexInfo {
             keyspace: key.keyspace().into(),
             index: key.index().into(),
-            index_type: IndexType::Vector {
-                data_type: entry.options().quantization.into(),
-            },
+            options: IndexOptions::Vector(entry.options().into()),
         })
-        .chain(indexes_guard.iter_fts().map(|(key, _)| IndexInfo {
+        .chain(indexes_guard.iter_fts().map(|(key, entry)| IndexInfo {
             keyspace: key.keyspace().into(),
             index: key.index().into(),
-            index_type: IndexType::Fulltext,
+            options: IndexOptions::Fulltext(entry.options().into()),
         }))
         .collect();
 
@@ -2146,6 +2212,60 @@ mod tests {
         assert_eq!(
             httpapi::IndexStatus::from(crate::node_state::IndexStatus::Serving),
             httpapi::IndexStatus::Serving
+        );
+    }
+
+    #[test]
+    fn similarity_function_conversion() {
+        assert_eq!(
+            SimilarityFunction::from(SpaceType::Euclidean),
+            SimilarityFunction::Euclidean
+        );
+        assert_eq!(
+            SimilarityFunction::from(SpaceType::Cosine),
+            SimilarityFunction::Cosine
+        );
+        assert_eq!(
+            SimilarityFunction::from(SpaceType::DotProduct),
+            SimilarityFunction::DotProduct
+        );
+        assert_eq!(
+            SimilarityFunction::from(SpaceType::Hamming),
+            SimilarityFunction::Hamming
+        );
+    }
+
+    #[test]
+    fn vector_index_options_conversion() {
+        let options = IndexOptionsVs {
+            dimensions: NonZeroUsize::new(384).unwrap().into(),
+            connectivity: 32.into(),
+            expansion_add: 200.into(),
+            expansion_search: 100.into(),
+            space_type: SpaceType::DotProduct,
+            quantization: Quantization::I8,
+        };
+        assert_eq!(
+            VectorIndexOptions::from(&options),
+            VectorIndexOptions {
+                dimensions: 384,
+                maximum_node_connections: 32,
+                construction_beam_width: 200,
+                search_beam_width: 100,
+                similarity_function: SimilarityFunction::DotProduct,
+                quantization: DataType::I8,
+            }
+        );
+    }
+
+    #[test]
+    fn fulltext_index_option_conversion() {
+        assert_eq!(
+            FulltextIndexOptions::from(&IndexOptionsFts {}),
+            FulltextIndexOptions {
+                analyzer: "standard".to_string(),
+                positions: true,
+            }
         );
     }
 

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -98,7 +98,7 @@ impl<I, D: std::fmt::Debug> std::fmt::Debug for IndexEntry<I, D> {
 }
 
 pub(crate) type VsIndexEntry = IndexEntry<VsIndex, VsIndexData>;
-pub(crate) type FtsIndexEntry = IndexEntry<FtsIndex>;
+pub(crate) type FtsIndexEntry = IndexEntry<FtsIndex, FtsIndexData>;
 
 #[derive(Debug)]
 pub(crate) struct VsIndexData {
@@ -108,6 +108,11 @@ pub(crate) struct VsIndexData {
     table_columns: Arc<HashMap<ColumnName, NativeType>>,
     version: IndexVersion,
     options: crate::IndexOptionsVs,
+}
+
+#[derive(Debug)]
+pub(crate) struct FtsIndexData {
+    options: crate::IndexOptionsFts,
 }
 
 impl<I, D> IndexEntry<I, D> {
@@ -239,17 +244,27 @@ impl FtsIndexEntry {
         index: mpsc::Sender<FtsIndex>,
         monitor: mpsc::Sender<MonitorItems>,
         db_index: mpsc::Sender<DbIndex>,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
+        let options = metadata
+            .fts()
+            .ok_or_else(|| {
+                anyhow::anyhow!("add_index_fts must be called with a fulltext-search index")
+            })?
+            .clone();
         let progress = db_index.full_scan_progress().await;
-        Self {
+        Ok(Self {
             index,
             _monitor: monitor,
             db_index,
             status: IndexStatus::Initializing,
             progress,
             primary_key_columns: metadata.primary_key_columns,
-            data: (),
-        }
+            data: FtsIndexData { options },
+        })
+    }
+
+    pub(crate) fn options(&self) -> &crate::IndexOptionsFts {
+        &self.data.options
     }
 }
 

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -614,6 +614,13 @@ impl IndexKind {
             IndexKind::Fts(_) => None,
         }
     }
+
+    pub fn as_fts(&self) -> Option<&IndexOptionsFts> {
+        match self {
+            IndexKind::Fts(fts) => Some(fts),
+            IndexKind::Vs(_) => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -638,6 +645,10 @@ impl IndexMetadata {
 
     pub fn vs(&self) -> Option<&IndexOptionsVs> {
         self.kind.as_vs()
+    }
+
+    pub fn fts(&self) -> Option<&IndexOptionsFts> {
+        self.kind.as_fts()
     }
 
     fn discard_version(&self) -> Self {

--- a/crates/vector-store/tests/integration/common.rs
+++ b/crates/vector-store/tests/integration/common.rs
@@ -50,7 +50,7 @@ pub(crate) fn single_row_scan(
     )])
 }
 
-pub(crate) fn make_index(
+pub(crate) fn make_vs_index(
     name: &str,
     primary_key_columns: &[&str],
     partition_key_count: usize,
@@ -58,6 +58,36 @@ pub(crate) fn make_index(
     partitioning: DbIndexPartitioning,
     filtering_columns: &[&str],
     version: Uuid,
+) -> IndexMetadata {
+    make_index_with_kind(
+        name,
+        primary_key_columns,
+        partition_key_count,
+        target_column,
+        partitioning,
+        filtering_columns,
+        version,
+        IndexKind::Vs(IndexOptionsVs {
+            dimensions: NonZeroUsize::new(3).unwrap().into(),
+            connectivity: Default::default(),
+            expansion_add: Default::default(),
+            expansion_search: Default::default(),
+            space_type: Default::default(),
+            quantization: Default::default(),
+        }),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn make_index_with_kind(
+    name: &str,
+    primary_key_columns: &[&str],
+    partition_key_count: usize,
+    target_column: &str,
+    partitioning: DbIndexPartitioning,
+    filtering_columns: &[&str],
+    version: Uuid,
+    kind: IndexKind,
 ) -> IndexMetadata {
     IndexMetadata {
         keyspace_name: "vector".into(),
@@ -75,14 +105,7 @@ pub(crate) fn make_index(
             .map(|s| ColumnName::from(*s))
             .collect(),
         version: version.into(),
-        kind: IndexKind::Vs(IndexOptionsVs {
-            dimensions: NonZeroUsize::new(3).unwrap().into(),
-            connectivity: Default::default(),
-            expansion_add: Default::default(),
-            expansion_search: Default::default(),
-            space_type: Default::default(),
-            quantization: Default::default(),
-        }),
+        kind,
     }
 }
 

--- a/crates/vector-store/tests/integration/common.rs
+++ b/crates/vector-store/tests/integration/common.rs
@@ -21,6 +21,7 @@ use vector_store::DbIndexPartitioning;
 use vector_store::HttpServerExt;
 use vector_store::IndexKind;
 use vector_store::IndexMetadata;
+use vector_store::IndexOptionsFts;
 use vector_store::IndexOptionsVs;
 use vector_store::NonemptyArc;
 use vector_store::NonemptyIteratorExt;
@@ -75,6 +76,25 @@ pub(crate) fn make_vs_index(
             space_type: Default::default(),
             quantization: Default::default(),
         }),
+    )
+}
+
+pub(crate) fn make_fts_index(
+    name: &str,
+    primary_key_columns: &[&str],
+    partition_key_count: usize,
+    target_column: &str,
+    version: Uuid,
+) -> IndexMetadata {
+    make_index_with_kind(
+        name,
+        primary_key_columns,
+        partition_key_count,
+        target_column,
+        DbIndexPartitioning::Global,
+        &[],
+        version,
+        IndexKind::Fts(IndexOptionsFts {}),
     )
 }
 

--- a/crates/vector-store/tests/integration/common.rs
+++ b/crates/vector-store/tests/integration/common.rs
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::create_config_channels;
+use crate::db_basic;
+use crate::db_basic::DbBasic;
+use crate::db_basic::ScanFn;
+use crate::db_basic::Table;
+use crate::vs_index::usearch_test_config;
+use futures::FutureExt;
+use httpclient::HttpClient;
+use scylla::cluster::metadata::NativeType;
+use scylla::value::CqlValue;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use uuid::Uuid;
+use vector_store::ColumnName;
+use vector_store::DbIndexPartitioning;
+use vector_store::HttpServerExt;
+use vector_store::IndexKind;
+use vector_store::IndexMetadata;
+use vector_store::IndexOptionsVs;
+use vector_store::NonemptyArc;
+use vector_store::NonemptyIteratorExt;
+use vector_store::Timestamp;
+
+pub(crate) fn ordered_timeuuid(time: u32) -> Uuid {
+    let mut bytes = [0u8; 16];
+    bytes[0..4].copy_from_slice(&time.to_be_bytes());
+    bytes[6] = 0x10;
+    bytes[8] = 0x80;
+    Uuid::from_bytes(bytes)
+}
+
+/// A scan function that never completes, keeping the index bootstrapping.
+pub(crate) fn blocking_scan_fn() -> ScanFn {
+    Box::new(|_tx| std::future::pending::<()>().boxed())
+}
+
+pub(crate) fn single_row_scan(
+    pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'static,
+) -> ScanFn {
+    db_basic::scan_fn_vectors([(
+        pks.into_iter().collect::<Vec<_>>().into(),
+        Some(vec![1.0, 2.0, 3.0].into()),
+        [].into(),
+        Timestamp::from_millis(10),
+    )])
+}
+
+pub(crate) fn make_index(
+    name: &str,
+    primary_key_columns: &[&str],
+    partition_key_count: usize,
+    target_column: &str,
+    partitioning: DbIndexPartitioning,
+    filtering_columns: &[&str],
+    version: Uuid,
+) -> IndexMetadata {
+    IndexMetadata {
+        keyspace_name: "vector".into(),
+        table_name: "items".into(),
+        index_name: name.into(),
+        primary_key_columns: NonemptyArc::new(
+            primary_key_columns.iter().map(|v| ColumnName::from(*v)),
+        )
+        .unwrap(),
+        partition_key_count: NonZeroUsize::new(partition_key_count).unwrap(),
+        target_columns: NonemptyArc::new([target_column]).unwrap(),
+        partitioning,
+        filtering_columns: filtering_columns
+            .iter()
+            .map(|s| ColumnName::from(*s))
+            .collect(),
+        version: version.into(),
+        kind: IndexKind::Vs(IndexOptionsVs {
+            dimensions: NonZeroUsize::new(3).unwrap().into(),
+            connectivity: Default::default(),
+            expansion_add: Default::default(),
+            expansion_search: Default::default(),
+            space_type: Default::default(),
+            quantization: Default::default(),
+        }),
+    }
+}
+
+pub(crate) async fn setup() -> (HttpClient, DbBasic, impl Sized) {
+    let node_state = vector_store::new_node_state().await;
+    let (db_actor, db) = db_basic::new(node_state.clone());
+    let (receivers, senders) = create_config_channels(usearch_test_config()).await;
+    let (server, _mtls) = vector_store::run(Some(node_state), Some(db_actor), receivers)
+        .await
+        .unwrap();
+    let addr = (*server.address().await.borrow()).unwrap();
+    (HttpClient::new(addr), db, (server, senders))
+}
+
+pub(crate) fn add_table(
+    db: &DbBasic,
+    primary_keys: impl IntoIterator<Item = ColumnName>,
+    partition_key_count: usize,
+    columns: impl IntoIterator<Item = (ColumnName, NativeType)>,
+    vector_columns: impl IntoIterator<Item = ColumnName>,
+) {
+    db.add_table(
+        "vector".into(),
+        "items".into(),
+        Table {
+            primary_keys: primary_keys.into_iter().collect_nonempty_arc().unwrap(),
+            partition_key_count,
+            columns: Arc::new(columns.into_iter().collect()),
+            dimensions: vector_columns
+                .into_iter()
+                .map(|c| (c, NonZeroUsize::new(3).unwrap().into()))
+                .collect(),
+        },
+    )
+    .unwrap();
+}

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -456,5 +456,8 @@ async fn fts_index_appears_in_indexes_list() {
         .find(|i| i.keyspace == keyspace_name && i.index == index_name);
 
     assert!(fts_index.is_some());
-    assert_eq!(fts_index.unwrap().index_type, httpapi::IndexType::Fulltext);
+    assert!(matches!(
+        fts_index.unwrap().options,
+        httpapi::IndexOptions::Fulltext(_)
+    ));
 }

--- a/crates/vector-store/tests/integration/index_info.rs
+++ b/crates/vector-store/tests/integration/index_info.rs
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+use crate::common::add_table;
+use crate::common::make_fts_index;
+use crate::common::make_index_with_kind;
+use crate::common::ordered_timeuuid;
+use crate::common::setup;
+use crate::common::single_row_scan;
+use crate::db_basic;
+use crate::wait_for;
+use httpapi::FulltextIndexOptions;
+use httpapi::IndexOptions;
+use httpapi::VectorIndexOptions;
+use rstest::rstest;
+use scylla::cluster::metadata::NativeType;
+use scylla::value::CqlValue;
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+use vector_store::DbIndexPartitioning;
+use vector_store::IndexKind;
+use vector_store::IndexOptionsFts;
+use vector_store::IndexOptionsVs;
+use vector_store::Timestamp;
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn indexes_lists_all_indexes_with_options() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [
+            ("pk".into(), NativeType::Int),
+            ("content".into(), NativeType::Text),
+        ],
+        ["embedding".into()],
+    );
+
+    let first_options = IndexOptionsVs {
+        dimensions: NonZeroUsize::new(3).unwrap().into(),
+        connectivity: 32.into(),
+        expansion_add: 200.into(),
+        expansion_search: 100.into(),
+        space_type: vector_store::SpaceType::Euclidean,
+        quantization: vector_store::Quantization::F16,
+    };
+    let first_index = make_index_with_kind(
+        "first",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(1),
+        IndexKind::Vs(first_options.clone()),
+    );
+    db.add_index(
+        first_index.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+
+    let second_options = IndexOptionsVs {
+        dimensions: NonZeroUsize::new(3).unwrap().into(),
+        connectivity: 64.into(),
+        expansion_add: 150.into(),
+        expansion_search: 50.into(),
+        space_type: vector_store::SpaceType::DotProduct,
+        quantization: vector_store::Quantization::BF16,
+    };
+    let second_index = make_index_with_kind(
+        "second",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(2),
+        IndexKind::Vs(second_options.clone()),
+    );
+    db.add_index(
+        second_index.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+
+    let fts_options = IndexOptionsFts {};
+    let fts_index = make_fts_index("third", &["pk"], 1, "content", ordered_timeuuid(3));
+    db.add_index(
+        fts_index.clone(),
+        Some(db_basic::scan_fn_documents([(
+            [CqlValue::Int(1)].into(),
+            Some("hello world".to_string()),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+    )
+    .unwrap();
+
+    wait_for(
+        || async { client.indexes().await.len() == 3 },
+        "all indexes to be listed",
+    )
+    .await;
+
+    let entries = client.indexes().await;
+    let expected_options = HashMap::from([
+        (
+            "first",
+            IndexOptions::Vector(VectorIndexOptions::from(&first_options)),
+        ),
+        (
+            "second",
+            IndexOptions::Vector(VectorIndexOptions::from(&second_options)),
+        ),
+        (
+            "third",
+            IndexOptions::Fulltext(FulltextIndexOptions::from(&fts_options)),
+        ),
+    ]);
+    for entry in &entries {
+        assert_eq!(
+            &entry.options,
+            expected_options.get(entry.index.as_ref()).unwrap()
+        );
+    }
+}

--- a/crates/vector-store/tests/integration/index_info.rs
+++ b/crates/vector-store/tests/integration/index_info.rs
@@ -10,8 +10,10 @@ use crate::common::setup;
 use crate::common::single_row_scan;
 use crate::db_basic;
 use crate::wait_for;
+use httpapi::DataType;
 use httpapi::FulltextIndexOptions;
 use httpapi::IndexOptions;
+use httpapi::SimilarityFunction;
 use httpapi::VectorIndexOptions;
 use rstest::rstest;
 use scylla::cluster::metadata::NativeType;
@@ -24,6 +26,115 @@ use vector_store::IndexKind;
 use vector_store::IndexOptionsFts;
 use vector_store::IndexOptionsVs;
 use vector_store::Timestamp;
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn index_info_reports_vector_index_options() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    let index = make_index_with_kind(
+        "custom",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(1),
+        IndexKind::Vs(IndexOptionsVs {
+            dimensions: NonZeroUsize::new(3).unwrap().into(),
+            connectivity: 32.into(),
+            expansion_add: 200.into(),
+            expansion_search: 100.into(),
+            space_type: vector_store::SpaceType::Euclidean,
+            quantization: vector_store::Quantization::F16,
+        }),
+    );
+    db.add_index(
+        index.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+
+    let ks = index.keyspace_name.as_ref().into();
+    let idx = index.index_name.as_ref().into();
+    wait_for(
+        || async { client.index_info(&ks, &idx).await.is_ok() },
+        "index to be discovered",
+    )
+    .await;
+
+    let info = client.index_info(&ks, &idx).await.unwrap();
+    assert_eq!(
+        info.options,
+        IndexOptions::Vector(VectorIndexOptions {
+            dimensions: 3,
+            maximum_node_connections: 32,
+            construction_beam_width: 200,
+            search_beam_width: 100,
+            similarity_function: SimilarityFunction::Euclidean,
+            quantization: DataType::F16,
+        })
+    );
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn index_info_reports_fulltext_index_options() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [
+            ("pk".into(), NativeType::Int),
+            ("content".into(), NativeType::Text),
+        ],
+        [],
+    );
+
+    let index = make_fts_index("fulltext", &["pk"], 1, "content", ordered_timeuuid(1));
+    db.add_index(
+        index.clone(),
+        Some(db_basic::scan_fn_documents([(
+            [CqlValue::Int(1)].into(),
+            Some("hello world".to_string()),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+    )
+    .unwrap();
+
+    let ks = index.keyspace_name.as_ref().into();
+    let idx = index.index_name.as_ref().into();
+    wait_for(
+        || async { client.index_info(&ks, &idx).await.is_ok() },
+        "index to be discovered",
+    )
+    .await;
+
+    let info = client.index_info(&ks, &idx).await.unwrap();
+    assert_eq!(
+        info.options,
+        IndexOptions::Fulltext(FulltextIndexOptions {
+            analyzer: "standard".to_string(),
+            positions: true,
+        })
+    );
+}
 
 #[rstest]
 #[timeout(Duration::from_secs(10))]

--- a/crates/vector-store/tests/integration/index_status.rs
+++ b/crates/vector-store/tests/integration/index_status.rs
@@ -5,7 +5,7 @@
 
 use crate::common::add_table;
 use crate::common::blocking_scan_fn;
-use crate::common::make_index;
+use crate::common::make_vs_index;
 use crate::common::ordered_timeuuid;
 use crate::common::setup;
 use crate::common::single_row_scan;
@@ -44,7 +44,7 @@ async fn index_status_reports_build_progress_while_bootstrapping() {
     // whose scan never completes, keeping it bootstrapping at that progress.
     db.set_next_full_scan_progress(Progress::InProgress(Percentage::try_from(37.0).unwrap()));
 
-    let index = make_index(
+    let index = make_vs_index(
         "building",
         &["pk"],
         1,
@@ -86,7 +86,7 @@ async fn index_status_reports_full_progress_when_serving() {
         ["embedding".into()],
     );
 
-    let index = make_index(
+    let index = make_vs_index(
         "ready",
         &["pk"],
         1,

--- a/crates/vector-store/tests/integration/index_status.rs
+++ b/crates/vector-store/tests/integration/index_status.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
-use crate::routing::add_table;
-use crate::routing::blocking_scan_fn;
-use crate::routing::make_index;
-use crate::routing::ordered_timeuuid;
-use crate::routing::setup;
-use crate::routing::single_row_scan;
+use crate::common::add_table;
+use crate::common::blocking_scan_fn;
+use crate::common::make_index;
+use crate::common::ordered_timeuuid;
+use crate::common::setup;
+use crate::common::single_row_scan;
 use crate::wait_for;
 use httpapi::IndexStatus;
 use rstest::rstest;

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -7,6 +7,7 @@ mod common;
 mod db_basic;
 mod fts;
 mod https;
+mod index_info;
 mod index_status;
 mod info;
 mod memory_limit;

--- a/crates/vector-store/tests/integration/main.rs
+++ b/crates/vector-store/tests/integration/main.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod common;
 mod db_basic;
 mod fts;
 mod https;

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -23,6 +23,7 @@ use vector_store::IndexKind;
 use vector_store::IndexMetadata;
 use vector_store::IndexOptionsVs;
 use vector_store::NonemptyArc;
+use vector_store::SpaceType::Euclidean;
 use vector_store::Timestamp;
 
 #[tokio::test]
@@ -46,7 +47,7 @@ async fn simple_create_search_delete_index() {
             connectivity: Default::default(),
             expansion_add: Default::default(),
             expansion_search: Default::default(),
-            space_type: Default::default(),
+            space_type: Euclidean,
             quantization: Default::default(),
         }),
     };

--- a/crates/vector-store/tests/integration/quantization.rs
+++ b/crates/vector-store/tests/integration/quantization.rs
@@ -163,12 +163,12 @@ async fn quantization_is_returned_as_index_data_type() {
         )
         .await;
 
-        assert_eq!(
-            index_info.index_type,
-            httpapi::IndexType::Vector {
-                data_type: expected_data_type
+        match index_info.options {
+            httpapi::IndexOptions::Vector(options) => {
+                assert_eq!(options.quantization, expected_data_type);
             }
-        );
+            httpapi::IndexOptions::Fulltext(_) => panic!("expected vector index options"),
+        }
     }
 }
 

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -5,7 +5,7 @@
 
 use crate::common::add_table;
 use crate::common::blocking_scan_fn;
-use crate::common::make_index;
+use crate::common::make_vs_index;
 use crate::common::ordered_timeuuid;
 use crate::common::setup;
 use crate::common::single_row_scan;
@@ -146,7 +146,7 @@ async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping() {
         ["embedding".into()],
     );
 
-    let oldest = make_index(
+    let oldest = make_vs_index(
         "oldest",
         &["pk"],
         1,
@@ -163,7 +163,7 @@ async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping() {
     .unwrap();
     wait_for_serving(&client, &oldest).await;
 
-    let replacement = make_index(
+    let replacement = make_vs_index(
         "replacement",
         &["pk"],
         1,
@@ -196,7 +196,7 @@ async fn ann_routes_to_newest_serving_index() {
         ["embedding".into()],
     );
 
-    let oldest = make_index(
+    let oldest = make_vs_index(
         "oldest",
         &["pk"],
         1,
@@ -213,7 +213,7 @@ async fn ann_routes_to_newest_serving_index() {
     .unwrap();
     wait_for_serving(&client, &oldest).await;
 
-    let replacement = make_index(
+    let replacement = make_vs_index(
         "replacement",
         &["pk"],
         1,
@@ -253,7 +253,7 @@ async fn ann_routes_to_newest_local_index_with_same_score() {
         ["embedding".into()],
     );
 
-    let older_local = make_index(
+    let older_local = make_vs_index(
         "older",
         &["pk", "ck"],
         1,
@@ -270,7 +270,7 @@ async fn ann_routes_to_newest_local_index_with_same_score() {
     .unwrap();
     wait_for_serving(&client, &older_local).await;
 
-    let newer_local = make_index(
+    let newer_local = make_vs_index(
         "newer",
         &["pk", "ck"],
         1,
@@ -324,7 +324,7 @@ async fn ann_routes_to_local_index_with_more_matching_partition_key_columns() {
         ["embedding".into()],
     );
 
-    let less_precise = make_index(
+    let less_precise = make_vs_index(
         "less_precise",
         &["pk1", "pk2", "ck"],
         2,
@@ -345,7 +345,7 @@ async fn ann_routes_to_local_index_with_more_matching_partition_key_columns() {
     .unwrap();
     wait_for_serving(&client, &less_precise).await;
 
-    let more_precise = make_index(
+    let more_precise = make_vs_index(
         "more_precise",
         &["pk1", "pk2", "ck"],
         2,
@@ -409,7 +409,7 @@ async fn ann_routes_to_local_index_with_filter_columns_covering_restriction() {
         ["embedding".into()],
     );
 
-    let covering = make_index(
+    let covering = make_vs_index(
         "covering",
         &["pk", "ck"],
         1,
@@ -426,7 +426,7 @@ async fn ann_routes_to_local_index_with_filter_columns_covering_restriction() {
     .unwrap();
     wait_for_serving(&client, &covering).await;
 
-    let non_covering = make_index(
+    let non_covering = make_vs_index(
         "non_covering",
         &["pk", "ck"],
         1,
@@ -486,7 +486,7 @@ async fn ann_routes_to_global_index_with_filter_columns_covering_restriction() {
         ["embedding".into()],
     );
 
-    let covering = make_index(
+    let covering = make_vs_index(
         "covering",
         &["pk", "ck"],
         1,
@@ -503,7 +503,7 @@ async fn ann_routes_to_global_index_with_filter_columns_covering_restriction() {
     .unwrap();
     wait_for_serving(&client, &covering).await;
 
-    let non_covering = make_index(
+    let non_covering = make_vs_index(
         "non_covering",
         &["pk", "ck"],
         1,
@@ -562,7 +562,7 @@ async fn ann_routes_to_local_index_when_pk_restrictions_match() {
         ["embedding".into()],
     );
 
-    let local_index = make_index(
+    let local_index = make_vs_index(
         "local_idx",
         &["pk", "ck"],
         1,
@@ -579,7 +579,7 @@ async fn ann_routes_to_local_index_when_pk_restrictions_match() {
     .unwrap();
     wait_for_serving(&client, &local_index).await;
 
-    let global_index = make_index(
+    let global_index = make_vs_index(
         "global_idx",
         &["pk", "ck"],
         1,
@@ -632,7 +632,7 @@ async fn ann_routes_to_global_index_without_pk_restrictions() {
         ["embedding".into()],
     );
 
-    let local_index = make_index(
+    let local_index = make_vs_index(
         "local_idx",
         &["pk", "ck"],
         1,
@@ -649,7 +649,7 @@ async fn ann_routes_to_global_index_without_pk_restrictions() {
     .unwrap();
     wait_for_serving(&client, &local_index).await;
 
-    let global_index = make_index(
+    let global_index = make_vs_index(
         "global_idx",
         &["pk", "ck"],
         1,

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -3,14 +3,13 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-use crate::create_config_channels;
-use crate::db_basic;
-use crate::db_basic::DbBasic;
-use crate::db_basic::ScanFn;
-use crate::db_basic::Table;
-use crate::vs_index::usearch_test_config;
+use crate::common::add_table;
+use crate::common::blocking_scan_fn;
+use crate::common::make_index;
+use crate::common::ordered_timeuuid;
+use crate::common::setup;
+use crate::common::single_row_scan;
 use crate::wait_for;
-use futures::FutureExt;
 use httpapi::IndexStatus;
 use httpapi::PostIndexAnnFilter;
 use httpapi::PostIndexAnnRestriction;
@@ -20,114 +19,12 @@ use rstest::rstest;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
 use std::time::Duration;
-use uuid::Uuid;
-use vector_store::ColumnName;
 use vector_store::DbIndexPartitioning;
-use vector_store::HttpServerExt;
-use vector_store::IndexKind;
 use vector_store::IndexMetadata;
-use vector_store::IndexOptionsVs;
 use vector_store::NonemptyArc;
-use vector_store::NonemptyIteratorExt;
-use vector_store::Timestamp;
 
 const ANN_LIMIT: usize = 5;
-
-pub(crate) fn ordered_timeuuid(time: u32) -> Uuid {
-    let mut bytes = [0u8; 16];
-    bytes[0..4].copy_from_slice(&time.to_be_bytes());
-    bytes[6] = 0x10;
-    bytes[8] = 0x80;
-    Uuid::from_bytes(bytes)
-}
-
-/// A scan function that never completes, keeping the index bootstrapping.
-pub(crate) fn blocking_scan_fn() -> ScanFn {
-    Box::new(|_tx| std::future::pending::<()>().boxed())
-}
-
-pub(crate) fn single_row_scan(
-    pks: impl IntoIterator<Item = CqlValue> + Send + Sync + 'static,
-) -> ScanFn {
-    db_basic::scan_fn_vectors([(
-        pks.into_iter().collect::<Vec<_>>().into(),
-        Some(vec![1.0, 2.0, 3.0].into()),
-        [].into(),
-        Timestamp::from_millis(10),
-    )])
-}
-
-pub(crate) fn make_index(
-    name: &str,
-    primary_key_columns: &[&str],
-    partition_key_count: usize,
-    target_column: &str,
-    partitioning: DbIndexPartitioning,
-    filtering_columns: &[&str],
-    version: Uuid,
-) -> IndexMetadata {
-    IndexMetadata {
-        keyspace_name: "vector".into(),
-        table_name: "items".into(),
-        index_name: name.into(),
-        primary_key_columns: NonemptyArc::new(
-            primary_key_columns.iter().map(|v| ColumnName::from(*v)),
-        )
-        .unwrap(),
-        partition_key_count: NonZeroUsize::new(partition_key_count).unwrap(),
-        target_columns: NonemptyArc::new([target_column]).unwrap(),
-        partitioning,
-        filtering_columns: filtering_columns
-            .iter()
-            .map(|s| ColumnName::from(*s))
-            .collect(),
-        version: version.into(),
-        kind: IndexKind::Vs(IndexOptionsVs {
-            dimensions: NonZeroUsize::new(3).unwrap().into(),
-            connectivity: Default::default(),
-            expansion_add: Default::default(),
-            expansion_search: Default::default(),
-            space_type: Default::default(),
-            quantization: Default::default(),
-        }),
-    }
-}
-
-pub(crate) async fn setup() -> (HttpClient, DbBasic, impl Sized) {
-    let node_state = vector_store::new_node_state().await;
-    let (db_actor, db) = db_basic::new(node_state.clone());
-    let (receivers, senders) = create_config_channels(usearch_test_config()).await;
-    let (server, _mtls) = vector_store::run(Some(node_state), Some(db_actor), receivers)
-        .await
-        .unwrap();
-    let addr = (*server.address().await.borrow()).unwrap();
-    (HttpClient::new(addr), db, (server, senders))
-}
-
-pub(crate) fn add_table(
-    db: &DbBasic,
-    primary_keys: impl IntoIterator<Item = ColumnName>,
-    partition_key_count: usize,
-    columns: impl IntoIterator<Item = (ColumnName, NativeType)>,
-    vector_columns: impl IntoIterator<Item = ColumnName>,
-) {
-    db.add_table(
-        "vector".into(),
-        "items".into(),
-        Table {
-            primary_keys: primary_keys.into_iter().collect_nonempty_arc().unwrap(),
-            partition_key_count,
-            columns: Arc::new(columns.into_iter().collect()),
-            dimensions: vector_columns
-                .into_iter()
-                .map(|c| (c, NonZeroUsize::new(3).unwrap().into()))
-                .collect(),
-        },
-    )
-    .unwrap();
-}
 
 async fn wait_for_serving(client: &HttpClient, index: &IndexMetadata) {
     let ks = index.keyspace_name.as_ref().into();

--- a/crates/vector-store/tests/integration/vs_index.rs
+++ b/crates/vector-store/tests/integration/vs_index.rs
@@ -335,7 +335,7 @@ async fn failed_db_index_create(#[case] config: Config) {
             connectivity: Default::default(),
             expansion_add: Default::default(),
             expansion_search: Default::default(),
-            space_type: Default::default(),
+            space_type: SpaceType::Euclidean,
             quantization: Default::default(),
         }),
     };


### PR DESCRIPTION
Today the only way to see the options an index was created with is to
query ScyllaDB directly via CQL (`system_schema.indexes`). This PR
surfaces those options through the HTTP API, using only what Vector Store
already holds in memory - no extra ScyllaDB queries.

- **`GET /indexes`** now includes each index's creation options, alongside its existing keyspace/name/type fields.
- **`GET /indexes/{keyspace}/{index}/status`** is unchanged - it stays
  focused on operational status (state, count, build progress).
- **`GET /indexes/{keyspace}/{index}`** is new - the same
  type and options information as the `/indexes` listing, scoped to one
  index, so a caller who already knows which index they care about
  doesn't have to fetch and filter the whole list.

Fixes: VECTOR-723
