### PR TITLE
vector-store: add "routing" option to disable index-routing per-request

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -789,6 +789,10 @@
           "limit": {
             "$ref": "#/components/schemas/Limit"
           },
+          "routing": {
+            "type": "boolean",
+            "description": "By default, the query may be routed to a different, better-matching index on the same column. Set to `false` to force the query to be served by exactly the index named in the URL."
+          },
           "vector": {
             "$ref": "#/components/schemas/Vector"
           }

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -371,6 +371,13 @@ pub struct PostIndexAnnRequest {
     pub filter: Option<PostIndexAnnFilter>,
     #[serde(default)]
     pub limit: Limit,
+    /// By default, the query may be routed to a different, better-matching index on the same column. Set to `false` to force the query to be served by exactly the index named in the URL.
+    #[serde(default = "default_routing")]
+    pub routing: bool,
+}
+
+fn default_routing() -> bool {
+    true
 }
 
 #[derive(serde::Deserialize, serde::Serialize, utoipa::ToSchema)]

--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -92,6 +92,7 @@ impl HttpClient {
             vector,
             filter,
             limit,
+            routing: true,
         };
         self.post_ann_data(keyspace_name, index_name, &request)
             .await

--- a/crates/testclient/src/lib.rs
+++ b/crates/testclient/src/lib.rs
@@ -59,6 +59,7 @@ impl TestClient {
                 vector,
                 filter,
                 limit,
+                routing: true,
             })
             .await
     }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -734,12 +734,12 @@ async fn post_index_ann(
         let index_key = IndexKey::new(&keyspace, &index_name);
         let (equality_cols, range_cols) = restriction_columns(&request.filter);
         let allow_filtering = request.filter.as_ref().is_some_and(|f| f.allow_filtering);
-        let best_index_state =
-            state
-                .indexes
-                .read()
-                .unwrap()
-                .best_index(&index_key, &equality_cols, &range_cols);
+        let best_index_state = state.indexes.read().unwrap().best_index(
+            &index_key,
+            &equality_cols,
+            &range_cols,
+            request.routing,
+        );
         let (routed_key, index, primary_key_columns, filtering_columns, table_columns) =
             match best_index_state {
             indexes::BestIndexState::Serving {

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -359,8 +359,8 @@ impl Indexes {
 
     /// Determines the index to route a query to, given a requested `IndexKey`.
     ///
-    /// To ensure queries are routed to the most up-to-date and best-matching index,
-    /// this function applies the following routing logic:
+    /// When `routing` is `true`, ensures queries are routed to the most
+    /// up-to-date and best-matching index by applying the following logic:
     ///
     /// 1. Returns `NotFound` if the requested index key does not exist.
     /// 2. Identifies all candidate indexes within the same routing group
@@ -370,19 +370,27 @@ impl Indexes {
     /// 5. Picks the candidate with the highest score, breaking ties by
     ///    the newest `IndexVersion`.
     /// 6. Returns `NotServing` if no candidate meets the criteria.
+    ///
+    /// When `routing` is `false`, the only candidate considered is the
+    /// requested index itself - the query is served by exactly the named
+    /// index, or not at all.
     pub(crate) fn best_index(
         &self,
         key: &IndexKey,
         equality_columns: &[ColumnName],
         range_columns: &[ColumnName],
+        routing: bool,
     ) -> BestIndexState {
         let Some(requested_entry) = self.vs_entries.get(key) else {
             return BestIndexState::NotFound;
         };
-        let candidates = self
-            .vs_routing
-            .get(&requested_entry.data.routing_group)
-            .expect("routing_map must contain group for every index in indexes");
+        let candidates: &[IndexKey] = if routing {
+            self.vs_routing
+                .get(&requested_entry.data.routing_group)
+                .expect("routing_map must contain group for every index in indexes")
+        } else {
+            std::slice::from_ref(key)
+        };
 
         let routed_key = candidates
             .iter()

--- a/crates/vector-store/tests/integration/https.rs
+++ b/crates/vector-store/tests/integration/https.rs
@@ -99,6 +99,7 @@ async fn test_https_server_responds() {
             vector: vec![1.0].into(),
             filter: None,
             limit: NonZeroUsize::new(1).unwrap().into(),
+            routing: true,
         })
         .send()
         .await
@@ -111,6 +112,7 @@ async fn test_https_server_responds() {
             vector: vec![1.0].into(),
             filter: None,
             limit: NonZeroUsize::new(1).unwrap().into(),
+            routing: true,
         })
         .send()
         .await

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -12,6 +12,7 @@ use crate::common::single_row_scan;
 use crate::wait_for;
 use httpapi::IndexStatus;
 use httpapi::PostIndexAnnFilter;
+use httpapi::PostIndexAnnRequest;
 use httpapi::PostIndexAnnRestriction;
 use httpclient::HttpClient;
 use reqwest::StatusCode;
@@ -66,6 +67,46 @@ async fn post_ann(client: &HttpClient, index: &IndexMetadata) -> reqwest::Respon
             vec![0.0_f32, 0.0, 0.0].into(),
             None,
             NonZeroUsize::new(ANN_LIMIT).unwrap().into(),
+        )
+        .await
+}
+
+async fn post_ann_without_routing(client: &HttpClient, index: &IndexMetadata) -> reqwest::Response {
+    let keyspace_name = index.keyspace_name.as_ref().into();
+    let index_name = index.index_name.as_ref().into();
+    client
+        .post_ann_data(
+            &keyspace_name,
+            &index_name,
+            &PostIndexAnnRequest {
+                vector: vec![0.0_f32, 0.0, 0.0].into(),
+                filter: None,
+                limit: NonZeroUsize::new(ANN_LIMIT).unwrap().into(),
+                routing: false,
+            },
+        )
+        .await
+}
+
+/// Posts an ANN request whose JSON body has no "routing" key at all, as an
+/// older client that predates the "routing" field would send. This must
+/// still be accepted and must still preserve the default (routing-enabled)
+/// behavior, exercising the `#[serde(default = "default_routing")]` path
+/// rather than relying on `PostIndexAnnRequest`'s Rust-level default.
+async fn post_ann_without_routing_field(
+    client: &HttpClient,
+    index: &IndexMetadata,
+) -> reqwest::Response {
+    let keyspace_name = index.keyspace_name.as_ref().into();
+    let index_name = index.index_name.as_ref().into();
+    client
+        .post_ann_data(
+            &keyspace_name,
+            &index_name,
+            &serde_json::json!({
+                "vector": [0.0_f32, 0.0, 0.0],
+                "limit": ANN_LIMIT,
+            }),
         )
         .await
 }
@@ -180,13 +221,12 @@ async fn ann_routes_to_serving_index_while_replacement_is_bootstrapping() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-#[rstest]
-#[timeout(Duration::from_secs(10))]
-#[tokio::test]
-#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
-async fn ann_routes_to_newest_serving_index() {
-    crate::enable_tracing();
-    let (client, db, _keep) = setup().await;
+/// Sets up a table with two globally-partitioned, fully-serving indexes on
+/// the same column, "oldest" and "replacement" (the newer of the two) -
+/// the shared fixture for the "which of two equally-matching indexes
+/// serves the query" tests below.
+async fn setup_oldest_and_replacement() -> (HttpClient, impl Sized, IndexMetadata, IndexMetadata) {
+    let (client, db, keep) = setup().await;
 
     add_table(
         &db,
@@ -230,7 +270,56 @@ async fn ann_routes_to_newest_serving_index() {
     .unwrap();
     wait_for_serving(&client, &replacement).await;
 
+    (client, (db, keep), oldest, replacement)
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_routes_to_newest_serving_index() {
+    crate::enable_tracing();
+    let (client, _keep, oldest, replacement) = setup_oldest_and_replacement().await;
+
     let response = assert_ann_served_by(&client, &replacement, post_ann(&client, &oldest)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_with_routing_disabled_is_not_rerouted() {
+    crate::enable_tracing();
+    let (client, _keep, oldest, _replacement) = setup_oldest_and_replacement().await;
+
+    // With routing enabled (the default, exercised by
+    // ann_routes_to_newest_serving_index above), a query addressed to
+    // "oldest" would be routed to "replacement". With routing disabled, it
+    // must stay pinned to the index it was addressed to.
+    let response =
+        assert_ann_served_by(&client, &oldest, post_ann_without_routing(&client, &oldest)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+#[cfg_attr(not(feature = "slow-test-hooks"), ignore = "requires slow-test-hooks")]
+async fn ann_with_routing_field_omitted_routes_to_newest_serving_index() {
+    crate::enable_tracing();
+    let (client, _keep, oldest, replacement) = setup_oldest_and_replacement().await;
+
+    // A request whose body never mentions "routing" at all - as sent by a
+    // client written before this field existed - must still get the
+    // default (routing-enabled) behavior via serde's field default, not
+    // just via PostIndexAnnRequest's Rust-level Default.
+    let response = assert_ann_served_by(
+        &client,
+        &replacement,
+        post_ann_without_routing_field(&client, &oldest),
+    )
+    .await;
     assert_eq!(response.status(), StatusCode::OK);
 }
 


### PR DESCRIPTION
The vector-search ANN endpoint let a query for one index be silently served by a different, "better" index on the same table and column - the newest fully-serving one, or one requiring less server-side filtering. This routing exists for CQL: CQL can create a second index over the same column (e.g. to swap in new HNSW parameters, or even a different distance function) without any way for a query to say which of the two it wants, so the vector store instead always picks the best match (e.g., the last-built index) on the fly.

Alternator has no such ambiguity: DynamoDB's API lets the caller name the exact index to query (IndexName), and different indexes on the same column with different distance functions are an intentional, documented feature, not a fallback. Silently overriding that explicit choice - as could happen here - breaks the DynamoDB semantics: a query addressed to a COSINE index could be served by a EUCLIDEAN one instead, returning a "top-K" that is simply wrong for the query that was asked, without any error.

Rather than changing what makes indexes eligible for routing (which was attempted and rejected during review), this patch adds an optional "routing" flag (default true) to the ANN request bodies. Alternator will set it to false so its queries are always served by exactly the index they name, while CQL keeps relying on the default routing behavior unchanged.

Add a test to the vector-search routing test suite, right after the one confirming an index is by default routed to a newer replacement, that same setup now queried with routing disabled - showing the older index keeps serving its own queries instead of being routed away.

Fixes: VECTOR-880