### PR TITLE
vector-store: make diskann generic over the data provider and strategy

### DIFF
--- a/crates/vector-store/src/vs_index/diskann/inmem.rs
+++ b/crates/vector-store/src/vs_index/diskann/inmem.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use super::DiskannBackend;
+use super::DiskannParams;
+use crate::PrimaryId;
+use anyhow::Context;
+use diskann::graph::DiskANNIndex;
+use diskann_inmem::Context as InmemContext;
+use diskann_inmem::Provider as InmemProvider;
+use diskann_inmem::Strategy as InmemStrategy;
+use diskann_inmem::layers::Full;
+use diskann_inmem::provider::Config as InmemProviderConfig;
+
+/// The fully in-memory DiskANN backend: both vectors and adjacency are
+/// resident in RAM.
+#[derive(Clone)]
+pub(super) struct InmemBackend {
+    strategy: InmemStrategy,
+    context: InmemContext,
+}
+
+impl InmemBackend {
+    pub(super) fn new() -> Self {
+        Self {
+            strategy: InmemStrategy,
+            context: InmemContext,
+        }
+    }
+}
+
+impl DiskannBackend for InmemBackend {
+    type Provider = InmemProvider<Full<f32>, PrimaryId>;
+    type Strategy = InmemStrategy;
+
+    fn create_index(
+        &self,
+        params: &DiskannParams,
+        start_point: &[f32],
+    ) -> anyhow::Result<DiskANNIndex<Self::Provider>> {
+        let layer = Full::<f32>::new(usize::from(params.dim.0), params.metric);
+        let cfg = InmemProviderConfig::new(
+            usize::from(params.max_points),
+            params.config.max_degree().get(),
+        );
+        let provider = InmemProvider::<_, PrimaryId>::new(layer, cfg, [start_point])
+            .context("failed to create InmemProvider")?;
+        Ok(DiskANNIndex::new(params.config.clone(), provider, None))
+    }
+
+    fn strategy(&self) -> &InmemStrategy {
+        &self.strategy
+    }
+
+    fn context(&self) -> &InmemContext {
+        &self.context
+    }
+}

--- a/crates/vector-store/src/vs_index/diskann/mod.rs
+++ b/crates/vector-store/src/vs_index/diskann/mod.rs
@@ -38,14 +38,15 @@ use diskann::graph::InplaceDeleteMethod;
 use diskann::graph::config::Builder;
 use diskann::graph::config::MaxDegree;
 use diskann::graph::config::defaults::ALPHA as DISKANN_DEFAULT_ALPHA;
+use diskann::graph::glue::DefaultPostProcessor;
+use diskann::graph::glue::InplaceDeleteStrategy;
+use diskann::graph::glue::InsertStrategy;
 use diskann::graph::index::SearchStats;
 use diskann::graph::search::Knn;
 use diskann::neighbor::Neighbor;
-use diskann_inmem::Context as InmemContext;
-use diskann_inmem::Provider as InmemProvider;
-use diskann_inmem::Strategy as InmemStrategy;
-use diskann_inmem::layers::Full;
-use diskann_inmem::provider::Config as InmemProviderConfig;
+use diskann::provider::DataProvider;
+use diskann::provider::Delete;
+use diskann::provider::SetElement;
 use diskann_vector::distance::Metric;
 use itertools::Itertools;
 use std::collections::BTreeMap;
@@ -65,11 +66,35 @@ use tracing::error;
 use tracing::trace;
 use tracing::warn;
 
+mod inmem;
+
 const DISKANN_DEFAULT_MAX_POINTS: NonZeroUsize = NonZeroUsize::new(1_000_000).unwrap();
 
-type DiskannProvider = InmemProvider<Full<f32>, PrimaryId>;
+/// A DiskANN index backend: a data provider together with the strategy and
+/// context driving it. The trait bounds spell out everything the actor needs
+/// to insert into, delete from, and search a [`DiskANNIndex`] built over the
+/// backend's provider.
+trait DiskannBackend: Send + Sync + 'static
+where
+    Self::Provider: for<'a> SetElement<&'a [f32]> + Delete,
+    Self::Strategy: for<'a> InsertStrategy<'a, Self::Provider, &'a [f32]>
+        + for<'a> DefaultPostProcessor<'a, Self::Provider, &'a [f32], PrimaryId>
+        + InplaceDeleteStrategy<Self::Provider>
+        + Clone,
+{
+    type Provider: DataProvider<ExternalId = PrimaryId>;
+    type Strategy;
 
-type DiskannIndex = DiskANNIndex<DiskannProvider>;
+    fn create_index(
+        &self,
+        params: &DiskannParams,
+        start_point: &[f32],
+    ) -> anyhow::Result<DiskANNIndex<Self::Provider>>;
+
+    fn strategy(&self) -> &Self::Strategy;
+
+    fn context(&self) -> &<Self::Provider as DataProvider>::Context;
+}
 
 pub struct DiskannIndexFactory {
     worker: async_channel::Sender<Worker>,
@@ -88,6 +113,7 @@ impl VsIndexFactory for DiskannIndexFactory {
             .context("failed to create DiskANN parameters")?;
 
         new(
+            inmem::InmemBackend::new(),
             index.key,
             self.worker.clone(),
             self.memory.clone(),
@@ -120,7 +146,8 @@ pub fn new_diskann(
     })
 }
 
-fn new(
+fn new<B: DiskannBackend>(
+    backend: B,
     index_key: IndexKey,
     worker: async_channel::Sender<Worker>,
     memory: mpsc::Sender<Memory>,
@@ -140,6 +167,7 @@ fn new(
 
                 let mut partitions = BTreeMap::new();
                 let mut sizes = BTreeMap::new();
+                let backend = Arc::new(backend);
 
                 let mut allocate_prev = Allocate::Can;
                 let allocate_rx = memory.subscribe_allocate().await;
@@ -150,13 +178,18 @@ fn new(
                         continue;
                     }
 
-                    let Some((partition, size, msg)) =
-                        preprocess(&mut partitions, &mut sizes, table.as_ref(), &params, msg)
-                    else {
+                    let Some((partition, size, msg)) = preprocess(
+                        &backend,
+                        &mut partitions,
+                        &mut sizes,
+                        table.as_ref(),
+                        &params,
+                        msg,
+                    ) else {
                         continue;
                     };
 
-                    dispatch_task(partition, &table, &params, &worker, size, msg).await;
+                    dispatch_task(&backend, partition, &table, &params, &worker, size, msg).await;
                 }
 
                 debug!("finished");
@@ -169,15 +202,17 @@ fn new(
 }
 
 #[hotpath::measure]
-fn preprocess<T>(
-    partitions: &mut BTreeMap<PartitionId, Arc<Partition>>,
+fn preprocess<T, B>(
+    backend: &Arc<B>,
+    partitions: &mut BTreeMap<PartitionId, Arc<Partition<B>>>,
     sizes: &mut BTreeMap<IndexId, Arc<AtomicUsize>>,
     table: &RwLock<T>,
     params: &DiskannParams,
     msg: Message,
-) -> Option<(Arc<Partition>, Arc<AtomicUsize>, Message)>
+) -> Option<(Arc<Partition<B>>, Arc<AtomicUsize>, Message)>
 where
     T: TableSearch + Send + Sync + 'static,
+    B: DiskannBackend,
 {
     match msg {
         Message::Modify(VsIndexModify::AddVector {
@@ -190,7 +225,8 @@ where
                 Entry::Vacant(entry) => {
                     // The first vector of a partition becomes the start point of the graph, so the
                     // index is created here to make it depend on the order of the messages only.
-                    let index = create_diskann_index(params, Some(embedding.as_slice()))
+                    let index = backend
+                        .create_index(params, embedding.as_slice())
                         .context(format!(
                             "failed to create index for partition {partition_id:?}"
                         ))
@@ -275,8 +311,9 @@ where
 }
 
 #[hotpath::measure]
-async fn dispatch_task<T>(
-    partition: Arc<Partition>,
+async fn dispatch_task<T, B>(
+    backend: &Arc<B>,
+    partition: Arc<Partition<B>>,
     table: &Arc<RwLock<T>>,
     params: &Arc<DiskannParams>,
     worker: &async_channel::Sender<Worker>,
@@ -284,11 +321,14 @@ async fn dispatch_task<T>(
     msg: Message,
 ) where
     T: TableSearch + Send + Sync + 'static,
+    B: DiskannBackend,
 {
     let non_blocking = is_non_blocking(&msg);
     let table = Arc::clone(table);
     let params = Arc::clone(params);
-    let task = move || process(partition, table, params, size, msg);
+    let backend = Arc::clone(backend);
+
+    let task = move || process(backend, partition, table, params, size, msg);
     if non_blocking {
         worker.spawn_async_non_blocking(task).await;
     } else {
@@ -302,14 +342,16 @@ fn is_non_blocking(msg: &Message) -> bool {
 }
 
 #[hotpath::measure]
-async fn process<T>(
-    partition: Arc<Partition>,
+async fn process<T, B>(
+    backend: Arc<B>,
+    partition: Arc<Partition<B>>,
     table: Arc<RwLock<T>>,
     params: Arc<DiskannParams>,
     size: Arc<AtomicUsize>,
     msg: Message,
 ) where
     T: TableSearch + Send + Sync + 'static,
+    B: DiskannBackend,
 {
     match msg {
         Message::Modify(VsIndexModify::AddVector {
@@ -317,13 +359,13 @@ async fn process<T>(
             embedding,
             in_progress: _in_progress,
             ..
-        }) => add_vector(&partition, &size, primary_id, embedding).await,
+        }) => add_vector(backend.as_ref(), &partition, &size, primary_id, embedding).await,
 
         Message::Modify(VsIndexModify::RemoveVector {
             primary_id,
             in_progress: _in_progress,
             ..
-        }) => remove_vector(&partition, &params, &size, primary_id).await,
+        }) => remove_vector(backend.as_ref(), &partition, &params, &size, primary_id).await,
 
         Message::Search(VsIndexSearch::Ann {
             embedding,
@@ -332,7 +374,17 @@ async fn process<T>(
             ..
         }) => {
             if let Some(tx) = validate_dimensions(tx, &embedding, params.dim) {
-                _ = tx.send(ann(&partition, &table, &params, embedding, limit).await);
+                _ = tx.send(
+                    ann(
+                        backend.as_ref(),
+                        &partition,
+                        &table,
+                        &params,
+                        embedding,
+                        limit,
+                    )
+                    .await,
+                );
             }
         }
 
@@ -344,28 +396,14 @@ async fn process<T>(
     }
 }
 
-fn create_diskann_index(
-    params: &DiskannParams,
-    start_point: Option<&[f32]>,
-) -> anyhow::Result<DiskannIndex> {
-    let layer = Full::<f32>::new(usize::from(params.dim.0), params.metric);
-    let cfg = InmemProviderConfig::new(
-        usize::from(params.max_points),
-        params.config.max_degree().get(),
-    );
-    let start_points: Vec<&[f32]> = start_point.into_iter().collect();
-    let provider = InmemProvider::<_, PrimaryId>::new(layer, cfg, start_points)
-        .context("failed to create InmemProvider")?;
-    Ok(DiskANNIndex::new(params.config.clone(), provider, None))
-}
-
-struct Partition {
+struct Partition<B: DiskannBackend> {
     partition_id: PartitionId,
-    index: DiskannIndex,
+    index: DiskANNIndex<B::Provider>,
 }
 
-async fn add_vector(
-    partition: &Partition,
+async fn add_vector<B: DiskannBackend>(
+    backend: &B,
+    partition: &Partition<B>,
     size: &AtomicUsize,
     primary_id: PrimaryId,
     embedding: Vector,
@@ -373,8 +411,8 @@ async fn add_vector(
     if let Err(err) = partition
         .index
         .insert(
-            &InmemStrategy,
-            &InmemContext,
+            backend.strategy(),
+            backend.context(),
             &primary_id,
             embedding.as_slice(),
         )
@@ -386,8 +424,9 @@ async fn add_vector(
     }
 }
 
-async fn remove_vector(
-    partition: &Partition,
+async fn remove_vector<B: DiskannBackend>(
+    backend: &B,
+    partition: &Partition<B>,
     params: &DiskannParams,
     size: &AtomicUsize,
     primary_id: PrimaryId,
@@ -395,8 +434,8 @@ async fn remove_vector(
     if let Err(err) = partition
         .index
         .inplace_delete(
-            InmemStrategy,
-            &InmemContext,
+            backend.strategy().clone(),
+            backend.context(),
             &primary_id,
             params.config.pruned_degree().get(),
             InplaceDeleteMethod::OneHop,
@@ -409,8 +448,9 @@ async fn remove_vector(
     }
 }
 
-async fn search(
-    partition: &Partition,
+async fn search<B: DiskannBackend>(
+    backend: &B,
+    partition: &Partition<B>,
     params: &DiskannParams,
     embedding: &Vector,
     k: usize,
@@ -428,8 +468,8 @@ async fn search(
         .index
         .search(
             knn,
-            &InmemStrategy,
-            &InmemContext,
+            backend.strategy(),
+            backend.context(),
             embedding.as_slice(),
             &mut neighbors,
         )
@@ -446,8 +486,9 @@ async fn search(
     }))
 }
 
-async fn ann<T>(
-    partition: &Partition,
+async fn ann<T, B>(
+    backend: &B,
+    partition: &Partition<B>,
     table: &RwLock<T>,
     params: &DiskannParams,
     embedding: Vector,
@@ -455,8 +496,9 @@ async fn ann<T>(
 ) -> AnnR
 where
     T: TableSearch + Send + Sync + 'static,
+    B: DiskannBackend,
 {
-    let matches = search(partition, params, &embedding, limit.0.get())
+    let matches = search(backend, partition, params, &embedding, limit.0.get())
         .await
         .context("ann search failed")?;
 
@@ -666,7 +708,11 @@ mod tests {
             .map(|i| Vector::from(vec![i as f32, i as f32]))
             .collect();
 
-        let index = create_diskann_index(&params, Some(embeddings[0].as_slice())).unwrap();
+        let backend = inmem::InmemBackend::new();
+
+        let index = backend
+            .create_index(&params, embeddings[0].as_slice())
+            .unwrap();
         let partition = Partition {
             partition_id: PartitionId::from(0u64),
             index,
@@ -675,7 +721,14 @@ mod tests {
 
         // Try to insert more vectors than the cap allows.
         for (i, embedding) in embeddings.into_iter().enumerate() {
-            add_vector(&partition, &size, PrimaryId::from(i as u64), embedding).await;
+            add_vector(
+                &backend,
+                &partition,
+                &size,
+                PrimaryId::from(i as u64),
+                embedding,
+            )
+            .await;
         }
 
         assert_eq!(size.load(Ordering::Relaxed), max_points.get());


### PR DESCRIPTION
### Motivations
We want to keep both diskann inmem provider and a new hybrid provider that will keep vectors in ScyllaDB.
To avoid code duplication we can make the current diskann usage generic over a structs implementing a new `DiskannBackend` trait. This way we can keep the integration centralized and switch to different DataProviders easily, *if* they implement the correct Diskann traits.

Refs: VECTOR-831
Refs: VECTOR-830