### PR TITLE
validator: fix flaky routing tests racing the BOOTSTRAPPING state

### DIFF
--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -57,6 +57,8 @@ pub const VS_OCTET_1: u8 = 21;
 pub const VS_OCTET_2: u8 = 22;
 pub const VS_OCTET_3: u8 = 23;
 
+const INDEX_STATUS_UPDATE_INTERVAL: &str = "100ms";
+
 // Credentials for the default, reduced-privilege role that the Vector Store
 // uses to connect to ScyllaDB, mirroring the setup used in production deployments.
 pub const DEFAULT_DB_USER: &str = "vector_store";
@@ -251,7 +253,12 @@ pub fn get_proxy_vs_node_configs(actors: &TestActors) -> Vec<VectorStoreNodeConf
             db_ip,
             user: Some(DEFAULT_DB_USER.to_string()),
             password: Some(DEFAULT_DB_PASSWORD.to_string()),
-            envs: Default::default(),
+            envs: [(
+                "VECTOR_STORE_INDEX_STATUS_UPDATE_INTERVAL".to_string(),
+                INDEX_STATUS_UPDATE_INTERVAL.to_string(),
+            )]
+            .into_iter()
+            .collect(),
         })
         .collect()
 }

--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -538,6 +538,8 @@ pub async fn prepare_connection_with_custom_vs_ips_no_tls(
     actors: &TestActors,
     vs_ips: Vec<Ipv4Addr>,
 ) -> (Arc<Session>, Vec<HttpClient>) {
+    actors.db_proxy.turn_off_rules().await;
+
     let session = Arc::new(
         SessionBuilder::new()
             .known_node(actors.services_subnet.ip(DB_OCTET_1).to_string())

--- a/crates/validator/src/crud.rs
+++ b/crates/validator/src/crud.rs
@@ -59,12 +59,7 @@ async fn simple_create_drop_index(actors: Arc<TestActors>) {
         .expect("failed to drop an index");
 
     for client in &clients {
-        wait_for(
-            || async { client.indexes().await.is_empty() },
-            "Waiting for index deletion",
-            DEFAULT_OPERATION_TIMEOUT,
-        )
-        .await;
+        wait_for_no_index(client, &index).await;
     }
 
     session
@@ -151,12 +146,7 @@ async fn simple_create_drop_multiple_indexes(actors: Arc<TestActors>) {
 
     // Wait for the first index to be dropped
     for client in &clients {
-        wait_for(
-            || async { client.indexes().await.len() == 1 },
-            "Waiting for the first index to be dropped",
-            DEFAULT_OPERATION_TIMEOUT,
-        )
-        .await;
+        wait_for_no_index(client, &index1).await;
     }
 
     // ANN query on v1 should not succeed after dropping the index
@@ -185,12 +175,7 @@ async fn simple_create_drop_multiple_indexes(actors: Arc<TestActors>) {
 
     // Wait for the second index to be dropped
     for client in &clients {
-        wait_for(
-            || async { client.indexes().await.is_empty() },
-            "Waiting for all indexes to be dropped",
-            DEFAULT_OPERATION_TIMEOUT,
-        )
-        .await;
+        wait_for_no_index(client, &index2).await;
     }
 
     // Drop keyspace
@@ -230,7 +215,7 @@ async fn drop_table_removes_index(actors: Arc<TestActors>) {
             .expect("failed to insert a row");
     }
 
-    let _ = create_index(CreateIndexQuery::new(
+    let index = create_index(CreateIndexQuery::new(
         &session,
         &clients,
         &table,
@@ -248,12 +233,7 @@ async fn drop_table_removes_index(actors: Arc<TestActors>) {
         .expect("failed to drop table");
 
     for client in &clients {
-        wait_for(
-            || async { client.indexes().await.is_empty() },
-            "Waiting for index deletion",
-            DEFAULT_OPERATION_TIMEOUT,
-        )
-        .await;
+        wait_for_no_index(client, &index).await;
     }
 
     session

--- a/crates/validator/src/full_scan.rs
+++ b/crates/validator/src/full_scan.rs
@@ -127,12 +127,7 @@ async fn full_scan_is_completed_when_responding_to_messages_concurrently(actors:
         .await
         .expect("failed to drop an index");
 
-    wait_for(
-        || async { client.indexes().await.is_empty() },
-        "index must be removed",
-        Duration::from_secs(60),
-    )
-    .await;
+    wait_for_no_index(client, &index).await;
 
     info!("Dropping keyspace");
     session
@@ -224,12 +219,7 @@ async fn full_scan_stops_when_index_is_dropped(actors: Arc<TestActors>) {
         .expect("failed to drop an index");
 
     info!("Waiting for index to be removed from vector-store");
-    wait_for(
-        || async { client.indexes().await.is_empty() },
-        "index must be removed",
-        DEFAULT_OPERATION_TIMEOUT,
-    )
-    .await;
+    wait_for_no_index(client, &index).await;
 
     info!("Verifying no DB execute traffic continues after index drop");
     let (tx_feedback, mut rx_feedback) = mpsc::unbounded_channel();

--- a/crates/validator/src/routing.rs
+++ b/crates/validator/src/routing.rs
@@ -128,18 +128,7 @@ async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping(actors: 
         .await
         .expect("failed to drop oldest index");
 
-    wait_for(
-        || async {
-            client
-                .indexes()
-                .await
-                .iter()
-                .all(|i| i.index != oldest.index)
-        },
-        "oldest index must be removed",
-        DEFAULT_OPERATION_TIMEOUT,
-    )
-    .await;
+    wait_for_no_index(client, &oldest).await;
 
     get_query_results(
         format!(
@@ -370,12 +359,7 @@ async fn ann_returns_not_found_after_index_is_dropped(actors: Arc<TestActors>) {
         .await
         .expect("failed to drop index");
 
-    wait_for(
-        || async { client.indexes().await.is_empty() },
-        "index must be removed",
-        DEFAULT_OPERATION_TIMEOUT,
-    )
-    .await;
+    wait_for_no_index(client, &index).await;
 
     session
         .query_unpaged(

--- a/crates/validator/src/routing.rs
+++ b/crates/validator/src/routing.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use tracing::info;
 
 const ANN_LIMIT: usize = 5;
-const FRAME_DELAY: Duration = Duration::from_millis(100);
+const FRAME_DELAY: Duration = Duration::from_millis(500);
 
 e2etest::group!(
     name = routing,


### PR DESCRIPTION
The validator routing tests has been failing on master as well as unrelated branches.

The index status reported over the HTTP API is a snapshot the engine refreshes once per second. The routing tests index a single-row table, so the whole BOOTSTRAPPING phase lasted ~0.65s and could fall between two refreshes, leaving the index to go from INITIALIZING straight to SERVING. The tests then timed out waiting for a state that was never reported. A panicking test also left its keyspace behind, so later tests waiting for an empty index listing failed too, which is why one flake showed up as several.

Changes:

- Wait for the specific index to disappear rather than for the whole listing to drain, so a failure stays attributed to the test that caused it.
- Give proxy-based groups a 100ms status refresh interval and raise the routing frame delay to 500ms, putting the bootstrapping phase an order of magnitude above the refresh interval.
- Reset the proxy rules when a test opens its connections. Rules belong to the group's proxy and the fixture is set up once, so a test that panics with rules active slows down every test after it.

The recurring `no SELECT permission` CDC warnings are unrelated. Dropping an index revokes the SELECT that VECTOR_SEARCH_INDEXING grants implicitly, before the readers shut down. They are emitted by scylla-cdc, one per stream reader, and appear in passing runs too.

Fixes: VECTOR-852
Fixes: VECTOR-679
Refs: VECTOR-680