### PR TITLE
vector-store: expose FTS highlighting over the HTTP API

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1064,6 +1064,46 @@
           }
         }
       },
+      "PostIndexHighlightRequest": {
+        "type": "object",
+        "description": "Request body for highlighting.",
+        "required": [
+          "query",
+          "documents"
+        ],
+        "properties": {
+          "documents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The documents to highlight."
+          },
+          "query": {
+            "type": "string",
+            "description": "The text query whose terms should be marked in the documents."
+          }
+        }
+      },
+      "PostIndexHighlightResponse": {
+        "type": "object",
+        "description": "Response for highlighting.",
+        "required": [
+          "highlights"
+        ],
+        "properties": {
+          "highlights": {
+            "type": "array",
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": "The highlighted documents. Each document is a string of text with the query terms marked."
+          }
+        }
+      },
       "SimilarityFunction": {
         "type": "string",
         "description": "Similarity function used to compare vectors, as set at index creation.",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -309,6 +309,100 @@
         }
       }
     },
+    "/api/v1/indexes/{keyspace}/{index}/highlight": {
+      "post": {
+        "tags": [
+          "scylla-vector-store-index"
+        ],
+        "description": "Computes a highlighted excerpt (snippet) for each of the supplied document texts. The index is used only to analyze the query and to weight its terms by their document frequency, prioritizing rarer terms when picking which fragment of a long text to show. Highlights are returned in the same order as the requested documents. A document that matches no query term yields `null`. If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
+        "operationId": "post_index_highlight",
+        "parameters": [
+          {
+            "name": "keyspace",
+            "in": "path",
+            "description": "The name of the ScyllaDB keyspace containing the index.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/KeyspaceName"
+            }
+          },
+          {
+            "name": "index",
+            "in": "path",
+            "description": "The name of the full-text index within the specified keyspace to highlight against.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IndexName"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PostIndexHighlightRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful highlighting. Returns one highlight per requested document, in the requested order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostIndexHighlightResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. Possible causes: malformed input, unparsable query, or missing required fields.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. TLS is enabled in the configuration, but the client connected over plain HTTP.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error while highlighting. Possible causes: internal error, or search engine issues.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "503": {
+            "$ref": "#/components/responses/IndexNotReadyResponse"
+          }
+        }
+      }
+    },
     "/api/v1/indexes/{keyspace}/{index}/status": {
       "get": {
         "tags": [

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -445,6 +445,21 @@ mod tests {
         assert_eq!(distances, vec![f32::MAX, -f32::MAX, 1.5]);
         assert_eq!(similarity_scores, vec![f32::MAX, -f32::MAX, 0.5]);
     }
+
+    #[test]
+    fn highlight_request_parses_query_and_documents() {
+        let request: PostIndexHighlightRequest =
+            serde_json::from_str(r#"{"query":"fox","documents":["the quick brown fox jumps","a completely different fox story"]}"#).unwrap();
+
+        assert_eq!(request.query, "fox");
+        assert_eq!(
+            request.documents,
+            vec![
+                "the quick brown fox jumps",
+                "a completely different fox story"
+            ]
+        );
+    }
 }
 
 #[derive(
@@ -475,4 +490,20 @@ pub struct PostIndexBm25Request {
 pub struct PostIndexBm25Response {
     pub primary_keys: HashMap<ColumnName, Vec<Value>>,
     pub scores: Vec<f32>,
+}
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+/// Request body for highlighting.
+pub struct PostIndexHighlightRequest {
+    /// The text query whose terms should be marked in the documents.
+    pub query: String,
+    /// The documents to highlight.
+    pub documents: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
+/// Response for highlighting.
+pub struct PostIndexHighlightResponse {
+    /// The highlighted documents. Each document is a string of text with the query terms marked.
+    pub highlights: Vec<Option<String>>,
 }

--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -17,6 +17,8 @@ use httpapi::PostIndexAnnRequest;
 use httpapi::PostIndexAnnResponse;
 use httpapi::PostIndexBm25Request;
 use httpapi::PostIndexBm25Response;
+use httpapi::PostIndexHighlightRequest;
+use httpapi::PostIndexHighlightResponse;
 use httpapi::SimilarityScore;
 use httpapi::Vector;
 use reqwest::Client;
@@ -139,6 +141,40 @@ impl HttpClient {
         self.client
             .post(format!(
                 "{}/indexes/{}/{}/bm25",
+                self.url_api, keyspace_name, index_name
+            ))
+            .json(&request)
+            .send()
+            .await
+            .unwrap()
+    }
+
+    pub async fn highlight(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+        query: String,
+        documents: Vec<String>,
+    ) -> Vec<Option<String>> {
+        self.post_highlight(keyspace_name, index_name, query, documents)
+            .await
+            .json::<PostIndexHighlightResponse>()
+            .await
+            .unwrap()
+            .highlights
+    }
+
+    pub async fn post_highlight(
+        &self,
+        keyspace_name: &KeyspaceName,
+        index_name: &IndexName,
+        query: String,
+        documents: Vec<String>,
+    ) -> reqwest::Response {
+        let request = PostIndexHighlightRequest { query, documents };
+        self.client
+            .post(format!(
+                "{}/indexes/{}/{}/highlight",
                 self.url_api, keyspace_name, index_name
             ))
             .json(&request)

--- a/crates/vector-store/src/fts_index/actor.rs
+++ b/crates/vector-store/src/fts_index/actor.rs
@@ -44,7 +44,7 @@ pub(crate) enum FtsIndex {
         limit: Limit,
         tx: oneshot::Sender<FtsSearchR>,
     },
-    _Highlight {
+    Highlight {
         index_key: IndexKey,
         query: String,
         documents: Vec<String>,
@@ -70,7 +70,7 @@ pub(crate) trait FtsIndexExt {
     ) -> anyhow::Result<()>;
     async fn count(&self, index_key: IndexKey) -> CountR;
     async fn search(&self, index_key: IndexKey, query: String, limit: Limit) -> FtsSearchR;
-    async fn _highlight(
+    async fn highlight(
         &self,
         index_key: IndexKey,
         query: String,
@@ -126,14 +126,14 @@ impl FtsIndexExt for mpsc::Sender<FtsIndex> {
         rx.await?
     }
 
-    async fn _highlight(
+    async fn highlight(
         &self,
         index_key: IndexKey,
         query: String,
         documents: Vec<String>,
     ) -> FtsHighlightR {
         let (tx, rx) = oneshot::channel();
-        self.send(FtsIndex::_Highlight {
+        self.send(FtsIndex::Highlight {
             index_key,
             query,
             documents,

--- a/crates/vector-store/src/fts_index/mod.rs
+++ b/crates/vector-store/src/fts_index/mod.rs
@@ -12,6 +12,7 @@ use crate::worker::Worker;
 pub(crate) use actor::FtsIndex;
 pub(crate) use actor::FtsIndexExt;
 pub(crate) use factory::FtsIndexFactory;
+pub(crate) use tantivy::QueryError;
 use tantivy::TantivyIndexFactory;
 use tokio::sync::mpsc;
 

--- a/crates/vector-store/src/fts_index/tantivy.rs
+++ b/crates/vector-store/src/fts_index/tantivy.rs
@@ -544,7 +544,7 @@ pub(crate) fn new(
                                 })
                                 .await;
                         }
-                        FtsIndex::_Highlight {
+                        FtsIndex::Highlight {
                             index_key,
                             query,
                             documents,
@@ -940,7 +940,7 @@ mod tests {
         documents: &[&str],
     ) -> Vec<Option<String>> {
         sender
-            ._highlight(
+            .highlight(
                 make_index_key(),
                 query.into(),
                 documents.iter().map(|doc| doc.to_string()).collect(),
@@ -1140,7 +1140,7 @@ mod tests {
         add_doc(&sender, 1, "fox").await;
 
         let result = sender
-            ._highlight(make_index_key(), "fox AND".into(), vec!["a fox".into()])
+            .highlight(make_index_key(), "fox AND".into(), vec!["a fox".into()])
             .await;
 
         assert!(result.is_err());
@@ -1154,7 +1154,7 @@ mod tests {
         add_doc(&sender, 2, "dog").await;
 
         let result = sender
-            ._highlight(
+            .highlight(
                 make_index_key(),
                 "(fox -dog)^2".into(),
                 vec!["fox dog".into()],
@@ -1174,7 +1174,7 @@ mod tests {
         // A plain boost carries no negation, but we still cannot see inside it
         // to rule one out, so we report it as unsupported rather than a false "no match".
         let result = sender
-            ._highlight(make_index_key(), "fox^2".into(), vec!["fox dog".into()])
+            .highlight(make_index_key(), "fox^2".into(), vec!["fox dog".into()])
             .await;
 
         assert!(result.is_err());
@@ -1186,7 +1186,7 @@ mod tests {
         let sender = make_sender(table);
 
         let result = sender
-            ._highlight(make_index_key(), "fox".into(), vec!["a fox".into()])
+            .highlight(make_index_key(), "fox".into(), vec!["a fox".into()])
             .await;
 
         assert!(result.is_err());

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -903,6 +903,30 @@ async fn post_index_ann(
     .await
 }
 
+async fn check_fts_serving<T>(
+    serving_or_progress: Result<T, Progress>,
+    node_state: &Sender<NodeState>,
+    keyspace: &crate::KeyspaceName,
+    index_name: &crate::IndexName,
+    route_name: &str,
+) -> Result<T, Response> {
+    match serving_or_progress {
+        Ok(serving) => Ok(serving),
+        Err(Progress::InProgress(percentage)) => {
+            let reason =
+                index_not_ready_reason(node_state, keyspace, index_name, percentage).await;
+            debug!("{route_name}: index {keyspace}.{index_name} not ready: {reason:?}");
+            Err((StatusCode::SERVICE_UNAVAILABLE, response::Json(reason)).into_response())
+        }
+        Err(Progress::Done) => {
+            let msg =
+                format!("Index {keyspace}.{index_name} is not serving, but full scan did finish.");
+            debug!("{route_name}: {msg}");
+            Err((StatusCode::INTERNAL_SERVER_ERROR, msg).into_response())
+        }
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/api/v1/indexes/{keyspace}/{index}/bm25",
@@ -988,23 +1012,19 @@ async fn post_index_bm25(
         }
     };
 
-    let (fts_sender, primary_key_columns) = match serving_or_progress {
+    let (fts_sender, primary_key_columns) = match check_fts_serving(
+        serving_or_progress,
+        &state.node_state,
+        &keyspace,
+        &index_name,
+        "post_index_bm25",
+    )
+    .await
+    {
         Ok(serving) => serving,
-        Err(Progress::InProgress(percentage)) => {
+        Err(resp) => {
             timer.observe_duration();
-
-            let reason =
-                index_not_ready_reason(&state.node_state, &keyspace, &index_name, percentage).await;
-            debug!("post_index_bm25: index {keyspace}.{index_name} not ready: {reason:?}");
-            return (StatusCode::SERVICE_UNAVAILABLE, response::Json(reason)).into_response();
-        }
-        Err(Progress::Done) => {
-            timer.observe_duration();
-
-            let msg =
-                format!("Index {keyspace}.{index_name} is not serving, but full scan did finish.");
-            debug!("post_index_bm25: {msg}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response();
+            return resp;
         }
     };
 

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -19,6 +19,7 @@ use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::fts_index::FtsIndex;
 use crate::fts_index::FtsIndexExt;
+use crate::fts_index::QueryError;
 use crate::indexes;
 use crate::indexes::Indexes;
 use crate::info::Info;
@@ -178,6 +179,7 @@ fn new_open_api_router() -> (Router<RoutesInnerState>, utoipa::openapi::OpenApi)
                 .routes(routes!(get_index_info))
                 .routes(routes!(post_index_ann))
                 .routes(routes!(post_index_bm25))
+                .routes(routes!(post_index_highlight))
                 .routes(routes!(get_info))
                 .routes(routes!(get_status)),
         )
@@ -913,8 +915,7 @@ async fn check_fts_serving<T>(
     match serving_or_progress {
         Ok(serving) => Ok(serving),
         Err(Progress::InProgress(percentage)) => {
-            let reason =
-                index_not_ready_reason(node_state, keyspace, index_name, percentage).await;
+            let reason = index_not_ready_reason(node_state, keyspace, index_name, percentage).await;
             debug!("{route_name}: index {keyspace}.{index_name} not ready: {reason:?}");
             Err((StatusCode::SERVICE_UNAVAILABLE, response::Json(reason)).into_response())
         }
@@ -1070,6 +1071,134 @@ async fn post_index_bm25(
                     .into_response(),
             }
         }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/indexes/{keyspace}/{index}/highlight",
+    tag = "scylla-vector-store-index",
+    description = "Computes a highlighted excerpt (snippet) for each of the supplied document texts. \
+The index is used only to analyze the query and to weight its terms by their document frequency, prioritizing \
+rarer terms when picking which fragment of a long text to show. \
+Highlights are returned in the same order as the requested documents. \
+A document that matches no query term yields `null`. \
+If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
+    params(
+        ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the index."),
+        ("index" = httpapi::IndexName, Path, description = "The name of the full-text index within the specified keyspace to highlight against.")
+    ),
+    request_body = httpapi::PostIndexHighlightRequest,
+    responses(
+        (
+            status = 200,
+            description = "Successful highlighting. Returns one highlight per requested document, in the requested order.",
+            body = httpapi::PostIndexHighlightResponse
+        ),
+        (
+            status = 400,
+            description = "Bad request. Possible causes: malformed input, unparsable query, or missing required fields.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 403,
+            description = "Forbidden. TLS is enabled in the configuration, but the client connected over plain HTTP.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 404,
+            description = "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 500,
+            description = "Error while highlighting. Possible causes: internal error, or search engine issues.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 503,
+            response = httpapi::IndexNotReadyResponse
+        )
+    )
+)]
+async fn post_index_highlight(
+    State(state): State<RoutesInnerState>,
+    extensions: Extensions,
+    Path((keyspace, index_name)): Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
+    extract::Json(request): extract::Json<httpapi::PostIndexHighlightRequest>,
+) -> Response {
+    let keyspace: crate::KeyspaceName = keyspace.into();
+    let index_name: crate::IndexName = index_name.into();
+    if let Some(resp) = check_insecure_tls(state.use_tls, &extensions, "post_index_highlight") {
+        return resp;
+    }
+
+    let timer = state
+        .metrics
+        .latency
+        .with_label_values(&[keyspace.as_ref(), index_name.as_ref()])
+        .start_timer();
+
+    let index_key = IndexKey::new(&keyspace, &index_name);
+
+    let serving_or_progress = {
+        let indexes = state.indexes.read().unwrap();
+        let Some(entry) = indexes.get_fts(&index_key) else {
+            timer.observe_duration();
+
+            let msg = format!("missing index: {keyspace}.{index_name}");
+            debug!("post_index_highlight: {msg}");
+            return (StatusCode::NOT_FOUND, msg).into_response();
+        };
+        if entry.status() == crate::node_state::IndexStatus::Serving {
+            Ok(entry.index().clone())
+        } else {
+            Err(entry.progress())
+        }
+    };
+
+    let fts_sender = match check_fts_serving(
+        serving_or_progress,
+        &state.node_state,
+        &keyspace,
+        &index_name,
+        "post_index_highlight",
+    )
+    .await
+    {
+        Ok(sender) => sender,
+        Err(resp) => {
+            timer.observe_duration();
+            return resp;
+        }
+    };
+
+    let result = fts_sender
+        .highlight(index_key, request.query, request.documents)
+        .await;
+
+    timer.observe_duration();
+
+    match result {
+        Err(err) => {
+            let msg = format!("index.highlight request error: {err}");
+            debug!("post_index_highlight: {msg}");
+            let status = if err.downcast_ref::<QueryError>().is_some() {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, msg).into_response()
+        }
+        Ok(highlights) => (
+            StatusCode::OK,
+            response::Json(httpapi::PostIndexHighlightResponse { highlights }),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -461,3 +461,165 @@ async fn fts_index_appears_in_indexes_list() {
         httpapi::IndexOptions::Fulltext(_)
     ));
 }
+
+#[tokio::test]
+async fn fts_highlight_marks_query_terms_in_supplied_text() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _db, _hold) = setup_fts_and_wait(
+        [(vec![CqlValue::Int(1)], "the quick brown fox jumps", 10)],
+        1,
+    )
+    .await;
+
+    let highlights = client
+        .highlight(
+            &keyspace_name,
+            &index_name,
+            "fox".into(),
+            vec!["a completely different fox story".into()],
+        )
+        .await;
+
+    assert_eq!(highlights.len(), 1);
+    assert_eq!(
+        highlights[0].as_deref(),
+        Some("a completely different <b>fox</b> story")
+    );
+}
+
+#[tokio::test]
+async fn fts_highlight_returns_null_for_unmatched_document() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _db, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "the quick brown fox", 10)], 1).await;
+
+    let highlights = client
+        .highlight(
+            &keyspace_name,
+            &index_name,
+            "fox".into(),
+            vec!["turtles all the way down".into()],
+        )
+        .await;
+
+    assert_eq!(highlights[0], None);
+}
+
+#[tokio::test]
+async fn fts_highlight_preserves_document_order() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _db, _hold) = setup_fts_and_wait(
+        [
+            (vec![CqlValue::Int(1)], "turtles", 10),
+            (vec![CqlValue::Int(2)], "fox", 20),
+            (vec![CqlValue::Int(3)], "dog", 30),
+        ],
+        3,
+    )
+    .await;
+
+    let highlights = client
+        .highlight(
+            &keyspace_name,
+            &index_name,
+            "fox OR dog OR turtles".into(),
+            vec![
+                "quick fox jumps".into(),
+                "turtles swim slowly".into(),
+                "lazy dog sleeps".into(),
+            ],
+        )
+        .await;
+
+    assert_eq!(highlights.len(), 3);
+    assert_eq!(highlights[0].as_deref(), Some("quick <b>fox</b> jumps"));
+    assert_eq!(highlights[1].as_deref(), Some("<b>turtles</b> swim slowly"));
+    assert_eq!(highlights[2].as_deref(), Some("lazy <b>dog</b> sleeps"));
+}
+
+#[tokio::test]
+async fn fts_highlight_not_found_returns_404() {
+    crate::enable_tracing();
+
+    let (client, _keyspace_name, _index_name, _db, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
+
+    let response = client
+        .post_highlight(
+            &"nonexistent_ks".into(),
+            &"nonexistent_idx".into(),
+            "hello".into(),
+            vec!["hello world".into()],
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn fts_highlight_unparsable_query_returns_400() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _db, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "hello world", 10)], 1).await;
+
+    let response = client
+        .post_highlight(
+            &keyspace_name,
+            &index_name,
+            "hello AND".into(),
+            vec!["hello world".into()],
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn fts_highlight_not_serving_returns_503() {
+    crate::enable_tracing();
+
+    let fullscan_fn = |_| {
+        use futures::FutureExt;
+        async move {
+            std::future::pending::<()>().await;
+        }
+        .boxed()
+    };
+    let (run, index, _db, _node_state) = setup_fts_store(
+        ["pk".into()],
+        1,
+        [("pk".to_string().into(), NativeType::Int)],
+        Some(Box::new(fullscan_fn)),
+        None,
+    )
+    .await;
+    let (client, _server, _config_tx) = run.await;
+    let keyspace_name: httpapi::KeyspaceName = index.keyspace_name.clone().into();
+    let index_name: httpapi::IndexName = index.index_name.clone().into();
+
+    wait_for(
+        || async {
+            client
+                .index_status(&keyspace_name, &index_name)
+                .await
+                .is_ok_and(|status| status.status == IndexStatus::Bootstrapping)
+        },
+        "Waiting for FTS index to be bootstrapping",
+    )
+    .await;
+
+    let response = client
+        .post_highlight(
+            &keyspace_name,
+            &index_name,
+            "hello".into(),
+            vec!["hello world".into()],
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}


### PR DESCRIPTION
A ScyllaDB coordinator running a BM25 search needs a way to show why a result matched — a highlighted excerpt of the matched text — without duplicating the query's term weighting on the coordinator side.

This PR exposes the FTS highlighting engine over a new `POST /indexes/{keyspace}/{index}/highlight` endpoint. It accepts a query and a list of caller-supplied document texts and returns one highlighted excerpt per document, in the same order, with null for documents that matched no query term. It adds the request/response types, wires the route (reusing the existing not-serving/in-progress status handling from the bm25 endpoint), and covers the new endpoint with integration tests.

Fixes: VECTOR-808