### PR TITLE
ci: build release per architecture on native runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,21 @@ env:
   VECTOR_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.VECTOR_VERSION }}
 
 jobs:
-  build-docker:
-    runs-on: ubuntu-latest
+  # Build vector-store once per architecture, natively (no QEMU emulation),
+  # and expose the results (binary tarball, docker image, SBOMs) as workflow
+  # artifacts for the downstream jobs.
+  build:
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -24,26 +35,65 @@ jobs:
           ref: ${{ env.VECTOR_VERSION }}
           fetch-depth: 0
 
-      - name: Set up QEMU (multi-arch emulation)
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
-
       - name: Install SBOM tooling (syft + cargo-cyclonedx) used by build-release
         run: |
           set -euo pipefail
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
           cargo install cargo-cyclonedx --locked
 
+      - name: Build image, tarball and SBOMs for ${{ matrix.arch }}
+        run: ./scripts/build-release ${{ matrix.arch }}
+
+      - name: Save the docker image
+        run: docker save "scylladb/vector-store:${VECTOR_VERSION}-${{ matrix.arch }}" -o "vector-store-image-${VECTOR_VERSION}-${{ matrix.arch }}.tar"
+
+      - name: Upload the docker image as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vector-store-image-${{ env.VECTOR_VERSION }}-${{ matrix.arch }}
+          path: vector-store-image-${{ env.VECTOR_VERSION }}-${{ matrix.arch }}.tar
+
+      - name: Upload the release tarball as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vector-store-${{ env.VECTOR_VERSION }}-${{ matrix.arch }}
+          path: target/${{ matrix.arch }}/release/vector-store-${{ env.VECTOR_VERSION }}-${{ matrix.arch }}.tar.gz
+
+      - name: Upload SBOMs as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vector-store-sboms-${{ env.VECTOR_VERSION }}-${{ matrix.arch }}
+          path: |
+            vector-store-${{ env.VECTOR_VERSION }}.cdx.json
+            vector-store-docker-${{ env.VECTOR_VERSION }}-${{ matrix.arch }}.cdx.json
+          if-no-files-found: warn
+
+  # Push the per-arch images built by the build job (no rebuild) and combine
+  # them into a multi-arch manifest.
+  push-docker:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download the docker image artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: vector-store-image-${{ env.VECTOR_VERSION }}-*
+          merge-multiple: true
+
+      - name: Load the docker images
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64 ; do
+            docker load -i "vector-store-image-${VECTOR_VERSION}-${arch}.tar"
+          done
+
       - name: Log in to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build images, SBOMs and manifest
-        run: ./scripts/build-release
 
       - name: Push per-arch images and multi-arch manifest
         run: |
@@ -57,16 +107,24 @@ jobs:
             "${IMAGE}:${VECTOR_VERSION}-arm64"
           docker manifest push --purge "${IMAGE}:${VECTOR_VERSION}"
 
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: vector-store-sboms-${{ env.VECTOR_VERSION }}-*
+          merge-multiple: true
+          path: sboms
+
       - name: Archive SBOMs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vector-store-sboms-${{ env.VECTOR_VERSION }}
           path: |
-            vector-store-${{ env.VECTOR_VERSION }}.cdx.json
-            vector-store-docker-${{ env.VECTOR_VERSION }}-*.cdx.json
+            sboms/vector-store-${{ env.VECTOR_VERSION }}.cdx.json
+            sboms/vector-store-docker-${{ env.VECTOR_VERSION }}-*.cdx.json
           if-no-files-found: warn
 
   build-cloud-images:
+    needs: [push-docker]
     runs-on: ubuntu-latest
     permissions:
       contents: write     # to attach the packer manifest to the release
@@ -126,7 +184,7 @@ jobs:
           asset_content_type: application/json
 
   announce:
-    needs: [build-docker, build-cloud-images]
+    needs: [push-docker, build-cloud-images]
     runs-on: ubuntu-latest
     steps:
       - name: Announce release on Slack

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,7 +29,13 @@ version tag. Then from the root of the repository run:
 ```
 
 This will create a tar.gz release in the `releases/{amd64/arm64}` directory,
-per-architecture docker images, and a multi-platform docker manifest. You can
+per-architecture docker images, and a multi-platform docker manifest. The
+script optionally accepts a subset of architectures to build as arguments
+(e.g. `./scripts/build-release arm64`). A single-architecture build doesn't
+create the multi-platform docker image, so it doesn't need qemu as long as
+the requested architecture matches the host — this is how the release
+workflow builds each architecture natively on its own per-arch runner.
+Building a non-native architecture still requires qemu. You can
 push the docker images and manifest to docker hub:
 
 ```bash

--- a/scripts/build-dockers
+++ b/scripts/build-dockers
@@ -9,7 +9,10 @@ cd $repo
 
 vector_store_version=$(./scripts/run-with-release-toolchain cargo info vector-store | grep ^version: | cut -d ' ' -f 2)
 
-archs="amd64 arm64"
+# architectures to build could be given as arguments (a subset of the default
+# list), e.g. `./scripts/build-dockers arm64`; defaults to all release
+# architectures
+archs="${*:-amd64 arm64}"
 
 dockerfile=$(cat <<EOF
 FROM redhat/ubi9-minimal
@@ -28,13 +31,18 @@ $dockerfile
 EOF
 done
 
-for arch in $archs ; do
-    [[ -z $platform ]] && platform="linux/$arch" || platform="$platform,linux/$arch"
-done
+# build the multi-arch docker image only when more than one architecture is
+# requested, a single-arch build (e.g. a per-arch CI job) doesn't need it and
+# it would require emulation for the non-native architectures
+if [[ $(wc -w <<< "$archs") -gt 1 ]] ; then
+    for arch in $archs ; do
+        [[ -z $platform ]] && platform="linux/$arch" || platform="$platform,linux/$arch"
+    done
 
-echo Build the multi-arch docker image for $platform
-docker build --platform $platform --tag $docker_tag -f- . <<EOF
+    echo Build the multi-arch docker image for $platform
+    docker build --platform $platform --tag $docker_tag -f- . <<EOF
 $dockerfile
 EOF
+fi
 
 docker images -f "reference=$docker_tag*"

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -19,7 +19,10 @@ if git status --porcelain | grep -q . ; then
     exit 1
 fi
 
-archs="amd64 arm64"
+# architectures to build could be given as arguments (a subset of the default
+# list), e.g. `./scripts/build-release arm64`; defaults to all release
+# architectures
+archs="${*:-amd64 arm64}"
 
 for arch in $archs ; do
     echo rebuild the release version $vector_store_version for $arch
@@ -49,7 +52,7 @@ cargo_sbom=crates/vector-store/vector-store.cdx.json
 mv $cargo_sbom vector-store-$vector_store_version.cdx.json
 echo "Cargo SBOM: vector-store-$vector_store_version.cdx.json"
 
-./scripts/build-dockers
+./scripts/build-dockers $archs
 
 for arch in $archs ; do
     echo generate Docker image SBOM for $arch using syft


### PR DESCRIPTION
## Motivation

The release workflow built both `amd64` and `arm64` images in a single `build-docker` job on `ubuntu-latest`, emulating arm64 with QEMU, which is slow. Building and pushing also happened in the same job, so nothing (e.g. validator tests) could be inserted between building a release and publishing it.

## Changes

- `scripts/build-release` and `scripts/build-dockers` accept an optional list of architectures as arguments, defaulting to the full `amd64 arm64` release list so the local release flow described in `docs/releasing.md` is unchanged. With a single architecture, `build-dockers` skips the combined multi-arch image — the only part that needed QEMU.
- The release workflow's `build-docker` job is split in two:
  - a matrix **`build`** job (`amd64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm`, same runner mapping as `daily.yml`) builds each architecture natively via `./scripts/build-release <arch>` and uploads the docker image, release tarball and SBOMs as per-arch artifacts;
  - a **`push-docker`** job downloads the per-arch images, pushes them, assembles the multi-arch manifest, and archives the combined `vector-store-sboms-<version>` artifact under the same name as before.
- `build-cloud-images` is untouched (Packer downloads the tarball from the GitHub release assets, not from these jobs); `announce` now depends on `push-docker` instead of `build-docker`.

vector-store is now built exactly once per architecture, natively, and the resulting artifacts are reusable by downstream jobs. A follow-up (VECTOR-790) will run the validator test suite against these artifacts and gate publishing on them.

## Test plan

- [x] `actionlint` clean on `.github/workflows/release.yaml`
- [x] `shellcheck -S warning` clean on `scripts/build-release` and `scripts/build-dockers`
- [ ] Dry-run the workflow via `workflow_dispatch` against a dev tag to verify the arm64 native build and the load/push/manifest path end to end

Refs: VECTOR-848