### PR TITLE
vector-store: return 400 for unparsable FTS queries

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -264,7 +264,7 @@
             }
           },
           "400": {
-            "description": "Bad request. Possible causes: malformed input, or missing required fields.",
+            "description": "Bad request. Possible causes: malformed input, unparsable query, or missing required fields.",
             "content": {
               "application/json": {
                 "schema": {

--- a/crates/vector-store/src/fts_index/mod.rs
+++ b/crates/vector-store/src/fts_index/mod.rs
@@ -12,6 +12,7 @@ use crate::worker::Worker;
 pub(crate) use actor::FtsIndex;
 pub(crate) use actor::FtsIndexExt;
 pub(crate) use factory::FtsIndexFactory;
+pub(crate) use tantivy::QueryError;
 use tantivy::TantivyIndexFactory;
 use tokio::sync::mpsc;
 

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -19,6 +19,7 @@ use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::fts_index::FtsIndex;
 use crate::fts_index::FtsIndexExt;
+use crate::fts_index::QueryError;
 use crate::indexes;
 use crate::indexes::Indexes;
 use crate::info::Info;
@@ -924,7 +925,7 @@ If TLS is enabled on the server, clients must connect using a HTTPS protocol.",
         ),
         (
             status = 400,
-            description = "Bad request. Possible causes: malformed input, or missing required fields.",
+            description = "Bad request. Possible causes: malformed input, unparsable query, or missing required fields.",
             content_type = "application/json",
             body = ErrorMessage
         ),
@@ -1018,7 +1019,12 @@ async fn post_index_bm25(
         Err(err) => {
             let msg = format!("index.bm25 request error: {err}");
             debug!("post_index_bm25: {msg}");
-            (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+            let status = if err.downcast_ref::<QueryError>().is_some() {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            (status, msg).into_response()
         }
         Ok((primary_keys, scores)) => {
             if primary_keys.len() != scores.len() {

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -309,6 +309,25 @@ async fn fts_bm25_search_not_found_returns_404() {
 }
 
 #[tokio::test]
+async fn fts_bm25_search_unparsable_query_returns_400() {
+    crate::enable_tracing();
+
+    let (client, keyspace_name, index_name, _db, _hold) =
+        setup_fts_and_wait([(vec![CqlValue::Int(1)], "a quiet fox", 10)], 1).await;
+
+    let response = client
+        .post_bm25(
+            &keyspace_name,
+            &index_name,
+            "fox AND".into(),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn fts_bm25_search_returns_503_and_node_bootstrapping_reason_when_index_is_building_during_node_bootstrapping()
  {
     crate::enable_tracing();


### PR DESCRIPTION
The BM25 endpoint mapped every search failure to 500, so a query the parser rejects came back as an internal error even though the query is the caller's input.

`QueryError` already distinguishes a bad query from an internal failure, but nothing consumed it. Re-export it from `fts_index` and have `post_index_bm25` downcast on it to pick the status code, mirroring how `post_index_ann` downcasts on `vs_index::Error`. Other failures keep returning 500.

Widen the documented 400 cause for the endpoint accordingly and regenerate the OpenAPI specification.

Fixes: [VECTOR-744](https://scylladb.atlassian.net/browse/VECTOR-744)

[VECTOR-744]: https://scylladb.atlassian.net/browse/VECTOR-744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ