### PR TITLE
vector-store: allow local/filtered indexes on Alternator tables

### DIFF
--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -791,9 +791,10 @@ impl Statements {
                                 .context(InvalidMetadata)
                         })?;
                     let partition_key_count = NonZeroUsize::new(table.partition_key.len()).unwrap();
+                    let is_alternator = KeyspaceName::from(&keyspace_name).is_alternator();
                     Ok(options.remove("target").and_then(|target| {
                         let kind = db_index_kind_from_options(&mut options)?;
-                        from_target_option(table, target, kind)
+                        from_target_option(table, target, kind, is_alternator)
                             .map(
                                 |(partitioning, target_column, filtering_columns)| DbCustomIndex {
                                     keyspace: keyspace_name.into(),
@@ -1077,21 +1078,26 @@ fn from_target_option(
     table: &Table,
     value: String,
     kind: DbIndexKind,
+    is_alternator: bool,
 ) -> anyhow::Result<(DbIndexPartitioning, ColumnName, Arc<[ColumnName]>)> {
     let Some(target) = parse_target_option(table, &value)? else {
         // Global index with a single target column
         return Ok((DbIndexPartitioning::Global, value.into(), Arc::new([])));
     };
 
-    validate_target_column(table, &target.target_column, kind)?;
+    // Alternator's tc/pk columns may not be real columns in the table.
+    if !is_alternator {
+        validate_target_column(table, &target.target_column, kind)?;
+    }
 
     let partitioning = if target.partition_key_columns.is_empty() {
         DbIndexPartitioning::Global
     } else {
-        if let Some(invalid) = target
-            .partition_key_columns
-            .iter()
-            .find(|pk_col| !table.columns.contains_key(*pk_col))
+        if !is_alternator
+            && let Some(invalid) = target
+                .partition_key_columns
+                .iter()
+                .find(|pk_col| !table.columns.contains_key(*pk_col))
         {
             bail!("invalid target option: pk column {invalid} is not in the table's columns");
         }


### PR DESCRIPTION
When a vector index was created on an Alternator vector column, the implementation knows it is not a real CQL column - and needs to be found in the ":attr" map of attributes.

Howver, the index's "target", instead of being given as a single vector column, can list tc,pk,fc - target column, partition key and filtering columns respectively. In this case, the vector search reaches a separate code path - that for some reason includes extra validation (that did not exist in bare single-column target case) that all these columns are real CQL columns.

This patch avoids this extra validation in the case of an Alternator table - these columns may very well NOT be real columns.

We'll need this change for Alternator's support for DynamoDB's new API's "SearchSchema", where INLINE_FILTER and HASH attributes can be specified, which correspond to our "pk" and "fc" respectively.

from_target_option() now takes an is_alternator flag (derived from the keyspace name) and skips the target-column existence/type check and the pk-columns existence check when set, leaving validation for CQL-native tables unchanged.