### PR TITLE
ci: update action-download-artifact to v21

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Try to download vector-store artifact
       id: download-vector-store
       continue-on-error: true
-      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
       with:
         workflow: daily.yml
         name: daily-vector-store-${{matrix.arch}}-${{github.sha}}
@@ -60,7 +60,7 @@ jobs:
     - name: Try to download vector-search-validator artifact
       id: download-vector-search-validator
       continue-on-error: true
-      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
       with:
         workflow: daily.yml
         name: daily-vector-search-validator-${{matrix.arch}}-${{github.sha}}

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Get scylla-nightly digest for the last working tag
       if: steps.get-scylla-nightly-latest-digest.outcome == 'skipped'
-      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
       with:
         workflow: daily.yml
         name: scylla-nightly-digest


### PR DESCRIPTION
## Summary

CI jobs using `dawidd6/action-download-artifact` (pinned at v3.1.4) emit a Node 20 deprecation warning, e.g. in [this validator run](https://github.com/scylladb/vector-store/actions/runs/31485030651/job/93758353925#step:6:2):

> Node 20 is being deprecated. This workflow is running with Node 24 by default. ...

v3.1.4 declares `node20` as its runtime, which is [deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This PR updates the pin to v21 (`b6e2e70`), which runs on `node24`, in the three places the action is used (`daily.yml` ×2, `validator.yml` ×1).

All inputs our workflows pass (`workflow`, `name`, `search_artifacts`, `workflow_conclusion`) exist unchanged in v21, so this is a drop-in upgrade. The pin stays a full commit SHA per the repo convention.

## Test plan

- [ ] `validator-scylla-nightly-digest` job downloads the `scylla-nightly-digest` artifact without the deprecation warning
- [ ] `daily.yml` artifact-download steps continue to resolve (or fall back to build) as before