### PR TITLE
vector-store: parallelize diskann msg handling

### DIFF
--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -52,6 +52,8 @@ use std::collections::btree_map::Entry;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
@@ -117,13 +119,15 @@ fn new(
     let (tx_search, mut rx_search) = mpsc::channel(perf::channel_size().into());
 
     let span_key = index_key.clone();
+    let params = Arc::new(params);
 
     tokio::spawn(perf::hotpath_async(
         {
             async move {
                 debug!("starting");
 
-                let mut state = State::new(table, params);
+                let mut partitions = BTreeMap::new();
+                let mut sizes = BTreeMap::new();
 
                 let mut allocate_prev = Allocate::Can;
                 let allocate_rx = memory.subscribe_allocate().await;
@@ -134,45 +138,20 @@ fn new(
                         continue;
                     }
 
-                    match msg {
-                        Message::Modify(VsIndexModify::AddVector {
-                            partition_id,
-                            primary_id,
-                            embedding,
-                            in_progress: _in_progress,
-                        }) => {
-                            state.add_vector(partition_id, primary_id, embedding).await;
-                        }
-                        Message::Modify(VsIndexModify::RemoveVector {
-                            partition_id,
-                            primary_id,
-                            in_progress: _in_progress,
-                        }) => {
-                            state.remove_vector(partition_id, primary_id).await;
-                        }
-                        Message::Modify(VsIndexModify::RemovePartition { partition_id }) => {
-                            state.remove_partition(partition_id);
-                        }
-                        Message::Search(VsIndexSearch::Ann {
-                            index_key,
-                            embedding,
-                            limit,
-                            tx,
-                        }) => {
-                            if let Some(tx) = validate_dimensions(tx, &embedding, state.params.dim)
-                            {
-                                _ = tx.send(state.ann(index_key, embedding, limit).await);
-                            }
-                        }
-                        Message::Search(VsIndexSearch::FilteredAnn { tx, .. }) => {
-                            _ = tx.send(Err(anyhow::anyhow!(
-                                "DiskANN index does not support filtered search"
-                            )));
-                        }
-                        Message::Search(VsIndexSearch::Count { index_key, tx }) => {
-                            _ = tx.send(state.count(&index_key));
-                        }
-                    }
+                    let Some((partition, size, msg)) =
+                        preprocess(&mut partitions, &mut sizes, table.as_ref(), &params, msg)
+                    else {
+                        continue;
+                    };
+
+                    process(
+                        partition,
+                        Arc::clone(&table),
+                        Arc::clone(&params),
+                        size,
+                        msg,
+                    )
+                    .await;
                 }
 
                 debug!("finished");
@@ -182,6 +161,155 @@ fn new(
     ));
 
     Ok((tx_modify, tx_search))
+}
+
+#[hotpath::measure]
+fn preprocess<T>(
+    partitions: &mut BTreeMap<PartitionId, Arc<Partition>>,
+    sizes: &mut BTreeMap<IndexId, Arc<AtomicUsize>>,
+    table: &RwLock<T>,
+    params: &DiskannParams,
+    msg: Message,
+) -> Option<(Arc<Partition>, Arc<AtomicUsize>, Message)>
+where
+    T: TableSearch + Send + Sync + 'static,
+{
+    match msg {
+        Message::Modify(VsIndexModify::AddVector {
+            partition_id,
+            ref embedding,
+            ..
+        }) => {
+            let partition = match partitions.entry(partition_id) {
+                Entry::Occupied(entry) => Arc::clone(entry.get()),
+                Entry::Vacant(entry) => {
+                    // The first vector of a partition becomes the start point of the graph, so the
+                    // index is created here to make it depend on the order of the messages only.
+                    let index = create_diskann_index(params, Some(embedding.as_slice()))
+                        .context(format!(
+                            "failed to create index for partition {partition_id:?}"
+                        ))
+                        .inspect_err(|err| warn!("add_vector failed: {err}"))
+                        .ok()?;
+                    Arc::clone(entry.insert(Arc::new(Partition {
+                        partition_id,
+                        index,
+                    })))
+                }
+            };
+            let size = Arc::clone(sizes.entry(partition_id.index_id()).or_default());
+            Some((partition, size, msg))
+        }
+
+        Message::Modify(VsIndexModify::RemoveVector { partition_id, .. }) => {
+            let Some(partition) = partitions.get(&partition_id).cloned() else {
+                debug!("remove_vector: partition {partition_id:?} not found");
+                return None;
+            };
+            let size = Arc::clone(sizes.entry(partition_id.index_id()).or_default());
+            Some((partition, size, msg))
+        }
+
+        Message::Search(VsIndexSearch::Ann {
+            index_key,
+            embedding,
+            limit,
+            tx,
+        }) => {
+            let Some((partition_id, _)) = table.read().unwrap().partition_id(&index_key, None)
+            else {
+                warn!("partition id not found for index key {index_key} during ann");
+                _ = tx.send(Ok((vec![], vec![])));
+                return None;
+            };
+            let Some(partition) = partitions.get(&partition_id).cloned() else {
+                _ = tx.send(Ok((vec![], vec![])));
+                return None;
+            };
+            let size = Arc::clone(sizes.entry(partition_id.index_id()).or_default());
+            Some((
+                partition,
+                size,
+                Message::Search(VsIndexSearch::Ann {
+                    index_key,
+                    embedding,
+                    limit,
+                    tx,
+                }),
+            ))
+        }
+
+        Message::Search(VsIndexSearch::FilteredAnn { tx, .. }) => {
+            _ = tx.send(Err(anyhow::anyhow!(
+                "DiskANN index does not support filtered search"
+            )));
+            None
+        }
+
+        Message::Search(VsIndexSearch::Count { index_key, tx }) => {
+            let count: CountR = match table.read().unwrap().index_id(&index_key) {
+                Some(index_id) => Ok(sizes
+                    .get(&index_id)
+                    .map(|size| size.load(Ordering::Relaxed))
+                    .unwrap_or(0)),
+                None => Err(anyhow::anyhow!(
+                    "index id not found for index key {index_key}"
+                )),
+            };
+            _ = tx.send(count);
+            None
+        }
+
+        Message::Modify(VsIndexModify::RemovePartition { partition_id }) => {
+            if partitions.remove(&partition_id).is_none() {
+                debug!("remove_partition: partition {partition_id:?} not found");
+            }
+            None
+        }
+    }
+}
+
+#[hotpath::measure]
+async fn process<T>(
+    partition: Arc<Partition>,
+    table: Arc<RwLock<T>>,
+    params: Arc<DiskannParams>,
+    size: Arc<AtomicUsize>,
+    msg: Message,
+) where
+    T: TableSearch + Send + Sync + 'static,
+{
+    match msg {
+        Message::Modify(VsIndexModify::AddVector {
+            primary_id,
+            embedding,
+            in_progress: _in_progress,
+            ..
+        }) => add_vector(&partition, &size, primary_id, embedding).await,
+
+        Message::Modify(VsIndexModify::RemoveVector {
+            primary_id,
+            in_progress: _in_progress,
+            ..
+        }) => remove_vector(&partition, &params, &size, primary_id).await,
+
+        Message::Search(VsIndexSearch::Ann {
+            embedding,
+            limit,
+            tx,
+            ..
+        }) => {
+            if let Some(tx) = validate_dimensions(tx, &embedding, params.dim) {
+                _ = tx.send(ann(&partition, &table, &params, embedding, limit).await);
+            }
+        }
+
+        Message::Search(VsIndexSearch::FilteredAnn { .. })
+        | Message::Search(VsIndexSearch::Count { .. })
+        | Message::Modify(VsIndexModify::RemovePartition { .. }) => {
+            unreachable!()
+        }
+    }
 }
 
 fn create_diskann_index(
@@ -200,201 +328,124 @@ fn create_diskann_index(
 }
 
 struct Partition {
-    index: DiskANNIndex<DiskannProvider>,
+    partition_id: PartitionId,
+    index: DiskannIndex,
 }
 
-struct State<T>
+async fn add_vector(
+    partition: &Partition,
+    size: &AtomicUsize,
+    primary_id: PrimaryId,
+    embedding: Vector,
+) {
+    if let Err(err) = partition
+        .index
+        .insert(
+            &InmemStrategy,
+            &InmemContext,
+            &primary_id,
+            embedding.as_slice(),
+        )
+        .await
+    {
+        warn!("add_vector: failed to insert vector: {err}");
+    } else {
+        size.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+async fn remove_vector(
+    partition: &Partition,
+    params: &DiskannParams,
+    size: &AtomicUsize,
+    primary_id: PrimaryId,
+) {
+    if let Err(err) = partition
+        .index
+        .inplace_delete(
+            InmemStrategy,
+            &InmemContext,
+            &primary_id,
+            params.config.pruned_degree().get(),
+            InplaceDeleteMethod::OneHop,
+        )
+        .await
+    {
+        warn!("remove_vector: failed to delete vector: {err}");
+    } else {
+        size.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+async fn search(
+    partition: &Partition,
+    params: &DiskannParams,
+    embedding: &Vector,
+    k: usize,
+) -> anyhow::Result<impl Iterator<Item = anyhow::Result<(PrimaryId, Distance)>>> {
+    let space_type = params.space_type;
+    let dimensions = embedding.dim();
+
+    let k = k.min(params.max_points.get());
+    let l_value = params.l_default.get().max(k);
+    let knn = Knn::new(k, l_value, Some(params.beam_width.get()))
+        .context("failed to build DiskANN search parameters")?;
+
+    let mut neighbors: Vec<Neighbor<PrimaryId>> = Vec::with_capacity(knn.k_value().get());
+    let SearchStats { result_count, .. } = partition
+        .index
+        .search(
+            knn,
+            &InmemStrategy,
+            &InmemContext,
+            embedding.as_slice(),
+            &mut neighbors,
+        )
+        .await?;
+
+    neighbors.truncate((result_count as usize).min(k));
+    Ok(neighbors.into_iter().map(move |neighbor| {
+        let raw_distance = match space_type {
+            SpaceType::DotProduct => neighbor.distance() + 1.0,
+            _ => neighbor.distance(),
+        };
+        Distance::try_from((raw_distance, space_type, dimensions))
+            .map(|distance| (*neighbor.id(), distance))
+    }))
+}
+
+async fn ann<T>(
+    partition: &Partition,
+    table: &RwLock<T>,
+    params: &DiskannParams,
+    embedding: Vector,
+    limit: Limit,
+) -> AnnR
 where
     T: TableSearch + Send + Sync + 'static,
 {
-    partitions: BTreeMap<PartitionId, Partition>,
-    sizes: BTreeMap<IndexId, usize>,
-    table: Arc<RwLock<T>>,
-    params: DiskannParams,
-}
+    let matches = search(partition, params, &embedding, limit.0.get())
+        .await
+        .context("ann search failed")?;
 
-impl<T> State<T>
-where
-    T: TableSearch + Send + Sync + 'static,
-{
-    fn new(table: Arc<RwLock<T>>, params: DiskannParams) -> Self {
-        Self {
-            partitions: BTreeMap::new(),
-            sizes: BTreeMap::new(),
-            table,
-            params,
-        }
-    }
-
-    fn get_or_create_partition(
-        &mut self,
-        partition_id: &PartitionId,
-        start_point: Option<&[f32]>,
-    ) -> anyhow::Result<&mut Partition> {
-        match self.partitions.entry(*partition_id) {
-            Entry::Occupied(entry) => Ok(entry.into_mut()),
-            Entry::Vacant(entry) => {
-                let index = create_diskann_index(&self.params, start_point).context(format!(
-                    "failed to create index for partition {partition_id:?}"
-                ))?;
-
-                self.sizes.entry(partition_id.index_id()).or_insert(0);
-
-                Ok(entry.insert(Partition { index }))
-            }
-        }
-    }
-
-    async fn add_vector(
-        &mut self,
-        partition_id: PartitionId,
-        primary_id: PrimaryId,
-        embedding: Vector,
-    ) {
-        let partition =
-            match self.get_or_create_partition(&partition_id, Some(embedding.as_slice())) {
-                Ok(partition) => partition,
-                Err(err) => {
-                    warn!("add_vector failed: {err}");
-                    return;
-                }
-            };
-        if let Err(err) = partition
-            .index
-            .insert(
-                &InmemStrategy,
-                &InmemContext,
-                &primary_id,
-                embedding.as_slice(),
-            )
-            .await
-        {
-            warn!("add_vector: failed to insert vector: {err}");
-        } else {
-            let size = self.sizes.entry(partition_id.index_id()).or_insert(0);
-            *size = size.saturating_add(1);
-        }
-    }
-
-    async fn remove_vector(&mut self, partition_id: PartitionId, primary_id: PrimaryId) {
-        let Some(partition) = self.partitions.get_mut(&partition_id) else {
-            debug!("remove_vector: partition {partition_id:?} not found");
-            return;
-        };
-        if let Err(err) = partition
-            .index
-            .inplace_delete(
-                InmemStrategy,
-                &InmemContext,
-                &primary_id,
-                self.params.config.pruned_degree().get(),
-                InplaceDeleteMethod::OneHop,
-            )
-            .await
-        {
-            warn!("remove_vector: failed to delete vector: {err}");
-        } else {
-            let size = self.sizes.entry(partition_id.index_id()).or_insert(0);
-            *size = size.saturating_sub(1);
-        }
-    }
-
-    async fn search(
-        &self,
-        embedding: &Vector,
-        k: usize,
-        partition: &Partition,
-    ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<(PrimaryId, Distance)>>> {
-        let space_type = self.params.space_type;
-        let dimensions = embedding.dim();
-
-        let k = k.min(self.params.max_points.get());
-        let l_value = self.params.l_default.get().max(k);
-        let params = Knn::new(k, l_value, Some(self.params.beam_width.get()))
-            .context("failed to build DiskANN search parameters")?;
-
-        let mut neighbors: Vec<Neighbor<PrimaryId>> = Vec::with_capacity(params.k_value().get());
-        let SearchStats { result_count, .. } = partition
-            .index
-            .search(
-                params,
-                &InmemStrategy,
-                &InmemContext,
-                embedding.as_slice(),
-                &mut neighbors,
-            )
-            .await?;
-
-        neighbors.truncate((result_count as usize).min(k));
-        Ok(neighbors.into_iter().map(move |neighbor| {
-            let raw_distance = match space_type {
-                SpaceType::DotProduct => neighbor.distance() + 1.0,
-                _ => neighbor.distance(),
-            };
-            Distance::try_from((raw_distance, space_type, dimensions))
-                .map(|distance| (*neighbor.id(), distance))
-        }))
-    }
-
-    async fn ann(&self, index_key: IndexKey, embedding: Vector, limit: Limit) -> AnnR {
-        let partition_id: PartitionId = {
-            let table = self.table.read().unwrap();
-            if let Some((partition_id, _)) = table.partition_id(&index_key, None) {
-                partition_id
-            } else {
-                warn!(
-                    "partition id not found for index key {} during ann",
-                    index_key
-                );
-                return Ok((vec![], vec![]));
-            }
-        };
-
-        let Some(partition) = self.partitions.get(&partition_id) else {
-            return Ok((vec![], vec![]));
-        };
-
-        let matches = self
-            .search(&embedding, limit.0.get(), partition)
-            .await
-            .context("ann search failed")?;
-
-        let table = self.table.read().unwrap();
-        let (primary_keys, distances) = itertools::process_results(
-            matches.filter_map_ok(|(primary_id, distance)| {
-                table
-                    .primary_key(partition_id, primary_id)
-                    .or_else(|| {
-                        debug!(
-                            "not defined primary key for partition_id {partition_id:?} \
-                                        and primary_id {primary_id:?}",
-                        );
-                        None
-                    })
-                    .map(|primary_key| (primary_key, distance))
-            }),
-            |it| it.unzip(),
-        )?;
-        Ok((primary_keys, distances))
-    }
-
-    fn remove_partition(&mut self, partition_id: PartitionId) {
-        if self.partitions.remove(&partition_id).is_none() {
-            debug!("remove_partition: partition {partition_id:?} not found");
-        }
-    }
-
-    fn count(&self, index_key: &IndexKey) -> CountR {
-        let index_id = {
-            let table = self.table.read().unwrap();
-            let Some(index_id) = table.index_id(index_key) else {
-                anyhow::bail!("index id not found for index key {index_key}");
-            };
-            index_id
-        };
-
-        Ok(self.sizes.get(&index_id).copied().unwrap_or(0))
-    }
+    let partition_id = partition.partition_id;
+    let table = table.read().unwrap();
+    let (primary_keys, distances) = itertools::process_results(
+        matches.filter_map_ok(|(primary_id, distance)| {
+            table
+                .primary_key(partition_id, primary_id)
+                .or_else(|| {
+                    debug!(
+                        "not defined primary key for partition_id {partition_id:?} \
+                                    and primary_id {primary_id:?}",
+                    );
+                    None
+                })
+                .map(|primary_key| (primary_key, distance))
+        }),
+        |it| it.unzip(),
+    )?;
+    Ok((primary_keys, distances))
 }
 
 #[hotpath::measure]

--- a/crates/vector-store/src/vs_index/diskann.rs
+++ b/crates/vector-store/src/vs_index/diskann.rs
@@ -30,6 +30,7 @@ use crate::vs_index::VsIndexModify;
 use crate::vs_index::VsIndexSearch;
 use crate::vs_index::validator;
 use crate::worker::Worker;
+use crate::worker::WorkerExt;
 use anyhow::Context;
 use diskann::graph::Config as DiskannConfig;
 use diskann::graph::DiskANNIndex;
@@ -71,7 +72,7 @@ type DiskannProvider = InmemProvider<Full<f32>, PrimaryId>;
 type DiskannIndex = DiskANNIndex<DiskannProvider>;
 
 pub struct DiskannIndexFactory {
-    _worker: async_channel::Sender<Worker>,
+    worker: async_channel::Sender<Worker>,
     memory: mpsc::Sender<Memory>,
     alpha: DiskannAlpha,
 }
@@ -85,7 +86,13 @@ impl VsIndexFactory for DiskannIndexFactory {
         let params = DiskannParams::new(&index, self.alpha, MAX_POINTS)
             .context("failed to create DiskANN parameters")?;
 
-        new(index.key, self.memory.clone(), table, params)
+        new(
+            index.key,
+            self.worker.clone(),
+            self.memory.clone(),
+            table,
+            params,
+        )
     }
 
     fn index_engine_version(&self) -> String {
@@ -101,7 +108,7 @@ pub fn new_diskann(
     let config = config_rx.borrow_and_update();
 
     Ok(DiskannIndexFactory {
-        _worker: worker,
+        worker,
         memory,
         alpha: config
             .diskann_alpha
@@ -111,6 +118,7 @@ pub fn new_diskann(
 
 fn new(
     index_key: IndexKey,
+    worker: async_channel::Sender<Worker>,
     memory: mpsc::Sender<Memory>,
     table: Arc<RwLock<impl TableSearch + Send + Sync + 'static>>,
     params: DiskannParams,
@@ -144,14 +152,7 @@ fn new(
                         continue;
                     };
 
-                    process(
-                        partition,
-                        Arc::clone(&table),
-                        Arc::clone(&params),
-                        size,
-                        msg,
-                    )
-                    .await;
+                    dispatch_task(partition, &table, &params, &worker, size, msg).await;
                 }
 
                 debug!("finished");
@@ -267,6 +268,33 @@ where
             None
         }
     }
+}
+
+#[hotpath::measure]
+async fn dispatch_task<T>(
+    partition: Arc<Partition>,
+    table: &Arc<RwLock<T>>,
+    params: &Arc<DiskannParams>,
+    worker: &async_channel::Sender<Worker>,
+    size: Arc<AtomicUsize>,
+    msg: Message,
+) where
+    T: TableSearch + Send + Sync + 'static,
+{
+    let non_blocking = is_non_blocking(&msg);
+    let table = Arc::clone(table);
+    let params = Arc::clone(params);
+    let task = move || process(partition, table, params, size, msg);
+    if non_blocking {
+        worker.spawn_async_non_blocking(task).await;
+    } else {
+        worker.spawn_async_blocking(task).await;
+    }
+}
+
+#[hotpath::measure]
+fn is_non_blocking(msg: &Message) -> bool {
+    matches!(msg, Message::Search(VsIndexSearch::Ann { .. }))
 }
 
 #[hotpath::measure]

--- a/crates/vector-store/src/worker.rs
+++ b/crates/vector-store/src/worker.rs
@@ -5,24 +5,47 @@
 
 use crate::perf;
 use async_channel::Sender;
+use futures::future::BoxFuture;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::thread;
+use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tracing::Instrument;
 use tracing::debug;
 use tracing::error_span;
 
+/// A lambda creating a future, instead of the future itself. The future has to be
+/// created by the runtime which polls it.
+type NewTaskFuture = Box<dyn FnOnce() -> BoxFuture<'static, ()> + Send>;
+
+fn new_task_future<Fut>(f: impl FnOnce() -> Fut + Send + 'static) -> NewTaskFuture
+where
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    Box::new(move || -> BoxFuture<'static, ()> { Box::pin(f()) })
+}
+
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum Worker {
     SpawnNonBlocking { f: Box<dyn FnOnce() + Send> },
     SpawnBlocking { f: Box<dyn FnOnce() + Send> },
+    SpawnAsyncNonBlocking { f: NewTaskFuture },
+    SpawnAsyncBlocking { f: NewTaskFuture },
 }
 
 pub(crate) trait WorkerExt {
     async fn spawn_non_blocking(&self, f: impl FnOnce() + Send + 'static);
     async fn spawn_blocking(&self, f: impl FnOnce() + Send + 'static);
+    async fn spawn_async_non_blocking<Fut>(&self, f: impl FnOnce() -> Fut + Send + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static;
+    async fn spawn_async_blocking<Fut>(&self, f: impl FnOnce() -> Fut + Send + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static;
 }
 
 impl WorkerExt for Sender<Worker> {
@@ -39,19 +62,81 @@ impl WorkerExt for Sender<Worker> {
             .await
             .expect("WorkerExt::spawn_blocking: internal actor should receive request");
     }
+
+    #[hotpath::measure]
+    async fn spawn_async_non_blocking<Fut>(&self, f: impl FnOnce() -> Fut + Send + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.send(Worker::SpawnAsyncNonBlocking {
+            f: new_task_future(f),
+        })
+        .await
+        .expect("WorkerExt::spawn_async_non_blocking: internal actor should receive request");
+    }
+
+    #[hotpath::measure]
+    async fn spawn_async_blocking<Fut>(&self, f: impl FnOnce() -> Fut + Send + 'static)
+    where
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.send(Worker::SpawnAsyncBlocking {
+            f: new_task_future(f),
+        })
+        .await
+        .expect("WorkerExt::spawn_async_blocking: internal actor should receive request");
+    }
+}
+
+fn try_acquire_thread(
+    id: usize,
+    in_flow: usize,
+    workers: usize,
+    thread_operations_in_flow: &AtomicUsize,
+) -> bool {
+    // If all workers are busy, we need to execute the blocking task in a
+    // separate thread to avoid starving runtime.
+    if in_flow != workers {
+        return false;
+    }
+    let thread_in_flow = thread_operations_in_flow.fetch_add(1, Ordering::Relaxed) + 1;
+    hotpath::val!("worker::thread_in_flow").set(&(id, in_flow, thread_in_flow));
+    if thread_in_flow == 1 {
+        true
+    } else {
+        thread_operations_in_flow.fetch_sub(1, Ordering::Relaxed);
+        false
+    }
+}
+
+async fn run_in_thread(
+    tx_thread: &mpsc::Sender<(NewTaskFuture, oneshot::Sender<()>)>,
+    thread_operations_in_flow: &AtomicUsize,
+    f: NewTaskFuture,
+) {
+    let (tx_call, rx_call) = oneshot::channel();
+    tx_thread
+        .send((f, tx_call))
+        .await
+        .expect("Worker: internal thread should receive task");
+    _ = rx_call.await;
+    thread_operations_in_flow.fetch_sub(1, Ordering::Relaxed);
 }
 
 pub(crate) fn new() -> Sender<Worker> {
     let (tx_worker, rx_worker) = async_channel::bounded(perf::channel_size().into());
-    let (tx_thread, mut rx_thread) =
-        mpsc::channel::<(Box<dyn FnOnce() + Send>, oneshot::Sender<()>)>(1);
+    let (tx_thread, mut rx_thread) = mpsc::channel::<(NewTaskFuture, oneshot::Sender<()>)>(1);
 
     // Dedicated thread for long tasks to avoid starving runtime.
     thread::spawn(move || {
-        while let Some((f, tx_call)) = rx_thread.blocking_recv() {
-            f();
-            _ = tx_call.send(());
-        }
+        let runtime = Builder::new_current_thread().build().unwrap();
+
+        runtime.block_on(async move {
+            while let Some((f, tx_call)) = rx_thread.recv().await {
+                f().await;
+                _ = tx_call.send(());
+            }
+        });
     });
 
     let operations_in_flow = Arc::new(AtomicUsize::new(0));
@@ -73,36 +158,28 @@ pub(crate) fn new() -> Sender<Worker> {
                         Worker::SpawnNonBlocking { f } => {
                             f();
                         }
+                        Worker::SpawnAsyncNonBlocking { f } => {
+                            f().await;
+                        }
                         Worker::SpawnBlocking { f } => {
-                            // If all workers are busy, we need to execute the blocking task in a
-                            // separate thread to avoid starving runtime.
-                            let in_thread = if in_flow == workers {
-                                let thread_in_flow =
-                                    thread_operations_in_flow.fetch_add(1, Ordering::Relaxed) + 1;
-                                hotpath::val!("worker::thread_in_flow").set(&(
-                                    id,
-                                    in_flow,
-                                    thread_in_flow,
-                                ));
-                                if thread_in_flow == 1 {
-                                    true
-                                } else {
-                                    thread_operations_in_flow.fetch_sub(1, Ordering::Relaxed);
-                                    false
-                                }
-                            } else {
-                                false
-                            };
-                            if in_thread {
-                                let (tx_call, rx_call) = oneshot::channel();
-                                tx_thread
-                                    .send((f, tx_call))
-                                    .await
-                                    .expect("Worker: internal thread should receive task");
-                                _ = rx_call.await;
-                                thread_operations_in_flow.fetch_sub(1, Ordering::Relaxed);
+                            if try_acquire_thread(id, in_flow, workers, &thread_operations_in_flow)
+                            {
+                                run_in_thread(
+                                    &tx_thread,
+                                    &thread_operations_in_flow,
+                                    new_task_future(move || async move { f() }),
+                                )
+                                .await;
                             } else {
                                 f();
+                            }
+                        }
+                        Worker::SpawnAsyncBlocking { f } => {
+                            if try_acquire_thread(id, in_flow, workers, &thread_operations_in_flow)
+                            {
+                                run_in_thread(&tx_thread, &thread_operations_in_flow, f).await;
+                            } else {
+                                f().await;
                             }
                         }
                     }


### PR DESCRIPTION
This PR is split into 3:
- Refactoring diskann to match usearch sync preproccess -> concurrent process
- Adding new variants to `worker` 
- Using the new worker to enable concurrency in diskann