### PR TITLE
vector-store: fix the stale rayon comment above main()

### DIFF
--- a/crates/vector-store/src/main.rs
+++ b/crates/vector-store/src/main.rs
@@ -25,7 +25,9 @@ fn dotenvy_to_std_var(key: &str) -> anyhow::Result<String> {
     Ok(dotenvy::var(key)?)
 }
 
-// Index creating/querying is CPU bound task, so that vector-store uses rayon ThreadPool for them.
+// Index creation and querying are CPU-bound tasks, so they are dispatched through the worker
+// actors. A blocking task is moved to a dedicated thread only when every worker actor is
+// already busy — so that the runtime does not get starved.
 // From the start there was no need (network traffic seems to be not so high) to support more than
 // one thread per network IO bound tasks.
 fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
The comment directly above `main()` told the reader that index creating and
querying run on a rayon `ThreadPool`:

```rust
// Index creating/querying is CPU bound task, so that vector-store uses rayon ThreadPool for them.
```

That has been false since May 2026.

## How it went stale

|  | Approach | Commit |
|---|---|---|
| 1 | USearch CPU tasks on Tokio threads | `adec0d9` |
| 2 | Dedicated rayon pool for blocking `add`/`remove` | `6935a83` (#294) |
| 3 | Worker actor with `spawn_blocking` | `27ddf4b` (2026-05-13, #423) |

The comment describes design 2; master runs design 3. **vector-store no longer
schedules any work on rayon** — no workspace crate depends on it. It does survive
in `Cargo.lock` transitively, via `tantivy` and `criterion`, so it is still linked
in and still doing work *inside tantivy*; it is simply not something this code
drives any more. (An earlier version of this description said "not a dependency of
the workspace", which was wrong — thanks @QuerthDP.)

## The replacement

Not "keeps it off the async runtime" either, which would have been a fresh
inaccuracy: `SpawnBlocking` runs the closure on the worker actor itself and only
escalates to a dedicated thread when `try_acquire_thread` finds every worker busy
and that thread free. The starvation guard is the exception, not the normal path —
thanks @Copilot for catching that. The comment now describes the scheduling.

It also **names no file and no symbol**, per @QuerthDP: a pointer to `worker.rs`
would be a second thing that can drift, which is exactly how the rayon sentence
got here.

The sentence about one thread being enough for network I/O is still accurate and
is kept verbatim.

Comment only, no behaviour change. `cargo fmt --check` clean.

Fixes: VECTOR-874
