### PR TITLE
vector-store: fix an index staying undiscovered until the next schema change

### DIFF
--- a/crates/vector-store/src/db_index_backend.rs
+++ b/crates/vector-store/src/db_index_backend.rs
@@ -11,6 +11,7 @@ use crate::KeyspaceIdentifier;
 use crate::KeyspaceName;
 use crate::TableIdentifier;
 use crate::TableName;
+use anyhow::bail;
 use futures::TryStreamExt;
 use regex::Regex;
 use scylla::client::session::Session;
@@ -145,21 +146,28 @@ async fn get_dimensions_from_column_type(
     re_get_index_target_type: &Regex,
     location: IndexLocation,
 ) -> anyhow::Result<Option<Dimensions>> {
+    let IndexLocation {
+        keyspace,
+        table,
+        index,
+    } = location;
     let column_type = session
         .execute_iter(
             st_get_index_target_type.clone(),
-            (location.keyspace, location.table, target_column.clone()),
+            (keyspace, table, target_column.clone()),
         )
         .await?
         .rows_stream::<(String,)>()?
         .try_next()
         .await?;
-    let dimensions = column_type
-        .and_then(|(typ,)| {
-            re_get_index_target_type
-                .captures(&typ)
-                .and_then(|captures| captures["dimensions"].parse::<usize>().ok())
-        })
+
+    // A missing row means the node that served the read has not applied the schema change yet.
+    let Some((column_type,)) = column_type else {
+        bail!("no type of the column {target_column} for the index {index}");
+    };
+    let dimensions = re_get_index_target_type
+        .captures(&column_type)
+        .and_then(|captures| captures["dimensions"].parse::<usize>().ok())
         .and_then(|dimensions| NonZeroUsize::new(dimensions).map(|dimensions| dimensions.into()));
     Ok(dimensions)
 }
@@ -173,21 +181,26 @@ async fn get_dimensions_from_index_options(
     st_get_index_options: &PreparedStatement,
     location: IndexLocation,
 ) -> anyhow::Result<Option<Dimensions>> {
+    let IndexLocation {
+        keyspace,
+        table,
+        index,
+    } = location;
     let index_options = session
         .execute_iter(
             st_get_index_options.clone(),
-            (location.keyspace, location.table, location.index),
+            (keyspace, table, index.clone()),
         )
         .await?
         .rows_stream::<(BTreeMap<String, String>,)>()?
         .try_next()
         .await?;
+    let Some((mut index_options,)) = index_options else {
+        bail!("no options for the index {index}");
+    };
     let dimensions = index_options
-        .and_then(|(mut options,)| {
-            options
-                .remove("dimensions")
-                .and_then(|s| s.parse::<usize>().ok())
-        })
+        .remove("dimensions")
+        .and_then(|s| s.parse::<usize>().ok())
         .and_then(|dimensions| NonZeroUsize::new(dimensions).map(|dimensions| dimensions.into()));
     Ok(dimensions)
 }

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -185,8 +185,10 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             .await
             .inspect_err(|err| warn!("unable to get index version: {err}"))?
         else {
-            debug!("get_indexes: no version for index {idx:?}");
-            continue;
+            // The index has just been listed, so its schema is still propagating.
+            // Fail the round to have the caller reset the schema version and retry
+            // this index on the next tick.
+            bail!("no options row for the index {idx:?}");
         };
 
         let kind = match idx.kind {
@@ -839,6 +841,48 @@ mod tests {
 
         // second index is invalid
         set_valid_indexes(vec![true, false, true]);
+        assert!(get_indexes(&db).await.is_err());
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn get_indexes_failed_while_index_options_row_is_missing() {
+        // A listed index without an options row has a schema that is still propagating.
+        // The whole round has to fail, so the caller resets the latched schema version
+        // and retries. Dropping just the index would leave it undiscovered until
+        // an unrelated schema change.
+        let mut mock_db = MockSimDb::new();
+
+        mock_db.expect_get_indexes().returning(move |tx| {
+            async move {
+                tx.send(Ok(vec![DbCustomIndex {
+                    keyspace: "ks".to_string().into(),
+                    index: "idx".to_string().into(),
+                    table: "tbl".to_string().into(),
+                    primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+                    partition_key_count: NonZeroUsize::new(1).unwrap(),
+                    target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+                    partitioning: DbIndexPartitioning::Global,
+                    filtering_columns: Arc::new([]),
+                    kind: DbIndexKind::VectorSearch,
+                }]))
+                .unwrap();
+            }
+            .boxed()
+        });
+
+        mock_db
+            .expect_get_index_version()
+            .returning(move |_, _, _, tx| {
+                async move {
+                    tx.send(Ok(None)).unwrap();
+                }
+                .boxed()
+            });
+
+        let db = db::tests::new(mock_db);
+
         assert!(get_indexes(&db).await.is_err());
     }
 


### PR DESCRIPTION
`monitor_indexes` reads the cluster schema version once per tick and skips the whole discovery round while that version has not changed. The version is stored as soon as it is read, so a round that completes successfully while dropping an index leaves nothing to retry: that index is never looked at again until an unrelated schema change bumps the version.

`get_indexes` had exactly that shape. `system_schema` is node-local, so the listing of all custom indexes and the per-index follow-up reads (the index options row, the target column type) can be served by different coordinators, and a coordinator whose schema is older than the listing simply returns no row. Both reads mapped a missing row to `Ok(None)`, which the caller read as "there is nothing to index here": the index was dropped from the discovered set and the round still returned `Ok`.

A node that loses this race answers `404 missing index` for an index its peers serve, and an index it had already built and was serving is removed from it, until any DDL happens in the cluster. Both skips logged at `debug!` only, so nothing reported it.

VECTOR-882 collects the occurrences seen in CI, the log evidence for each, and why this change fixes the individual reports linked to it.

Fixes: VECTOR-882
Fixes: VECTOR-680
Fixes: VECTOR-868
Fixes: VECTOR-881
