### PR TITLE
validator: update e2etest to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,9 +1895,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2etest"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c07d6e20f5593d38a99c606d037cd6e5c48ae207c807be3ba0bd41c772da0b2"
+checksum = "f6295e4e70c848165ef0f1463b0ae68611429f363e8a2057a5c72ce7429cdde0"
 dependencies = [
  "async-backtrace",
  "e2etest-macros",
@@ -1934,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "e2etest-macros"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319137d449236a9c0b537f2d2266d31ce919bc3d367364178a05a1c69c01ff63"
+checksum = "db22f36307489497d9241f4245dbae82d7c13ba7276fb8b297d4e916c03bda01"
 dependencies = [
  "convert_case 0.11.0",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ diskann = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a75
 diskann-vector = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
 diskann-inmem = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
 dotenvy = "0.15.7"
-e2etest = "0.2.0"
+e2etest = "0.3.1"
 e2etest-dns = "0.1.0"
 e2etest-firewall = "0.1.0"
 e2etest-scylla-cluster = "0.1.1"

--- a/crates/validator/src/alternator/auth.rs
+++ b/crates/validator/src/alternator/auth.rs
@@ -258,9 +258,8 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
 
         let scylla_configs = alternator::get_scylla_configs(
             &actors,
@@ -277,7 +276,7 @@ impl e2etest::Fixture for Fixture {
 
         common::init_with_config(&actors, scylla_configs, vs_configs, false).await;
 
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/batch_write_item.rs
+++ b/crates/validator/src/alternator/batch_write_item.rs
@@ -247,11 +247,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/create_table.rs
+++ b/crates/validator/src/alternator/create_table.rs
@@ -475,11 +475,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/delete_item.rs
+++ b/crates/validator/src/alternator/delete_item.rs
@@ -90,11 +90,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/lwt.rs
+++ b/crates/validator/src/alternator/lwt.rs
@@ -221,9 +221,8 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
 
         alternator::init_with_args(
             &actors,
@@ -231,7 +230,7 @@ impl e2etest::Fixture for Fixture {
         )
         .await;
 
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/put_item.rs
+++ b/crates/validator/src/alternator/put_item.rs
@@ -160,11 +160,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/query.rs
+++ b/crates/validator/src/alternator/query.rs
@@ -760,11 +760,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/ttl.rs
+++ b/crates/validator/src/alternator/ttl.rs
@@ -200,11 +200,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/types.rs
+++ b/crates/validator/src/alternator/types.rs
@@ -190,11 +190,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/update_item.rs
+++ b/crates/validator/src/alternator/update_item.rs
@@ -478,11 +478,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/alternator/update_table.rs
+++ b/crates/validator/src/alternator/update_table.rs
@@ -244,11 +244,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         alternator::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/ann.rs
+++ b/crates/validator/src/ann.rs
@@ -19,11 +19,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/auth.rs
+++ b/crates/validator/src/auth.rs
@@ -23,10 +23,9 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
-        Self { actors }
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/cdc.rs
+++ b/crates/validator/src/cdc.rs
@@ -37,11 +37,10 @@ struct FixtureDirect {
 }
 
 impl e2etest::Fixture for FixtureDirect {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {
@@ -60,11 +59,10 @@ struct FixtureProxy {
 }
 
 impl e2etest::Fixture for FixtureProxy {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init_with_proxy_single_vs(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/coexisting_indexes.rs
+++ b/crates/validator/src/coexisting_indexes.rs
@@ -24,11 +24,10 @@ struct Cluster {
 }
 
 impl e2etest::Fixture for Cluster {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {
@@ -44,16 +43,16 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        let cluster = setup.setup::<Cluster>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let cluster = setup.setup::<Cluster>().await?;
+        let actors = setup.setup::<TestActors>().await?;
         let (session, keyspace, table) = setup_table(&actors).await;
-        Self {
+        Some(Self {
             _cluster: cluster,
             session,
             keyspace,
             table,
-        }
+        })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/connection_timeout.rs
+++ b/crates/validator/src/connection_timeout.rs
@@ -25,11 +25,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init_with_proxy_single_vs(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/crud.rs
+++ b/crates/validator/src/crud.rs
@@ -18,11 +18,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/db_timeout.rs
+++ b/crates/validator/src/db_timeout.rs
@@ -29,11 +29,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init_with_proxy(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -22,11 +22,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/fts.rs
+++ b/crates/validator/src/fts.rs
@@ -22,11 +22,10 @@ struct Cluster {
 }
 
 impl e2etest::Fixture for Cluster {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {
@@ -43,17 +42,16 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<Cluster>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
-        let (session, clients, keyspace, table) = Self::init_fts_table(&actors).await;
-        Self {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let cluster = setup.setup::<Cluster>().await?;
+        let (session, clients, keyspace, table) = Self::init_fts_table(&cluster.actors).await;
+        Some(Self {
             session,
             keyspace,
             table,
             clients,
             index: RwLock::new(None),
-        }
+        })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/full_scan.rs
+++ b/crates/validator/src/full_scan.rs
@@ -32,11 +32,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init_with_proxy_single_vs(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/high_availability.rs
+++ b/crates/validator/src/high_availability.rs
@@ -26,10 +26,9 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
-        Self { actors }
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/index_create.rs
+++ b/crates/validator/src/index_create.rs
@@ -29,11 +29,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         common::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/index_modify.rs
+++ b/crates/validator/src/index_modify.rs
@@ -29,11 +29,10 @@ struct GroupFixture {
 }
 
 impl e2etest::Fixture for GroupFixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         common::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {
@@ -49,8 +48,8 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
 
         let (session, clients) = common::prepare_connection(&actors).await;
 
@@ -62,12 +61,12 @@ impl e2etest::Fixture for Fixture {
             None,
         )
         .await;
-        Self {
+        Some(Self {
             session,
             clients,
             keyspace,
             table,
-        }
+        })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/index_status.rs
+++ b/crates/validator/src/index_status.rs
@@ -22,11 +22,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -203,8 +203,12 @@ pub async fn run() -> ExitCode {
 
     if !stats.is_success() {
         error!(
-            "{error_list}",
-            error_list = format_failed_names(&stats.failed_names())
+            "Tests skipped by fixture errors:\n{list}",
+            list = format_test_names(&stats.tests_skipped_by_fixture_err_names())
+        );
+        error!(
+            "Tests failed:\n{list}",
+            list = format_test_names(&stats.failed_names())
         );
         return ExitCode::FAILURE;
     }
@@ -212,13 +216,12 @@ pub async fn run() -> ExitCode {
     ExitCode::SUCCESS
 }
 
-pub(crate) fn format_failed_names(failed_names: &[String]) -> String {
-    let failed_names = failed_names
+pub(crate) fn format_test_names(names: &[String]) -> String {
+    names
         .iter()
         .map(|name| format!("- {name}"))
         .collect::<Vec<_>>()
-        .join("\n");
-    format!("List of failures:\n{failed_names}")
+        .join("\n")
 }
 
 /// Represents a subnet for services, derived from a base IP address.
@@ -258,7 +261,7 @@ struct TestActors {
 }
 
 impl e2etest::Fixture for TestActors {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
         let args = setup.get::<RunArgs>().await.unwrap();
 
         validate_different_subnet(args.dns_ip, args.base_ip);
@@ -293,7 +296,7 @@ impl e2etest::Fixture for TestActors {
         info!("dns version: {}", dns.version().await);
         info!("vector-store version: {}", vs.version().await);
 
-        Self {
+        Some(Self {
             services_subnet,
             tls,
             dns,
@@ -301,7 +304,7 @@ impl e2etest::Fixture for TestActors {
             db,
             vs,
             db_proxy,
-        }
+        })
     }
     async fn teardown(self) {}
 }

--- a/crates/validator/src/quantization_and_rescoring.rs
+++ b/crates/validator/src/quantization_and_rescoring.rs
@@ -76,11 +76,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/reconnect.rs
+++ b/crates/validator/src/reconnect.rs
@@ -34,11 +34,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init_with_proxy_single_vs(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/routing.rs
+++ b/crates/validator/src/routing.rs
@@ -31,11 +31,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         init_with_proxy_single_vs(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/serde.rs
+++ b/crates/validator/src/serde.rs
@@ -25,11 +25,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         common::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/similarity_functions.rs
+++ b/crates/validator/src/similarity_functions.rs
@@ -21,11 +21,10 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
         common::init(&actors).await;
-        Self { actors }
+        Some(Self { actors })
     }
 
     async fn teardown(self) {

--- a/crates/validator/src/tls_reload.rs
+++ b/crates/validator/src/tls_reload.rs
@@ -29,10 +29,9 @@ struct Fixture {
 }
 
 impl e2etest::Fixture for Fixture {
-    async fn setup(setup: &mut impl e2etest::Setup) -> Self {
-        setup.setup::<TestActors>().await;
-        let actors = setup.get::<TestActors>().await.unwrap();
-        Self { actors }
+    async fn setup(setup: &mut impl e2etest::Setup) -> Option<Self> {
+        let actors = setup.setup::<TestActors>().await?;
+        Some(Self { actors })
     }
 
     async fn teardown(self) {


### PR DESCRIPTION
This commit updates e2etest and fixes Fixtures setup to return Option<Self>.
It also updates a list of failed or skipped by fixture errors tests at the end.
