### PR TITLE
vector-store: index status 500 description is not vector-specific

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -363,7 +363,7 @@
             }
           },
           "500": {
-            "description": "Error while checking index state or counting vectors. Possible causes: internal error, or issues accessing the database.",
+            "description": "Error while checking index state or counting indexed items. Possible causes: internal error, or issues accessing the database.",
             "content": {
               "application/json": {
                 "schema": {

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -394,7 +394,7 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
         ),
         (
             status = 500,
-            description = "Error while checking index state or counting vectors. Possible causes: internal error, or issues accessing the database.",
+            description = "Error while checking index state or counting indexed items. Possible causes: internal error, or issues accessing the database.",
             content_type = "application/json",
             body = ErrorMessage
         )


### PR DESCRIPTION
`GET /api/v1/indexes/{keyspace}/{index}/status` reports on **both** vector-search
and full-text-search indexes, but its 500 response still read:

> Error while checking index state or **counting vectors**.

There are no vectors to count for an FTS index, so the published API description
was wrong for half the cases the endpoint handles.

## Why only this line

The rest of the endpoint's documentation had already been made index-type
neutral — the operation description and the 200 response both say "items
currently indexed" — and the `IndexStatus` conversion (`httproutes.rs:355-363`)
never cared which kind of index it was. This one line was left behind.

The mismatch was raised during review of #470, where `get_index_status` began
counting FTS indexes, and deferred as out of scope at the time. Reasonable then;
worth closing now.

## The change

Two lines: the description in `httproutes.rs`, and the same string in
`api/openapi.json`.

`api/openapi.json` was **regenerated with `cargo openapi`**, not hand-edited —
the regenerated diff is exactly the one string, which is a useful check that the
committed spec was otherwise in sync with the source.

Wording only, no behaviour change. `cargo fmt --check` clean.

Fixes: VECTOR-875
