### PR TITLE
Don't route ANN requests across indexes with different options

### DIFF
--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -58,21 +58,24 @@ impl Ord for NeedsFiltering {
     }
 }
 
-/// Key for grouping indexes that can be routed between each other
-/// (i.e., indexes over the same keyspace, table, and target column).
+/// Key for grouping indexes that can be routed between each other: the same
+/// keyspace, table, and target column, with identical index options. Name,
+/// partitioning, filtering columns, and version may still differ.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct RoutingGroupKey {
     keyspace: KeyspaceName,
     table: TableName,
     columns: NonemptyArc<ColumnName>,
+    options: crate::IndexOptionsVs,
 }
 
-impl From<&IndexMetadata> for RoutingGroupKey {
-    fn from(metadata: &IndexMetadata) -> Self {
+impl RoutingGroupKey {
+    fn new(metadata: &IndexMetadata, options: &crate::IndexOptionsVs) -> Self {
         Self {
             keyspace: metadata.keyspace_name.clone(),
             table: metadata.table_name.clone(),
             columns: metadata.target_columns.clone(),
+            options: options.clone(),
         }
     }
 }
@@ -152,13 +155,13 @@ impl VsIndexEntry {
         db_index: mpsc::Sender<DbIndex>,
         metadata: IndexMetadata,
     ) -> anyhow::Result<Self> {
-        let routing_group = RoutingGroupKey::from(&metadata);
         let options = metadata
             .vs()
             .ok_or_else(|| {
                 anyhow::anyhow!("add_index_vs must be called with a vector-search index")
             })?
             .clone();
+        let routing_group = RoutingGroupKey::new(&metadata, &options);
         let filtering_columns = metadata
             .primary_key_columns
             .iter()
@@ -364,7 +367,8 @@ impl Indexes {
     ///
     /// 1. Returns `NotFound` if the requested index key does not exist.
     /// 2. Identifies all candidate indexes within the same routing group
-    ///    (i.e., sharing the same keyspace, table, and target column).
+    ///    (i.e., sharing the same keyspace, table, target column, and
+    ///    index options).
     /// 3. Filters out candidates whose `score_index` returns `None` (invalid).
     /// 4. Narrows down the remaining candidates to those that are actively serving.
     /// 5. Picks the candidate with the highest score, breaking ties by

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -5,6 +5,7 @@
 
 use crate::common::add_table;
 use crate::common::blocking_scan_fn;
+use crate::common::make_index_with_kind;
 use crate::common::make_vs_index;
 use crate::common::ordered_timeuuid;
 use crate::common::setup;
@@ -21,8 +22,11 @@ use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 use vector_store::DbIndexPartitioning;
+use vector_store::IndexKind;
 use vector_store::IndexMetadata;
+use vector_store::IndexOptionsVs;
 use vector_store::NonemptyArc;
+use vector_store::SpaceType;
 
 const ANN_LIMIT: usize = 5;
 
@@ -126,6 +130,51 @@ async fn assert_ann_served_by(
         1,
         "expected ANN request to be served by {}",
         expected.index_name,
+    );
+    response
+}
+
+/// Like `assert_ann_served_by`, but also asserts the request was not served
+/// by `not_expected`.
+async fn assert_ann_served_by_and_not(
+    client: &HttpClient,
+    expected: &IndexMetadata,
+    not_expected: &IndexMetadata,
+    request: impl std::future::Future<Output = reqwest::Response>,
+) -> reqwest::Response {
+    client
+        .internals_clear_counters()
+        .await
+        .expect("internals counters must be cleared");
+    let expected_counter = format!(
+        "ann-served-request--{}--{}",
+        expected.keyspace_name, expected.index_name
+    );
+    let not_expected_counter = format!(
+        "ann-served-request--{}--{}",
+        not_expected.keyspace_name, not_expected.index_name
+    );
+    for counter in [&expected_counter, &not_expected_counter] {
+        client
+            .internals_start_counter(counter.clone())
+            .await
+            .expect("internals served counter must be registered");
+    }
+
+    let response = request.await;
+
+    let counters = client.internals_counters().await.unwrap();
+    assert_eq!(
+        counters.get(&expected_counter).copied().unwrap_or(0),
+        1,
+        "expected ANN request to be served by {}",
+        expected.index_name,
+    );
+    assert_eq!(
+        counters.get(&not_expected_counter).copied().unwrap_or(0),
+        0,
+        "expected ANN request not to be served by {}",
+        not_expected.index_name,
     );
     response
 }
@@ -668,5 +717,86 @@ async fn ann_routes_to_global_index_without_pk_restrictions() {
 
     let response =
         assert_ann_served_by(&client, &global_index, post_ann(&client, &local_index)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+fn vs_options_with_space_type(space_type: SpaceType) -> IndexOptionsVs {
+    IndexOptionsVs {
+        dimensions: NonZeroUsize::new(3).unwrap().into(),
+        connectivity: Default::default(),
+        expansion_add: Default::default(),
+        expansion_search: Default::default(),
+        space_type,
+        quantization: Default::default(),
+    }
+}
+
+/// Regression test for indexes on the same column being routed to each
+/// other despite disagreeing on their distance function (or any other part
+/// of their definition). Two indexes on the same column, one COSINE and one
+/// EUCLIDEAN, are both fully serving; the EUCLIDEAN one is the newer of the
+/// two, so before the fix it would win the "prefer the newest index in the
+/// routing group" tie-break even for a query addressed to the COSINE index,
+/// silently answering it under the wrong distance function.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_does_not_route_between_indexes_with_different_distance_function() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    let cosine = make_index_with_kind(
+        "cosine",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(1),
+        IndexKind::Vs(vs_options_with_space_type(SpaceType::Cosine)),
+    );
+    db.add_index(
+        cosine.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &cosine).await;
+
+    let euclidean = make_index_with_kind(
+        "euclidean",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(2),
+        IndexKind::Vs(vs_options_with_space_type(SpaceType::Euclidean)),
+    );
+    db.add_index(
+        euclidean.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+    wait_for_serving(&client, &euclidean).await;
+
+    let response =
+        assert_ann_served_by_and_not(&client, &cosine, &euclidean, post_ann(&client, &cosine))
+            .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response =
+        assert_ann_served_by_and_not(&client, &euclidean, &cosine, post_ann(&client, &euclidean))
+            .await;
     assert_eq!(response.status(), StatusCode::OK);
 }


### PR DESCRIPTION
If a table has two vector indexes on the same column but with different DistanceFunction (e.g., one COSINE and one EUCLIDEAN), an ANN query addressed to one of them could silently be served by the other, using the wrong distance metric and returning a wrong nearest-neighbor result with no error.
    
Commit 5326ed26bc6b9d66dbe0b1892034cd8c5eb00f1c ("vector-store: route ANN requests to best matching serving index") deliberately grouped all indexes over the same keyspace/table/target column into one "routing group" and, for a query addressed to any index in the group, routes it to whichever member of the group is the best-scoring and newest, not necessarily the one actually named. This was intentional: it lets an index be rebuilt under a new name and take over serving without the caller having to know the new name, and it lets a more specific local index be preferred over a global one. Our own test suite (tests/integration/routing.rs) confirms this is deliberate: it asserts that a query addressed to an older, fully-serving index gets routed to a newer, fully-serving one on the same column, purely because the newer one is presumed to be the intended upgrade.    

That grouping was too broad: it only considered keyspace, table, and target column, so any two indexes on the same column ended up interchangeable regardless of what they actually compute. Two indexes that disagree on any part of their definition are not safe substitutes for one another - obviously not distance function or dimensionality, but not even the ANN tuning parameters (connectivity, expansion_add, expansion_search, quantization), since those govern an approximate search structure and can themselves make two indexes return a different top-K for the same query.
    
Fix this by requiring full equality of IndexOptionsVs (not just a hand-picked subset of its fields) for two indexes to be considered part of the same routing group. Indexes may still differ in name, partitioning, filtering columns, or version and be routed between each other - that's the point of the feature - but only when their definition is otherwise identical.
    
The second patch adds a regression test that reproduces this bug - and checks its fix.

Fixes: VECTOR-880