### PR TITLE
vector-store: honor the analyzer and positions options of FTS indexes

### DIFF
--- a/crates/validator/src/fts.rs
+++ b/crates/validator/src/fts.rs
@@ -6,7 +6,9 @@
 use crate::TestActors;
 use crate::common::*;
 use async_backtrace::framed;
+use httpapi::FulltextIndexOptions;
 use httpapi::IndexInfo;
+use httpapi::IndexOptions;
 use httpapi::KeyspaceName;
 use httpclient::HttpClient;
 use scylla::client::session::Session;
@@ -111,6 +113,17 @@ impl Fixture {
     #[framed]
     async fn create_fts_index(&self) {
         let index = create_fts_index(&self.session, &self.clients, &self.table).await;
+        self.wait_for_index_on_all_nodes(index).await;
+    }
+
+    #[framed]
+    async fn create_fts_index_with_options(&self, options: &[(&str, &str)]) {
+        let index =
+            create_fts_index_with_options(&self.session, &self.clients, &self.table, options).await;
+        self.wait_for_index_on_all_nodes(index).await;
+    }
+
+    async fn wait_for_index_on_all_nodes(&self, index: IndexInfo) {
         for client in &self.clients {
             wait_for_index(client, &index).await;
         }
@@ -173,8 +186,19 @@ async fn create_fts_index(
     clients: &[HttpClient],
     table: &TableName,
 ) -> IndexInfo {
+    create_fts_index_with_options(session, clients, table, &[]).await
+}
+
+async fn create_fts_index_with_options(
+    session: &Session,
+    clients: &[HttpClient],
+    table: &TableName,
+    options: &[(&str, &str)],
+) -> IndexInfo {
     create_index(
-        CreateIndexQuery::new(session, clients, table, "content").index_type("fulltext_index"),
+        CreateIndexQuery::new(session, clients, table, "content")
+            .index_type("fulltext_index")
+            .options(options.iter().copied()),
     )
     .await
 }
@@ -738,6 +762,124 @@ async fn fts_large_document_set(fixture: Arc<Fixture>) {
         common_hits_rows_num, MAX_SEARCH_LIMIT,
         "Expected common-term results capped at {MAX_SEARCH_LIMIT}, got {common_hits_rows_num}"
     );
+
+    info!("finished");
+}
+
+#[e2etest::test(group = fts)]
+async fn fts_index_options_are_reported(fixture: Arc<Fixture>) {
+    info!("started");
+
+    fixture
+        .create_fts_index_with_options(&[("analyzer", "german"), ("positions", "false")])
+        .await;
+
+    let index = fixture.index();
+    for client in &fixture.clients {
+        let info = client
+            .index_info(&fixture.keyspace, &index.index)
+            .await
+            .expect("failed to get index info");
+        assert_eq!(
+            info.options,
+            IndexOptions::Fulltext(FulltextIndexOptions {
+                analyzer: "german".to_string(),
+                positions: false,
+            }),
+            "reported index options do not match the ones it was created with"
+        );
+    }
+
+    info!("finished");
+}
+
+#[e2etest::test(group = fts)]
+async fn fts_english_analyzer_stems_terms(fixture: Arc<Fixture>) {
+    info!("started");
+
+    fixture
+        .insert_documents([
+            (1, "the runners are running quickly"),
+            (2, "a turtle walks through the garden"),
+        ])
+        .await;
+    fixture
+        .create_fts_index_with_options(&[("analyzer", "english")])
+        .await;
+
+    // Both the document and the query are stemmed, so "run" matches "running"
+    // but not the semantically matching "walks" document.
+    let pks = fixture.bm25_search_pks("run").await;
+    assert_eq!(pks, vec![1], "expected only pk 1 matching 'run'");
+
+    info!("finished");
+}
+
+#[e2etest::test(group = fts)]
+async fn fts_standard_analyzer_does_not_stem_terms(fixture: Arc<Fixture>) {
+    info!("started");
+
+    fixture
+        .insert_documents([
+            (1, "the runners are running quickly"),
+            (2, "a turtle walks through the garden"),
+        ])
+        .await;
+    fixture
+        .create_fts_index_with_options(&[("analyzer", "standard")])
+        .await;
+
+    // The standard analyzer does not stem, so only the exact term matches.
+    assert!(
+        fixture.bm25_search_pks("run").await.is_empty(),
+        "the standard analyzer should not match 'run' against 'running'"
+    );
+
+    info!("finished");
+}
+
+#[e2etest::test(group = fts)]
+async fn fts_whitespace_analyzer_keeps_case(fixture: Arc<Fixture>) {
+    info!("started");
+
+    fixture.insert_documents([(1, "Quick brown Fox")]).await;
+    fixture
+        .create_fts_index_with_options(&[("analyzer", "whitespace")])
+        .await;
+
+    // The whitespace analyzer neither lowercases nor splits on punctuation.
+    assert_eq!(
+        fixture.bm25_search_pks("Quick").await,
+        vec![1],
+        "the whitespace analyzer should match the exact term 'Quick'"
+    );
+    assert!(
+        fixture.bm25_search_pks("quick").await.is_empty(),
+        "the whitespace analyzer should keep the letter case of the indexed terms"
+    );
+
+    info!("finished");
+}
+
+#[e2etest::test(group = fts)]
+async fn fts_index_with_unsupported_options_returns_error(fixture: Arc<Fixture>) {
+    info!("started");
+
+    for (option, value) in [("analyzer", "klingon"), ("positions", "sometimes")] {
+        fixture
+            .session
+            .query_unpaged(
+                format!(
+                    "CREATE CUSTOM INDEX {} ON {}(content) USING 'fulltext_index' \
+                     WITH OPTIONS = {{'{option}': '{value}'}}",
+                    unique_index_name(),
+                    fixture.table
+                ),
+                (),
+            )
+            .await
+            .expect_err(&format!("'{option}': '{value}' should be rejected"));
+    }
 
     info!("finished");
 }

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -54,6 +54,7 @@ use scylla::value::CqlTimeuuid;
 use secrecy::ExposeSecret;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tap::Pipe;
@@ -454,6 +455,18 @@ async fn process(
             .send(statements.is_valid_index(metadata).await)
             .unwrap_or_else(|_| trace!("process: Db::IsValidIndex: unable to send response")),
     }
+}
+
+/// Parses a single value of an index `options` map, falling back to its default
+/// when the option is absent or carries an unsupported value.
+fn parse_index_option<T: FromStr + Default>(options: &BTreeMap<String, String>, name: &str) -> T {
+    let Some(value) = options.get(name) else {
+        return T::default();
+    };
+    value.parse().unwrap_or_else(|_| {
+        warn!("unsupported value '{value}' of the index option '{name}', using the default");
+        T::default()
+    })
 }
 
 fn reconnect_reasons(old_config: &Config, new_config: &Config) -> Vec<&'static str> {
@@ -917,30 +930,15 @@ impl Statements {
             .try_next()
             .await?
             .map(|(options,)| options);
-        Ok(options.map(|mut options| {
-            let connectivity = options
-                .remove("maximum_node_connections")
-                .and_then(|s| s.parse::<usize>().ok())
-                .map(Connectivity)
-                .unwrap_or_default();
-            let expansion_add = options
-                .remove("construction_beam_width")
-                .and_then(|s| s.parse::<usize>().ok())
-                .map(ExpansionAdd)
-                .unwrap_or_default();
-            let expansion_search = options
-                .remove("search_beam_width")
-                .and_then(|s| s.parse::<usize>().ok())
-                .map(ExpansionSearch)
-                .unwrap_or_default();
-            let space_type = options
-                .remove("similarity_function")
-                .and_then(|s| s.parse().ok())
-                .unwrap_or_default();
-            let quantization = options
-                .remove("quantization")
-                .and_then(|s| s.parse::<Quantization>().ok())
-                .unwrap_or_default();
+        Ok(options.map(|options| {
+            let connectivity: Connectivity =
+                parse_index_option(&options, "maximum_node_connections");
+            let expansion_add: ExpansionAdd =
+                parse_index_option(&options, "construction_beam_width");
+            let expansion_search: ExpansionSearch =
+                parse_index_option(&options, "search_beam_width");
+            let space_type: SpaceType = parse_index_option(&options, "similarity_function");
+            let quantization: Quantization = parse_index_option(&options, "quantization");
             (
                 connectivity,
                 expansion_add,
@@ -1268,6 +1266,34 @@ pub(crate) mod tests {
         );
 
         tx
+    }
+
+    #[test]
+    fn index_option_is_parsed_when_supported() {
+        let options = BTreeMap::from([("maximum_node_connections".to_string(), "48".to_string())]);
+
+        assert_eq!(
+            parse_index_option::<Connectivity>(&options, "maximum_node_connections"),
+            Connectivity::from(48)
+        );
+    }
+
+    #[test]
+    fn index_option_falls_back_to_default_when_unsupported() {
+        let options = BTreeMap::from([("search_beam_width".to_string(), "many".to_string())]);
+
+        assert_eq!(
+            parse_index_option::<ExpansionSearch>(&options, "search_beam_width"),
+            ExpansionSearch::default()
+        );
+    }
+
+    #[test]
+    fn index_option_falls_back_to_default_when_missing() {
+        assert_eq!(
+            parse_index_option::<Connectivity>(&BTreeMap::new(), "maximum_node_connections"),
+            Connectivity::default()
+        );
     }
 
     #[test]

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::Analyzer;
 use crate::AsyncInProgress;
 use crate::ColumnName;
 use crate::Config;
@@ -17,11 +18,13 @@ use crate::ExpansionAdd;
 use crate::ExpansionSearch;
 use crate::IndexMetadata;
 use crate::IndexName;
+use crate::IndexOptionsFts;
 use crate::IndexVersion;
 use crate::KeyspaceName;
 use crate::Metrics;
 use crate::NonemptyArc;
 use crate::NonemptyIteratorExt;
+use crate::Positions;
 use crate::Quantization;
 use crate::SpaceType;
 use crate::TableName;
@@ -89,6 +92,7 @@ type GetVsIndexParamsR = anyhow::Result<
         Quantization,
     )>,
 >;
+type GetFtsIndexParamsR = anyhow::Result<Option<IndexOptionsFts>>;
 type IsValidIndexR = bool;
 
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(1);
@@ -127,6 +131,13 @@ pub enum Db {
         table: TableName,
         index: IndexName,
         tx: oneshot::Sender<GetVsIndexParamsR>,
+    },
+
+    GetFtsIndexParams {
+        keyspace: KeyspaceName,
+        table: TableName,
+        index: IndexName,
+        tx: oneshot::Sender<GetFtsIndexParamsR>,
     },
 
     // Schema changes are concurrent processes without an atomic view from the client/driver side.
@@ -170,6 +181,13 @@ pub(crate) trait DbExt {
         table: TableName,
         index: IndexName,
     ) -> GetVsIndexParamsR;
+
+    async fn get_fts_index_params(
+        &self,
+        keyspace: KeyspaceName,
+        table: TableName,
+        index: IndexName,
+    ) -> GetFtsIndexParamsR;
 
     async fn is_valid_index(&self, metadata: IndexMetadata) -> IsValidIndexR;
 }
@@ -237,6 +255,23 @@ impl DbExt for mpsc::Sender<Db> {
     ) -> GetVsIndexParamsR {
         let (tx, rx) = oneshot::channel();
         self.send(Db::GetVsIndexParams {
+            keyspace,
+            table,
+            index,
+            tx,
+        })
+        .await?;
+        rx.await?
+    }
+
+    async fn get_fts_index_params(
+        &self,
+        keyspace: KeyspaceName,
+        table: TableName,
+        index: IndexName,
+    ) -> GetFtsIndexParamsR {
+        let (tx, rx) = oneshot::channel();
+        self.send(Db::GetFtsIndexParams {
             keyspace,
             table,
             index,
@@ -387,6 +422,9 @@ fn respond_with_error(msg: Db, error: anyhow::Error) {
         Db::GetVsIndexParams { tx, .. } => {
             let _ = tx.send(Err(error));
         }
+        Db::GetFtsIndexParams { tx, .. } => {
+            let _ = tx.send(Err(error));
+        }
         Db::IsValidIndex { tx, .. } => {
             let _ = tx.send(false);
         }
@@ -450,6 +488,19 @@ async fn process(
         } => tx
             .send(statements.get_vs_index_params(keyspace, table, index).await)
             .unwrap_or_else(|_| trace!("process: Db::GetVsIndexParams: unable to send response")),
+
+        Db::GetFtsIndexParams {
+            keyspace,
+            table,
+            index,
+            tx,
+        } => tx
+            .send(
+                statements
+                    .get_fts_index_params(keyspace, table, index)
+                    .await,
+            )
+            .unwrap_or_else(|_| trace!("process: Db::GetFtsIndexParams: unable to send response")),
 
         Db::IsValidIndex { metadata, tx } => tx
             .send(statements.is_valid_index(metadata).await)
@@ -912,24 +963,33 @@ impl Statements {
         }))
     }
 
+    async fn get_index_options(
+        &self,
+        keyspace: KeyspaceName,
+        table: TableName,
+        index: IndexName,
+    ) -> anyhow::Result<Option<BTreeMap<String, String>>> {
+        let session = self
+            .session_rx
+            .borrow()
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("No active session"))?;
+        Ok(session
+            .execute_iter(self.st_get_index_options.clone(), (keyspace, table, index))
+            .await?
+            .rows_stream::<(BTreeMap<String, String>,)>()?
+            .try_next()
+            .await?
+            .map(|(options,)| options))
+    }
+
     async fn get_vs_index_params(
         &self,
         keyspace: KeyspaceName,
         table: TableName,
         index: IndexName,
     ) -> GetVsIndexParamsR {
-        let session = self
-            .session_rx
-            .borrow()
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("No active session"))?;
-        let options = session
-            .execute_iter(self.st_get_index_options.clone(), (keyspace, table, index))
-            .await?
-            .rows_stream::<(BTreeMap<String, String>,)>()?
-            .try_next()
-            .await?
-            .map(|(options,)| options);
+        let options = self.get_index_options(keyspace, table, index).await?;
         Ok(options.map(|options| {
             let connectivity: Connectivity =
                 parse_index_option(&options, "maximum_node_connections");
@@ -946,6 +1006,23 @@ impl Statements {
                 space_type,
                 quantization,
             )
+        }))
+    }
+
+    async fn get_fts_index_params(
+        &self,
+        keyspace: KeyspaceName,
+        table: TableName,
+        index: IndexName,
+    ) -> GetFtsIndexParamsR {
+        let options = self.get_index_options(keyspace, table, index).await?;
+        Ok(options.map(|options| {
+            let analyzer: Analyzer = parse_index_option(&options, "analyzer");
+            let positions: Positions = parse_index_option(&options, "positions");
+            IndexOptionsFts {
+                analyzer,
+                positions,
+            }
         }))
     }
 
@@ -1205,6 +1282,14 @@ pub(crate) mod tests {
             tx: oneshot::Sender<GetVsIndexParamsR>,
         ) -> impl Future<Output = ()> + Send + 'static;
 
+        fn get_fts_index_params(
+            &self,
+            keyspace: KeyspaceName,
+            table: TableName,
+            index: IndexName,
+            tx: oneshot::Sender<GetFtsIndexParamsR>,
+        ) -> impl Future<Output = ()> + Send + 'static;
+
         fn is_valid_index(
             &self,
             metadata: IndexMetadata,
@@ -1255,6 +1340,13 @@ pub(crate) mod tests {
                             index,
                             tx,
                         } => sim.get_vs_index_params(keyspace, table, index, tx).await,
+
+                        Db::GetFtsIndexParams {
+                            keyspace,
+                            table,
+                            index,
+                            tx,
+                        } => sim.get_fts_index_params(keyspace, table, index, tx).await,
 
                         Db::IsValidIndex { metadata, tx } => sim.is_valid_index(metadata, tx).await,
                     }

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -79,7 +79,7 @@ pub(crate) type LatestSchemaVersionR = anyhow::Result<Option<CqlTimeuuid>>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;
 type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;
 type GetIndexTargetTypeR = anyhow::Result<Option<Dimensions>>;
-type GetIndexParamsR = anyhow::Result<
+type GetVsIndexParamsR = anyhow::Result<
     Option<(
         Connectivity,
         ExpansionAdd,
@@ -121,11 +121,11 @@ pub enum Db {
         tx: oneshot::Sender<GetIndexTargetTypeR>,
     },
 
-    GetIndexParams {
+    GetVsIndexParams {
         keyspace: KeyspaceName,
         table: TableName,
         index: IndexName,
-        tx: oneshot::Sender<GetIndexParamsR>,
+        tx: oneshot::Sender<GetVsIndexParamsR>,
     },
 
     // Schema changes are concurrent processes without an atomic view from the client/driver side.
@@ -163,12 +163,12 @@ pub(crate) trait DbExt {
         index: IndexName,
     ) -> GetIndexTargetTypeR;
 
-    async fn get_index_params(
+    async fn get_vs_index_params(
         &self,
         keyspace: KeyspaceName,
         table: TableName,
         index: IndexName,
-    ) -> GetIndexParamsR;
+    ) -> GetVsIndexParamsR;
 
     async fn is_valid_index(&self, metadata: IndexMetadata) -> IsValidIndexR;
 }
@@ -228,14 +228,14 @@ impl DbExt for mpsc::Sender<Db> {
         rx.await?
     }
 
-    async fn get_index_params(
+    async fn get_vs_index_params(
         &self,
         keyspace: KeyspaceName,
         table: TableName,
         index: IndexName,
-    ) -> GetIndexParamsR {
+    ) -> GetVsIndexParamsR {
         let (tx, rx) = oneshot::channel();
-        self.send(Db::GetIndexParams {
+        self.send(Db::GetVsIndexParams {
             keyspace,
             table,
             index,
@@ -383,7 +383,7 @@ fn respond_with_error(msg: Db, error: anyhow::Error) {
         Db::GetIndexTargetType { tx, .. } => {
             let _ = tx.send(Err(error));
         }
-        Db::GetIndexParams { tx, .. } => {
+        Db::GetVsIndexParams { tx, .. } => {
             let _ = tx.send(Err(error));
         }
         Db::IsValidIndex { tx, .. } => {
@@ -441,14 +441,14 @@ async fn process(
             )
             .unwrap_or_else(|_| trace!("process: Db::GetIndexTargetType: unable to send response")),
 
-        Db::GetIndexParams {
+        Db::GetVsIndexParams {
             keyspace,
             table,
             index,
             tx,
         } => tx
-            .send(statements.get_index_params(keyspace, table, index).await)
-            .unwrap_or_else(|_| trace!("process: Db::GetIndexParams: unable to send response")),
+            .send(statements.get_vs_index_params(keyspace, table, index).await)
+            .unwrap_or_else(|_| trace!("process: Db::GetVsIndexParams: unable to send response")),
 
         Db::IsValidIndex { metadata, tx } => tx
             .send(statements.is_valid_index(metadata).await)
@@ -899,12 +899,12 @@ impl Statements {
         }))
     }
 
-    async fn get_index_params(
+    async fn get_vs_index_params(
         &self,
         keyspace: KeyspaceName,
         table: TableName,
         index: IndexName,
-    ) -> GetIndexParamsR {
+    ) -> GetVsIndexParamsR {
         let session = self
             .session_rx
             .borrow()
@@ -1199,12 +1199,12 @@ pub(crate) mod tests {
             tx: oneshot::Sender<GetIndexTargetTypeR>,
         ) -> impl Future<Output = ()> + Send + 'static;
 
-        fn get_index_params(
+        fn get_vs_index_params(
             &self,
             keyspace: KeyspaceName,
             table: TableName,
             index: IndexName,
-            tx: oneshot::Sender<GetIndexParamsR>,
+            tx: oneshot::Sender<GetVsIndexParamsR>,
         ) -> impl Future<Output = ()> + Send + 'static;
 
         fn is_valid_index(
@@ -1251,12 +1251,12 @@ pub(crate) mod tests {
                                 .await
                         }
 
-                        Db::GetIndexParams {
+                        Db::GetVsIndexParams {
                             keyspace,
                             table,
                             index,
                             tx,
-                        } => sim.get_index_params(keyspace, table, index, tx).await,
+                        } => sim.get_vs_index_params(keyspace, table, index, tx).await,
 
                         Db::IsValidIndex { metadata, tx } => sim.is_valid_index(metadata, tx).await,
                     }

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -743,7 +743,7 @@ mod tests {
     }
 
     fn fts_kind() -> IndexKind {
-        IndexKind::Fts(IndexOptionsFts {})
+        IndexKind::Fts(IndexOptionsFts::default())
     }
 
     #[test]

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -14,6 +14,7 @@ use crate::db::DbExt;
 use crate::db_index::DbIndex;
 use crate::db_index::DbIndexExt;
 use crate::fts_index::FtsIndex;
+use crate::fts_index::FtsIndexConfiguration;
 use crate::fts_index::FtsIndexFactory;
 use crate::indexes::Indexes;
 use crate::monitor_indexes;
@@ -305,10 +306,17 @@ async fn add_index_vs(ctx: AddIndexContext<'_>) -> anyhow::Result<()> {
 }
 
 async fn add_index_fts(ctx: AddIndexContext<'_>) -> anyhow::Result<()> {
-    let fts_sender = ctx
-        .index_factories
-        .fts
-        .create_index(ctx.key.clone(), Arc::clone(&ctx.table));
+    let options = ctx.metadata.fts().ok_or_else(|| {
+        anyhow::anyhow!("add_index_fts must be called with a full-text-search index")
+    })?;
+    let fts_sender = ctx.index_factories.fts.create_index(
+        FtsIndexConfiguration {
+            key: ctx.key.clone(),
+            analyzer: options.analyzer,
+            positions: options.positions,
+        },
+        Arc::clone(&ctx.table),
+    );
 
     let monitor_actor = monitor_items::new(
         ctx.key.clone(),

--- a/crates/vector-store/src/fts_index/factory.rs
+++ b/crates/vector-store/src/fts_index/factory.rs
@@ -3,13 +3,26 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+use crate::Analyzer;
 use crate::IndexKey;
+use crate::Positions;
 use crate::fts_index::actor::FtsIndex;
 use crate::table::Table;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tokio::sync::mpsc;
 
+#[derive(Clone, Debug)]
+pub(crate) struct FtsIndexConfiguration {
+    pub key: IndexKey,
+    pub analyzer: Analyzer,
+    pub positions: Positions,
+}
+
 pub(crate) trait FtsIndexFactory {
-    fn create_index(&self, key: IndexKey, table: Arc<RwLock<Table>>) -> mpsc::Sender<FtsIndex>;
+    fn create_index(
+        &self,
+        index: FtsIndexConfiguration,
+        table: Arc<RwLock<Table>>,
+    ) -> mpsc::Sender<FtsIndex>;
 }

--- a/crates/vector-store/src/fts_index/mod.rs
+++ b/crates/vector-store/src/fts_index/mod.rs
@@ -11,6 +11,7 @@ use crate::memory::Memory;
 use crate::worker::Worker;
 pub(crate) use actor::FtsIndex;
 pub(crate) use actor::FtsIndexExt;
+pub(crate) use factory::FtsIndexConfiguration;
 pub(crate) use factory::FtsIndexFactory;
 pub(crate) use tantivy::QueryError;
 use tantivy::TantivyIndexFactory;

--- a/crates/vector-store/src/fts_index/tantivy.rs
+++ b/crates/vector-store/src/fts_index/tantivy.rs
@@ -31,16 +31,21 @@ use tantivy::snippet::SnippetGenerator;
 use tantivy::tokenizer::Language;
 use tantivy::tokenizer::LowerCaser;
 use tantivy::tokenizer::SimpleTokenizer;
+use tantivy::tokenizer::Stemmer;
 use tantivy::tokenizer::StopWordFilter;
 use tantivy::tokenizer::TextAnalyzer;
+use tantivy::tokenizer::WhitespaceTokenizer;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tracing::debug;
 use tracing::error;
 
+use crate::Analyzer;
 use crate::AsyncInProgress;
 use crate::IndexKey;
 use crate::Limit;
+use crate::Positions;
+use crate::fts_index::factory::FtsIndexConfiguration;
 use crate::fts_index::factory::FtsIndexFactory;
 use crate::memory::Allocate;
 use crate::memory::Memory;
@@ -71,9 +76,13 @@ impl TantivyIndexFactory {
 }
 
 impl FtsIndexFactory for TantivyIndexFactory {
-    fn create_index(&self, key: IndexKey, table: Arc<RwLock<Table>>) -> mpsc::Sender<FtsIndex> {
+    fn create_index(
+        &self,
+        index: FtsIndexConfiguration,
+        table: Arc<RwLock<Table>>,
+    ) -> mpsc::Sender<FtsIndex> {
         new(
-            key,
+            index,
             table,
             self.worker.clone(),
             self.memory.clone(),
@@ -131,17 +140,17 @@ struct IndexState {
     schema: Schema,
 }
 
-const TOKENIZER_NAME: &str = "standard";
 const COMMIT_INTERVAL: Duration = Duration::from_secs(3);
 const MAX_UNCOMMITTED_THRESHOLD: usize = 10_000;
 
 impl IndexState {
-    fn new() -> anyhow::Result<Self> {
-        let schema = build_schema();
+    fn new(analyzer: Analyzer, positions: Positions) -> anyhow::Result<Self> {
+        let tokenizer = analyzer.to_string();
+        let schema = build_schema(&tokenizer, positions);
         let index = tantivy::Index::create_in_ram(schema.clone());
         index
             .tokenizers()
-            .register(TOKENIZER_NAME, build_standard_analyzer()?);
+            .register(&tokenizer, build_token_pipeline(analyzer)?);
         let options = IndexWriterOptions::builder()
             .num_worker_threads(perf::num_workers().into())
             .build();
@@ -165,26 +174,67 @@ impl IndexState {
     }
 }
 
-fn build_standard_analyzer() -> anyhow::Result<TextAnalyzer> {
-    let stop_words = StopWordFilter::new(Language::English)
-        .ok_or_else(|| anyhow!("fts: english stop words unavailable"))?;
+fn stop_words(language: Language) -> anyhow::Result<StopWordFilter> {
+    StopWordFilter::new(language)
+        .ok_or_else(|| anyhow!("fts: stop words unavailable for {language:?}"))
+}
+
+/// The same token pipeline runs over the indexed documents and over the queries,
+/// so both sides produce matching tokens.
+fn build_token_pipeline(analyzer: Analyzer) -> anyhow::Result<TextAnalyzer> {
+    // The language analyzers share the pipeline of `standard` and add the stop
+    // words and the stemming of their own language.
+    let language = match analyzer {
+        // Splits on whitespace only, keeping punctuation and letter case.
+        Analyzer::Whitespace => {
+            return Ok(TextAnalyzer::builder(WhitespaceTokenizer::default()).build());
+        }
+        // Splits on non-alphanumeric characters and lowercases, nothing more.
+        Analyzer::Simple => {
+            return Ok(TextAnalyzer::builder(SimpleTokenizer::default())
+                .filter(LowerCaser)
+                .build());
+        }
+        // Removes English stop words, but does not stem.
+        Analyzer::Standard => {
+            return Ok(TextAnalyzer::builder(SimpleTokenizer::default())
+                .filter(LowerCaser)
+                .filter(stop_words(Language::English)?)
+                .build());
+        }
+        Analyzer::English => Language::English,
+        Analyzer::German => Language::German,
+        Analyzer::French => Language::French,
+        Analyzer::Spanish => Language::Spanish,
+        Analyzer::Italian => Language::Italian,
+        Analyzer::Portuguese => Language::Portuguese,
+        Analyzer::Russian => Language::Russian,
+    };
     Ok(TextAnalyzer::builder(SimpleTokenizer::default())
         .filter(LowerCaser)
-        .filter(stop_words)
+        .filter(stop_words(language)?)
+        .filter(Stemmer::new(language))
         .build())
 }
 
-fn body_text_options() -> TextOptions {
+fn body_text_options(tokenizer: &str, positions: Positions) -> TextOptions {
+    // Positions are what phrase queries match on.
+    // Dropping them makes the index smaller at the cost of rejecting phrase queries against it.
+    let index_option = if *positions.as_ref() {
+        IndexRecordOption::WithFreqsAndPositions
+    } else {
+        IndexRecordOption::WithFreqs
+    };
     let indexing = TextFieldIndexing::default()
-        .set_tokenizer(TOKENIZER_NAME)
-        .set_index_option(IndexRecordOption::WithFreqsAndPositions);
+        .set_tokenizer(tokenizer)
+        .set_index_option(index_option);
     TextOptions::default().set_indexing_options(indexing)
 }
 
-fn build_schema() -> Schema {
+fn build_schema(tokenizer: &str, positions: Positions) -> Schema {
     let mut schema_builder = Schema::builder();
     schema_builder.add_u64_field("primary_id", INDEXED | STORED);
-    schema_builder.add_text_field("body", body_text_options());
+    schema_builder.add_text_field("body", body_text_options(tokenizer, positions));
     schema_builder.build()
 }
 
@@ -391,13 +441,14 @@ fn handle_stats(state: &IndexState) -> FtsStatsR {
 fn get_or_create_state<T: TableSearch>(
     states: &mut BTreeMap<IndexId, Arc<IndexState>>,
     table: &RwLock<T>,
-    key: &IndexKey,
+    index: &FtsIndexConfiguration,
 ) -> Option<Arc<IndexState>> {
+    let key = &index.key;
     let index_id = table.read().unwrap().index_id(key)?;
     if let Some(state) = states.get(&index_id) {
         return Some(Arc::clone(state));
     }
-    match IndexState::new() {
+    match IndexState::new(index.analyzer, index.positions) {
         Ok(state) => {
             let state = Arc::new(state);
             states.insert(index_id, Arc::clone(&state));
@@ -437,7 +488,7 @@ fn can_allocate_memory(
 }
 
 pub(crate) fn new(
-    key: IndexKey,
+    index: FtsIndexConfiguration,
     table: Arc<RwLock<impl TableSearch + Send + Sync + 'static>>,
     worker: async_channel::Sender<Worker>,
     memory: mpsc::Sender<Memory>,
@@ -446,6 +497,7 @@ pub(crate) fn new(
 ) -> mpsc::Sender<FtsIndex> {
     let (tx, mut rx) = mpsc::channel::<FtsIndex>(perf::channel_size().into());
     tokio::spawn(async move {
+        let key = index.key.clone();
         debug!("fts index actor starting for {key}");
         let mut states: BTreeMap<IndexId, Arc<IndexState>> = BTreeMap::new();
 
@@ -470,7 +522,7 @@ pub(crate) fn new(
                             let Some(state) = get_or_create_state(
                                 &mut states,
                                 table.as_ref(),
-                                &key,
+                                &index,
                             ) else {
                                 continue;
                             };
@@ -499,7 +551,7 @@ pub(crate) fn new(
                             let Some(state) = get_or_create_state(
                                 &mut states,
                                 table.as_ref(),
-                                &key,
+                                &index,
                             ) else {
                                 continue;
                             };
@@ -648,11 +700,30 @@ mod tests {
     const TEST_COMMIT_INTERVAL: Duration = Duration::from_millis(50);
     const TEST_COMMIT_THRESHOLD: usize = 3;
 
+    fn make_configuration() -> FtsIndexConfiguration {
+        FtsIndexConfiguration {
+            key: make_index_key(),
+            analyzer: Analyzer::default(),
+            positions: Positions::default(),
+        }
+    }
+
     fn make_sender(table: Arc<RwLock<MockTableSearch>>) -> mpsc::Sender<FtsIndex> {
-        let key = make_index_key();
+        make_sender_with_options(table, Analyzer::default(), Positions::default())
+    }
+
+    fn make_sender_with_options(
+        table: Arc<RwLock<MockTableSearch>>,
+        analyzer: Analyzer,
+        positions: Positions,
+    ) -> mpsc::Sender<FtsIndex> {
         let memory = make_memory_actor();
         new(
-            key,
+            FtsIndexConfiguration {
+                analyzer,
+                positions,
+                ..make_configuration()
+            },
             table,
             worker::new(),
             memory,
@@ -698,14 +769,18 @@ mod tests {
         tx
     }
 
-    fn tokenize_with_standard_analyzer(text: &str) -> Vec<String> {
-        let mut analyzer = build_standard_analyzer().unwrap();
+    fn tokenize_with(analyzer: Analyzer, text: &str) -> Vec<String> {
+        let mut analyzer = build_token_pipeline(analyzer).unwrap();
         let mut stream = analyzer.token_stream(text);
         let mut tokens = Vec::new();
         while stream.advance() {
             tokens.push(stream.token().text.clone());
         }
         tokens
+    }
+
+    fn tokenize_with_standard_analyzer(text: &str) -> Vec<String> {
+        tokenize_with(Analyzer::Standard, text)
     }
 
     #[rstest]
@@ -879,10 +954,9 @@ mod tests {
     #[tokio::test]
     async fn add_document_rejected_when_memory_exhausted() {
         let table = make_table_with_keys();
-        let key = make_index_key();
         let memory = make_memory_actor_cannot_allocate();
         let sender = new(
-            key,
+            make_configuration(),
             table,
             worker::new(),
             memory,
@@ -902,10 +976,9 @@ mod tests {
     #[tokio::test]
     async fn threshold_forces_commit_before_interval() {
         let table = make_table_with_keys();
-        let key = make_index_key();
         let memory = make_memory_actor();
         let sender = new(
-            key.clone(),
+            make_configuration(),
             table,
             worker::new(),
             memory,
@@ -929,7 +1002,7 @@ mod tests {
         // when the threshold-forced commit clears the guards - i.e. once the commit has completed.
         drop(tx);
         rx.recv().await;
-        let count = sender.count(key).await.unwrap();
+        let count = sender.count(make_index_key()).await.unwrap();
 
         assert_eq!(count, TEST_COMMIT_THRESHOLD);
     }
@@ -1192,6 +1265,22 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[tokio::test]
+    async fn highlight_uses_the_configured_analyzer() {
+        let table = make_table_with_keys();
+        let sender = make_sender_with_options(table, Analyzer::English, Positions::default());
+        add_doc(&sender, 1, "the runners are running").await;
+
+        // The English analyzer stems both the query and the highlighted text,
+        // so "run" marks the "running" occurrence in the caller-supplied document.
+        let highlights = highlight(&sender, "run", &["a story about running fast"]).await;
+
+        assert_eq!(
+            highlights[0].as_deref(),
+            Some("a story about <b>running</b> fast")
+        );
+    }
+
     #[test]
     fn tokenize_lowercases_mixed_case() {
         assert_eq!(
@@ -1237,5 +1326,133 @@ mod tests {
     #[test]
     fn tokenize_punctuation_only_yields_no_tokens() {
         assert!(tokenize_with_standard_analyzer("!@#$ ,.;:").is_empty());
+    }
+
+    #[test]
+    fn standard_analyzer_does_not_stem() {
+        assert_eq!(
+            tokenize_with_standard_analyzer("the running runners"),
+            vec!["running", "runners"]
+        );
+    }
+
+    #[rstest]
+    #[case(Analyzer::English, "the running runners", vec!["run", "runner"])]
+    #[case(Analyzer::German, "die laufenden Läufer", vec!["laufend", "lauf"])]
+    #[case(Analyzer::French, "les coureurs courants", vec!["coureur", "cour"])]
+    #[case(Analyzer::Spanish, "los corredores corriendo", vec!["corredor", "corr"])]
+    #[case(Analyzer::Italian, "i corridori correnti", vec!["corridor", "corrent"])]
+    #[case(Analyzer::Portuguese, "os corredores correndo", vec!["corredor", "corr"])]
+    #[case(Analyzer::Russian, "и бегущие бегуны", vec!["бегущ", "бегун"])]
+    fn language_analyzers_stem_and_remove_stop_words(
+        #[case] analyzer: Analyzer,
+        #[case] text: &str,
+        #[case] expected: Vec<&str>,
+    ) {
+        assert_eq!(tokenize_with(analyzer, text), expected);
+    }
+
+    #[test]
+    fn simple_analyzer_lowercases_without_stop_words_or_stemming() {
+        assert_eq!(
+            tokenize_with(Analyzer::Simple, "The Running Runners, and a dog"),
+            vec!["the", "running", "runners", "and", "a", "dog"]
+        );
+    }
+
+    #[test]
+    fn whitespace_analyzer_keeps_case_and_punctuation() {
+        assert_eq!(
+            tokenize_with(Analyzer::Whitespace, "The Running, Runners!"),
+            vec!["The", "Running,", "Runners!"]
+        );
+    }
+
+    async fn search_phrase(positions: bool) -> FtsSearchR {
+        let sender = make_sender_with_options(
+            make_table_with_keys(),
+            Analyzer::default(),
+            Positions::from(positions),
+        );
+
+        add_doc(&sender, 1, "quick brown fox").await;
+        add_doc(&sender, 2, "brown quick fox").await;
+
+        sender
+            .search(
+                make_index_key(),
+                "\"quick brown\"".into(),
+                Limit::from(std::num::NonZeroUsize::new(10).unwrap()),
+            )
+            .await
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(10))]
+    #[tokio::test]
+    async fn phrase_query_matches_with_positions() {
+        let (keys, _) = search_phrase(true).await.unwrap();
+
+        assert_eq!(keys.len(), 1);
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(10))]
+    #[tokio::test]
+    async fn phrase_query_is_rejected_without_positions() {
+        let err = search_phrase(false)
+            .await
+            .expect_err("phrase query should not be answerable");
+
+        // A QueryError is what makes the endpoint answer 400 rather than 500.
+        // The index cannot serve the query, but the service is healthy.
+        assert!(
+            err.downcast_ref::<QueryError>().is_some(),
+            "expected a query error, got: {err}"
+        );
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(10))]
+    #[tokio::test]
+    async fn term_query_works_without_positions() {
+        let table = make_table_with_keys();
+        let sender = make_sender_with_options(table, Analyzer::default(), Positions::from(false));
+
+        add_doc(&sender, 1, "quick brown fox").await;
+        add_doc(&sender, 2, "lazy dog").await;
+
+        let (keys, _) = sender
+            .search(
+                make_index_key(),
+                "fox".into(),
+                Limit::from(std::num::NonZeroUsize::new(10).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(keys.len(), 1);
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(10))]
+    #[tokio::test]
+    async fn search_uses_the_configured_analyzer() {
+        let table = make_table_with_keys();
+        let sender = make_sender_with_options(table, Analyzer::English, Positions::default());
+
+        add_doc(&sender, 1, "the runners are running").await;
+
+        // Only an analyzer that stems both sides matches "run" against "running".
+        let (keys, _) = sender
+            .search(
+                make_index_key(),
+                "run".into(),
+                Limit::from(std::num::NonZeroUsize::new(10).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(keys.len(), 1);
     }
 }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -259,14 +259,10 @@ impl From<&IndexOptionsVs> for VectorIndexOptions {
 }
 
 impl From<&IndexOptionsFts> for FulltextIndexOptions {
-    fn from(_options: &IndexOptionsFts) -> Self {
-        // The service does not yet track per-index full-text options,
-        // and the full-text backend applies a fixed "standard" analyzer with
-        // token positions enabled.
-        // Report those defaults until the options are modeled.
+    fn from(options: &IndexOptionsFts) -> Self {
         FulltextIndexOptions {
-            analyzer: "standard".to_string(),
-            positions: true,
+            analyzer: options.analyzer.to_string(),
+            positions: *options.positions.as_ref(),
         }
     }
 }
@@ -1735,6 +1731,7 @@ async fn get_internal_session_counters(State(state): State<RoutesInnerState>) ->
 mod tests {
 
     use super::*;
+    use crate::Analyzer;
     use uuid::Uuid;
 
     #[test]
@@ -2487,10 +2484,20 @@ mod tests {
     #[test]
     fn fulltext_index_option_conversion() {
         assert_eq!(
-            FulltextIndexOptions::from(&IndexOptionsFts {}),
+            FulltextIndexOptions::from(&IndexOptionsFts::default()),
             FulltextIndexOptions {
                 analyzer: "standard".to_string(),
                 positions: true,
+            }
+        );
+        assert_eq!(
+            FulltextIndexOptions::from(&IndexOptionsFts {
+                analyzer: Analyzer::German,
+                positions: false.into(),
+            }),
+            FulltextIndexOptions {
+                analyzer: "german".to_string(),
+                positions: false,
             }
         );
     }

--- a/crates/vector-store/src/indexes.rs
+++ b/crates/vector-store/src/indexes.rs
@@ -245,12 +245,9 @@ impl FtsIndexEntry {
         monitor: mpsc::Sender<MonitorItems>,
         db_index: mpsc::Sender<DbIndex>,
     ) -> anyhow::Result<Self> {
-        let options = metadata
-            .fts()
-            .ok_or_else(|| {
-                anyhow::anyhow!("add_index_fts must be called with a fulltext-search index")
-            })?
-            .clone();
+        let options = *metadata.fts().ok_or_else(|| {
+            anyhow::anyhow!("add_index_fts must be called with a fulltext-search index")
+        })?;
         let progress = db_index.full_scan_progress().await;
         Ok(Self {
             index,

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -389,6 +389,7 @@ pub struct Dimensions(NonZeroUsize);
     derive_more::AsRef,
     derive_more::From,
     derive_more::Display,
+    derive_more::FromStr,
 )]
 /// Limit number of neighbors per graph node
 pub struct Connectivity(usize);
@@ -409,6 +410,7 @@ impl Default for Connectivity {
     derive_more::AsRef,
     derive_more::From,
     derive_more::Display,
+    derive_more::FromStr,
 )]
 /// Control the recall of indexing
 pub struct ExpansionAdd(usize);
@@ -429,6 +431,7 @@ impl Default for ExpansionAdd {
     derive_more::AsRef,
     derive_more::From,
     derive_more::Display,
+    derive_more::FromStr,
 )]
 /// Control the quality of the search
 pub struct ExpansionSearch(usize);

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -499,6 +499,74 @@ impl FromStr for Quantization {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default, derive_more::Display)]
+/// A text analyzer a full-text index uses to split text into tokens.
+pub enum Analyzer {
+    #[default]
+    #[display("standard")]
+    Standard,
+    #[display("english")]
+    English,
+    #[display("german")]
+    German,
+    #[display("french")]
+    French,
+    #[display("spanish")]
+    Spanish,
+    #[display("italian")]
+    Italian,
+    #[display("portuguese")]
+    Portuguese,
+    #[display("russian")]
+    Russian,
+    #[display("simple")]
+    Simple,
+    #[display("whitespace")]
+    Whitespace,
+}
+
+impl FromStr for Analyzer {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "standard" => Ok(Self::Standard),
+            "english" => Ok(Self::English),
+            "german" => Ok(Self::German),
+            "french" => Ok(Self::French),
+            "spanish" => Ok(Self::Spanish),
+            "italian" => Ok(Self::Italian),
+            "portuguese" => Ok(Self::Portuguese),
+            "russian" => Ok(Self::Russian),
+            "simple" => Ok(Self::Simple),
+            "whitespace" => Ok(Self::Whitespace),
+            _ => Err(anyhow::anyhow!("Unknown analyzer: {s}")),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, derive_more::AsRef, derive_more::From)]
+/// Whether a full-text index stores token positions, which are required by phrase queries.
+pub struct Positions(bool);
+
+impl Default for Positions {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl FromStr for Positions {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "true" => Ok(Self(true)),
+            "false" => Ok(Self(false)),
+            _ => Err(anyhow::anyhow!("Unknown positions value: {s}")),
+        }
+    }
+}
+
 #[derive(Clone, Copy, derive_more::AsRef, derive_more::Display, derive_more::From)]
 /// Limit the number of search result
 pub struct Limit(NonZeroUsize);
@@ -605,9 +673,12 @@ pub struct IndexOptionsVs {
     pub quantization: Quantization,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 /// Full-text-search-specific index configuration.
-pub struct IndexOptionsFts {}
+pub struct IndexOptionsFts {
+    pub analyzer: Analyzer,
+    pub positions: Positions,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 /// Discriminates between vector-search and full-text-search index.
@@ -902,5 +973,49 @@ mod tests {
         assert!(Percentage::try_from(101.0).is_err());
         assert!(Percentage::try_from(0.0).is_ok());
         assert!(Percentage::try_from(100.0).is_ok());
+    }
+
+    #[test]
+    fn analyzer_parses_every_value_scylladb_accepts() {
+        for (text, expected) in [
+            ("standard", Analyzer::Standard),
+            ("english", Analyzer::English),
+            ("german", Analyzer::German),
+            ("french", Analyzer::French),
+            ("spanish", Analyzer::Spanish),
+            ("italian", Analyzer::Italian),
+            ("portuguese", Analyzer::Portuguese),
+            ("russian", Analyzer::Russian),
+            ("simple", Analyzer::Simple),
+            ("whitespace", Analyzer::Whitespace),
+        ] {
+            assert_eq!(text.parse::<Analyzer>().unwrap(), expected);
+            assert_eq!(text.to_uppercase().parse::<Analyzer>().unwrap(), expected);
+            assert_eq!(expected.to_string(), text);
+        }
+    }
+
+    #[test]
+    fn analyzer_rejects_unknown_value() {
+        assert!("klingon".parse::<Analyzer>().is_err());
+    }
+
+    #[test]
+    fn analyzer_defaults_to_standard() {
+        assert_eq!(Analyzer::default(), Analyzer::Standard);
+    }
+
+    #[test]
+    fn positions_parses_booleans_case_insensitively() {
+        assert!(*"true".parse::<Positions>().unwrap().as_ref());
+        assert!(*"TRUE".parse::<Positions>().unwrap().as_ref());
+        assert!(!*"false".parse::<Positions>().unwrap().as_ref());
+        assert!(!*"False".parse::<Positions>().unwrap().as_ref());
+        assert!("yes".parse::<Positions>().is_err());
+    }
+
+    #[test]
+    fn positions_defaults_to_enabled() {
+        assert!(*Positions::default().as_ref());
     }
 }

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -245,7 +245,7 @@ async fn build_vs_index_kind(
 
     let (connectivity, expansion_add, expansion_search, space_type, quantization) =
         if let Some(params) = db
-            .get_index_params(idx.keyspace.clone(), idx.table.clone(), idx.index.clone())
+            .get_vs_index_params(idx.keyspace.clone(), idx.table.clone(), idx.index.clone())
             .await
             .inspect_err(|err| warn!("unable to get index params: {err}"))?
         {
@@ -674,7 +674,7 @@ mod tests {
             });
 
         mock_db
-            .expect_get_index_params()
+            .expect_get_vs_index_params()
             .returning(move |_, _, _, tx| {
                 async move {
                     // Return default params for all indexes
@@ -807,7 +807,7 @@ mod tests {
             });
 
         mock_db
-            .expect_get_index_params()
+            .expect_get_vs_index_params()
             .returning(move |_, _, _, tx| {
                 async move {
                     tx.send(Ok(Some((

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -198,7 +198,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
                 };
                 kind
             }
-            DbIndexKind::FullTextSearch => IndexKind::Fts(IndexOptionsFts {}),
+            DbIndexKind::FullTextSearch => IndexKind::Fts(IndexOptionsFts::default()),
         };
 
         let metadata = IndexMetadata {
@@ -430,7 +430,7 @@ mod tests {
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
             version: Uuid::new_v4().into(),
-            kind: IndexKind::Fts(IndexOptionsFts {}),
+            kind: IndexKind::Fts(IndexOptionsFts::default()),
         }
     }
 
@@ -932,7 +932,7 @@ mod tests {
         assert_eq!(result.len(), 1);
         let idx = result.into_iter().next().unwrap();
         assert_eq!(idx.index_name.as_ref(), "fts_idx");
-        assert_eq!(idx.kind, IndexKind::Fts(IndexOptionsFts {}));
+        assert_eq!(idx.kind, IndexKind::Fts(IndexOptionsFts::default()));
     }
 
     #[test]

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -198,7 +198,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
                 };
                 kind
             }
-            DbIndexKind::FullTextSearch => IndexKind::Fts(IndexOptionsFts::default()),
+            DbIndexKind::FullTextSearch => build_fts_index_kind(db, &idx).await?,
         };
 
         let metadata = IndexMetadata {
@@ -247,11 +247,11 @@ async fn build_vs_index_kind(
         if let Some(params) = db
             .get_vs_index_params(idx.keyspace.clone(), idx.table.clone(), idx.index.clone())
             .await
-            .inspect_err(|err| warn!("unable to get index params: {err}"))?
+            .inspect_err(|err| warn!("unable to get vector index params: {err}"))?
         {
             params
         } else {
-            debug!("get_indexes: no params for index {idx:?}");
+            debug!("get_indexes: no vector index params for index {idx:?}");
             (
                 Connectivity::default(),
                 ExpansionAdd::default(),
@@ -269,6 +269,18 @@ async fn build_vs_index_kind(
         space_type,
         quantization,
     })))
+}
+
+async fn build_fts_index_kind(db: &Sender<Db>, idx: &DbCustomIndex) -> anyhow::Result<IndexKind> {
+    let options = db
+        .get_fts_index_params(idx.keyspace.clone(), idx.table.clone(), idx.index.clone())
+        .await
+        .inspect_err(|err| warn!("unable to get full-text index params: {err}"))?
+        .unwrap_or_else(|| {
+            debug!("get_indexes: no full-text index params for index {idx:?}");
+            IndexOptionsFts::default()
+        });
+    Ok(IndexKind::Fts(options))
 }
 
 struct AddIndexesR {
@@ -376,6 +388,7 @@ fn discovered_indexes_simulator(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Analyzer;
     use crate::DbCustomIndex;
     use crate::DbIndexPartitioning;
     use crate::IndexKey;
@@ -886,38 +899,44 @@ mod tests {
         assert!(get_indexes(&db).await.is_err());
     }
 
-    #[tokio::test]
-    async fn get_indexes_returns_fts_index() {
+    fn mock_db_with_fts_index(options: Option<IndexOptionsFts>) -> MockSimDb {
         let mut mock_db = MockSimDb::new();
 
-        mock_db.expect_get_indexes().returning({
-            move |tx| {
-                async move {
-                    tx.send(Ok(vec![DbCustomIndex {
-                        keyspace: "ks".to_string().into(),
-                        index: "fts_idx".to_string().into(),
-                        table: "tbl".to_string().into(),
-                        primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
-                        partition_key_count: NonZeroUsize::new(1).unwrap(),
-                        target_columns: NonemptyArc::new(["content"]).unwrap(),
-                        partitioning: DbIndexPartitioning::Global,
-                        filtering_columns: Arc::new([]),
-                        kind: DbIndexKind::FullTextSearch,
-                    }]))
-                    .unwrap();
-                }
-                .boxed()
+        mock_db.expect_get_indexes().returning(move |tx| {
+            async move {
+                tx.send(Ok(vec![DbCustomIndex {
+                    keyspace: "ks".to_string().into(),
+                    index: "fts_idx".to_string().into(),
+                    table: "tbl".to_string().into(),
+                    primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+                    partition_key_count: NonZeroUsize::new(1).unwrap(),
+                    target_columns: NonemptyArc::new(["content"]).unwrap(),
+                    partitioning: DbIndexPartitioning::Global,
+                    filtering_columns: Arc::new([]),
+                    kind: DbIndexKind::FullTextSearch,
+                }]))
+                .unwrap();
             }
+            .boxed()
         });
 
-        mock_db.expect_get_index_version().returning({
-            move |_, _, _, tx| {
+        mock_db
+            .expect_get_index_version()
+            .returning(move |_, _, _, tx| {
                 async move {
                     tx.send(Ok(Some(Uuid::new_v4().into()))).unwrap();
                 }
                 .boxed()
-            }
-        });
+            });
+
+        mock_db
+            .expect_get_fts_index_params()
+            .returning(move |_, _, _, tx| {
+                async move {
+                    tx.send(Ok(options)).unwrap();
+                }
+                .boxed()
+            });
 
         mock_db.expect_is_valid_index().returning(move |_, tx| {
             async move {
@@ -926,12 +945,32 @@ mod tests {
             .boxed()
         });
 
-        let db = db::tests::new(mock_db);
+        mock_db
+    }
+
+    #[tokio::test]
+    async fn get_indexes_returns_fts_index() {
+        let options = IndexOptionsFts {
+            analyzer: Analyzer::German,
+            positions: false.into(),
+        };
+        let db = db::tests::new(mock_db_with_fts_index(Some(options)));
+
         let result = get_indexes(&db).await.unwrap();
 
         assert_eq!(result.len(), 1);
         let idx = result.into_iter().next().unwrap();
         assert_eq!(idx.index_name.as_ref(), "fts_idx");
+        assert_eq!(idx.kind, IndexKind::Fts(options));
+    }
+
+    #[tokio::test]
+    async fn get_indexes_defaults_fts_options_when_db_has_none() {
+        let db = db::tests::new(mock_db_with_fts_index(None));
+
+        let result = get_indexes(&db).await.unwrap();
+
+        let idx = result.into_iter().next().unwrap();
         assert_eq!(idx.kind, IndexKind::Fts(IndexOptionsFts::default()));
     }
 

--- a/crates/vector-store/tests/integration/common.rs
+++ b/crates/vector-store/tests/integration/common.rs
@@ -94,7 +94,7 @@ pub(crate) fn make_fts_index(
         DbIndexPartitioning::Global,
         &[],
         version,
-        IndexKind::Fts(IndexOptionsFts {}),
+        IndexKind::Fts(IndexOptionsFts::default()),
     )
 }
 

--- a/crates/vector-store/tests/integration/common.rs
+++ b/crates/vector-store/tests/integration/common.rs
@@ -86,6 +86,24 @@ pub(crate) fn make_fts_index(
     target_column: &str,
     version: Uuid,
 ) -> IndexMetadata {
+    make_fts_index_with_options(
+        name,
+        primary_key_columns,
+        partition_key_count,
+        target_column,
+        version,
+        IndexOptionsFts::default(),
+    )
+}
+
+pub(crate) fn make_fts_index_with_options(
+    name: &str,
+    primary_key_columns: &[&str],
+    partition_key_count: usize,
+    target_column: &str,
+    version: Uuid,
+    options: IndexOptionsFts,
+) -> IndexMetadata {
     make_index_with_kind(
         name,
         primary_key_columns,
@@ -94,7 +112,7 @@ pub(crate) fn make_fts_index(
         DbIndexPartitioning::Global,
         &[],
         version,
-        IndexKind::Fts(IndexOptionsFts::default()),
+        IndexKind::Fts(options),
     )
 }
 

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -404,7 +404,7 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
             .map_err(|_| anyhow!("Db::GetIndexTargetType: unable to send response"))
             .unwrap(),
 
-        Db::GetIndexParams {
+        Db::GetVsIndexParams {
             keyspace,
             table: _,
             index,
@@ -428,7 +428,7 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
                         )
                     })
                 })))
-            .map_err(|_| anyhow!("Db::GetIndexParams: unable to send response"))
+            .map_err(|_| anyhow!("Db::GetVsIndexParams: unable to send response"))
             .unwrap(),
 
         Db::IsValidIndex { tx, .. } => tx

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -431,6 +431,23 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
             .map_err(|_| anyhow!("Db::GetVsIndexParams: unable to send response"))
             .unwrap(),
 
+        Db::GetFtsIndexParams {
+            keyspace,
+            table: _,
+            index,
+            tx,
+        } => tx
+            .send(Ok(db
+                .0
+                .read()
+                .unwrap()
+                .keyspaces
+                .get(&keyspace)
+                .and_then(|keyspace| keyspace.indexes.get(&index))
+                .and_then(|index| index.metadata.fts().copied())))
+            .map_err(|_| anyhow!("Db::GetFtsIndexParams: unable to send response"))
+            .unwrap(),
+
         Db::IsValidIndex { tx, .. } => tx
             .send(true)
             .map_err(|_| anyhow!("Db::IsValidIndex: unable to send response"))

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -49,7 +49,7 @@ fn fts_index_metadata(primary_key_columns: impl IntoIterator<Item = ColumnName>)
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
         version: Uuid::new_v4().into(),
-        kind: IndexKind::Fts(IndexOptionsFts {}),
+        kind: IndexKind::Fts(IndexOptionsFts::default()),
     }
 }
 

--- a/crates/vector-store/tests/integration/index_info.rs
+++ b/crates/vector-store/tests/integration/index_info.rs
@@ -4,6 +4,7 @@
  */
 use crate::common::add_table;
 use crate::common::make_fts_index;
+use crate::common::make_fts_index_with_options;
 use crate::common::make_index_with_kind;
 use crate::common::ordered_timeuuid;
 use crate::common::setup;
@@ -21,6 +22,7 @@ use scylla::value::CqlValue;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::time::Duration;
+use vector_store::Analyzer;
 use vector_store::DbIndexPartitioning;
 use vector_store::IndexKind;
 use vector_store::IndexOptionsFts;
@@ -89,9 +91,22 @@ async fn index_info_reports_vector_index_options() {
 }
 
 #[rstest]
+#[case::defaults(IndexOptionsFts::default(), "standard", true)]
+#[case::non_defaults(
+    IndexOptionsFts {
+        analyzer: Analyzer::German,
+        positions: false.into(),
+    },
+    "german",
+    false
+)]
 #[timeout(Duration::from_secs(10))]
 #[tokio::test]
-async fn index_info_reports_fulltext_index_options() {
+async fn index_info_reports_fulltext_index_options(
+    #[case] options: IndexOptionsFts,
+    #[case] analyzer: &str,
+    #[case] positions: bool,
+) {
     crate::enable_tracing();
     let (client, db, _keep) = setup().await;
 
@@ -106,7 +121,14 @@ async fn index_info_reports_fulltext_index_options() {
         [],
     );
 
-    let index = make_fts_index("fulltext", &["pk"], 1, "content", ordered_timeuuid(1));
+    let index = make_fts_index_with_options(
+        "fulltext",
+        &["pk"],
+        1,
+        "content",
+        ordered_timeuuid(1),
+        options,
+    );
     db.add_index(
         index.clone(),
         Some(db_basic::scan_fn_documents([(
@@ -130,8 +152,8 @@ async fn index_info_reports_fulltext_index_options() {
     assert_eq!(
         info.options,
         IndexOptions::Fulltext(FulltextIndexOptions {
-            analyzer: "standard".to_string(),
-            positions: true,
+            analyzer: analyzer.to_string(),
+            positions,
         })
     );
 }

--- a/crates/vector-store/tests/integration/index_info.rs
+++ b/crates/vector-store/tests/integration/index_info.rs
@@ -204,7 +204,7 @@ async fn indexes_lists_all_indexes_with_options() {
     )
     .unwrap();
 
-    let fts_options = IndexOptionsFts {};
+    let fts_options = IndexOptionsFts::default();
     let fts_index = make_fts_index("third", &["pk"], 1, "content", ordered_timeuuid(3));
     db.add_index(
         fts_index.clone(),


### PR DESCRIPTION
ScyllaDB lets a full-text index choose its `analyzer` and whether token positions are stored, and records both in the index schema. The Vector Store ignored them. Every FTS index was built with a fixed standard-analyzer pipeline and positions always on, and the API reported that hardcoded pair whatever the index had actually been created with. An index created with `'analyzer': 'english'` was searched as if it were a standard one.

Both options are now read from the index schema and applied to the index the service builds, so the analyzer decides the token pipeline and positions are stored only when the index asks for them. The analyzer is registered per index, which makes queries and highlights tokenize the way the indexed documents did, and the API reports what the index actually carries. Dropping positions makes phrase queries against that index fail with a 400, which is what the option means.

Fixes: [VECTOR-788](https://scylladb.atlassian.net/browse/VECTOR-788)

[VECTOR-788]: https://scylladb.atlassian.net/browse/VECTOR-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
