### PR TITLE
vector-store: support Alternator Vector Search filtering columns

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -792,6 +792,12 @@
           "routing": {
             "type": "boolean",
             "description": "By default, the query may be routed to a different, better-matching index on the same column. Set to `false` to force the query to be served by exactly the index named in the URL."
+          "return_columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnName"
+            },
+            "description": "Filtering-column names whose stored values should be returned alongside\nthe primary keys. Empty (the default) means return no column values."
           },
           "vector": {
             "$ref": "#/components/schemas/Vector"
@@ -806,6 +812,18 @@
           "similarity_scores"
         ],
         "properties": {
+          "column_values": {
+            "type": "object",
+            "description": "Per-column stored values for the filtering columns requested in\n`return_columns`. Each entry maps a column name to a Vec of\n`Option<Value>` — one entry per returned nearest neighbour, in the\nsame order as `similarity_scores`. `None` means the value was not\npresent for that row (e.g. the attribute did not exist when the row\nwas indexed). Absent when `return_columns` was empty.",
+            "additionalProperties": {
+              "type": "array",
+              "items": {}
+            },
+            "propertyNames": {
+              "type": "string",
+              "description": "Name of the column in a db table."
+            }
+          },
           "distances": {
             "type": "array",
             "items": {

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -374,6 +374,10 @@ pub struct PostIndexAnnRequest {
     /// By default, the query may be routed to a different, better-matching index on the same column. Set to `false` to force the query to be served by exactly the index named in the URL.
     #[serde(default = "default_routing")]
     pub routing: bool,
+    /// Filtering-column names whose stored values should be returned alongside
+    /// the primary keys. Empty (the default) means return no column values.
+    #[serde(default)]
+    pub return_columns: Vec<ColumnName>,
 }
 
 fn default_routing() -> bool {
@@ -385,6 +389,14 @@ pub struct PostIndexAnnResponse {
     pub primary_keys: HashMap<ColumnName, Vec<Value>>,
     pub distances: Vec<Distance>,
     pub similarity_scores: Vec<SimilarityScore>,
+    /// Per-column stored values for the filtering columns requested in
+    /// `return_columns`. Each entry maps a column name to a Vec of
+    /// `Option<Value>` — one entry per returned nearest neighbour, in the
+    /// same order as `similarity_scores`. `None` means the value was not
+    /// present for that row (e.g. the attribute did not exist when the row
+    /// was indexed). Absent when `return_columns` was empty.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub column_values: HashMap<ColumnName, Vec<Option<Value>>>,
 }
 
 #[derive(Copy, Clone, Debug, serde::Deserialize, derive_more::From, utoipa::ToSchema)]
@@ -433,6 +445,7 @@ mod tests {
                 SimilarityScore::from(f32::NEG_INFINITY),
                 SimilarityScore::from(0.5),
             ],
+            column_values: HashMap::new(),
         })
         .unwrap();
 

--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -93,6 +93,7 @@ impl HttpClient {
             filter,
             limit,
             routing: true,
+            return_columns: vec![],
         };
         self.post_ann_data(keyspace_name, index_name, &request)
             .await

--- a/crates/testclient/src/lib.rs
+++ b/crates/testclient/src/lib.rs
@@ -60,6 +60,7 @@ impl TestClient {
                 filter,
                 limit,
                 routing: true,
+                return_columns: vec![],
             })
             .await
     }

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -131,6 +131,7 @@ fn default_index_metadata(
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(dimensions).unwrap().into(),

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -855,9 +855,10 @@ impl Statements {
                                 .context(InvalidMetadata)
                         })?;
                     let partition_key_count = NonZeroUsize::new(table.partition_key.len()).unwrap();
+                    let is_alternator = KeyspaceName::from(&keyspace_name).is_alternator();
                     Ok(options.remove("target").and_then(|target| {
                         let kind = db_index_kind_from_options(&mut options)?;
-                        from_target_option(table, target, kind)
+                        from_target_option(table, target, kind, is_alternator)
                             .map(
                                 |(partitioning, target_column, filtering_columns)| DbCustomIndex {
                                     keyspace: keyspace_name.into(),
@@ -1152,21 +1153,26 @@ fn from_target_option(
     table: &Table,
     value: String,
     kind: DbIndexKind,
+    is_alternator: bool,
 ) -> anyhow::Result<(DbIndexPartitioning, ColumnName, Arc<[ColumnName]>)> {
     let Some(target) = parse_target_option(table, &value)? else {
         // Global index with a single target column
         return Ok((DbIndexPartitioning::Global, value.into(), Arc::new([])));
     };
 
-    validate_target_column(table, &target.target_column, kind)?;
+    // Alternator's tc/pk columns may not be real columns in the table.
+    if !is_alternator {
+        validate_target_column(table, &target.target_column, kind)?;
+    }
 
     let partitioning = if target.partition_key_columns.is_empty() {
         DbIndexPartitioning::Global
     } else {
-        if let Some(invalid) = target
-            .partition_key_columns
-            .iter()
-            .find(|pk_col| !table.columns.contains_key(*pk_col))
+        if !is_alternator
+            && let Some(invalid) = target
+                .partition_key_columns
+                .iter()
+                .find(|pk_col| !table.columns.contains_key(*pk_col))
         {
             bail!("invalid target option: pk column {invalid} is not in the table's columns");
         }

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -856,6 +856,14 @@ impl Statements {
                         })?;
                     let partition_key_count = NonZeroUsize::new(table.partition_key.len()).unwrap();
                     let is_alternator = KeyspaceName::from(&keyspace_name).is_alternator();
+                    let alternator_attribute_types = Arc::new(if is_alternator {
+                        options
+                            .remove("search_schema_types")
+                            .map(|v| parse_alternator_attribute_types(&v))
+                            .unwrap_or_default()
+                    } else {
+                        BTreeMap::new()
+                    });
                     Ok(options.remove("target").and_then(|target| {
                         let kind = db_index_kind_from_options(&mut options)?;
                         from_target_option(table, target, kind, is_alternator)
@@ -870,6 +878,7 @@ impl Statements {
                                         .expect("target column should be non-empty"),
                                     partitioning,
                                     filtering_columns,
+                                    alternator_attribute_types,
                                     kind,
                                 },
                             )
@@ -1104,6 +1113,17 @@ fn parse_target_option(table: &Table, value: &str) -> anyhow::Result<Option<Targ
         return Ok(Some(convert_legacy_target_option(table, legacy)?));
     };
     Ok(None)
+}
+
+/// Parses an Alternator index's "search_schema_types" option: a JSON map
+/// from attribute name to declared DynamoDB type ("S"/"N"/"B"). Invalid
+/// JSON yields an empty map rather than an error.
+fn parse_alternator_attribute_types(value: &str) -> BTreeMap<ColumnName, String> {
+    serde_json::from_str::<BTreeMap<String, String>>(value)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(name, dynamodb_type)| (ColumnName::from(name), dynamodb_type))
+        .collect()
 }
 
 fn convert_legacy_target_option(

--- a/crates/vector-store/src/db_cdc/actor.rs
+++ b/crates/vector-store/src/db_cdc/actor.rs
@@ -325,7 +325,7 @@ impl CdcReaderState {
                 );
             }
             Err(e) => {
-                error!("Failed to create {} CDC reader: {e}", self.name);
+                error!("Failed to create {} CDC reader: {e:#}", self.name);
                 self.set_reader_metric_down();
                 self.error_notify.notify_one();
             }

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -306,15 +306,14 @@ impl CdcConsumerFactory {
                 .chain(filtering_columns.iter()),
             primary_key_columns.iter(),
         );
-        let st_select_values =
-            session
-                .prepare(query)
-                .await
-                .context("request_query")?
-                .pipe(|mut stmt| {
-                    stmt.set_is_idempotent(true);
-                    stmt
-                });
+        let st_select_values = session
+            .prepare(query.clone())
+            .await
+            .with_context(|| format!("request_query: {query}"))?
+            .pipe(|mut stmt| {
+                stmt.set_is_idempotent(true);
+                stmt
+            });
 
         Ok(Self(Arc::new(CdcConsumerData {
             session,

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -22,6 +22,7 @@ use anyhow::anyhow;
 use anyhow::bail;
 use async_trait::async_trait;
 use scylla::client::session::Session;
+use scylla::cluster::metadata::NativeType;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
 use scylla::value::Row;
@@ -50,6 +51,8 @@ struct CdcConsumerData {
     nonpk_partition_key_columns: Box<[ColumnName]>,
     target_columns: NonemptyArc<ColumnName>,
     filtering_columns: Arc<[ColumnName]>,
+    /// See Statements::alternator_decode_types in db_index.rs.
+    alternator_decode_types: Box<[Option<NativeType>]>,
     kind: IndexKind,
     tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     metrics: Arc<Metrics>,
@@ -106,8 +109,13 @@ impl CdcConsumerData {
             bail!(msg);
         }
 
-        let values =
-            db_index::parse_values(row.columns, Some(timestamp), target_columns_len, &self.kind)?;
+        let values = db_index::parse_values(
+            row.columns,
+            Some(timestamp),
+            target_columns_len,
+            &self.kind,
+            &self.alternator_decode_types,
+        )?;
         _ = self
             .tx
             .send((
@@ -282,6 +290,13 @@ impl CdcConsumerFactory {
             .cloned()
             .collect();
 
+        let alternator_decode_types = db_index::alternator_decode_types(
+            nonpk_partition_key_columns
+                .iter()
+                .chain(filtering_columns.iter()),
+            metadata,
+        );
+
         let query = db_index_backend::request_query(
             &metadata.keyspace_name.as_ref().into(),
             &metadata.table_name.as_ref().into(),
@@ -309,6 +324,7 @@ impl CdcConsumerFactory {
             nonpk_partition_key_columns,
             target_columns,
             filtering_columns,
+            alternator_decode_types,
             kind: metadata.kind.clone(),
             tx,
             metrics,

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -273,12 +273,7 @@ impl CdcConsumerFactory {
             .ok_or_else(|| anyhow!("primary key must have at least one column"))?;
 
         let target_columns = metadata.target_columns.clone();
-        let filtering_columns: Arc<[_]> = metadata
-            .filtering_columns
-            .iter()
-            .filter(|column| !primary_key_columns.contains(column))
-            .cloned()
-            .collect();
+        let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
 
         let nonpk_partition_key_columns: Box<[_]> = metadata
             .nonpk_partition_key_columns()

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -338,12 +338,7 @@ impl Statements {
         );
 
         let target_columns = metadata.target_columns.clone();
-        let filtering_columns: Arc<[_]> = metadata
-            .filtering_columns
-            .iter()
-            .filter(|column| !primary_key_columns.contains(column))
-            .cloned()
-            .collect();
+        let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
 
         let table_columns = Arc::new(
             table

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -359,6 +359,22 @@ impl Statements {
                         None
                     }
                 }))
+                // A filtering column added purely for an Alternator
+                // Projection's sake (see Alternator's
+                // compute_extra_fc_attributes()) has no declared type - it's
+                // a plain opaque attribute value, not usable for typed
+                // filtering. Store it as a raw Blob, exactly as it comes out
+                // of the ":attrs" map, so Table::new() below can still
+                // include it (for projection/return purposes only).
+                .chain(
+                    filtering_columns
+                        .iter()
+                        .filter(|name| {
+                            !metadata.alternator_attribute_types.contains_key(*name)
+                                && !table.columns.contains_key(name.as_ref())
+                        })
+                        .map(|name| (name.clone(), NativeType::Blob)),
+                )
                 .collect(),
         );
         let alternator_decode_types = alternator_decode_types(

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -284,6 +284,10 @@ struct Statements {
     nonpk_partition_key_columns: Box<[ColumnName]>,
     filtering_columns: Arc<[ColumnName]>,
     table_columns: GetTableColumnsR,
+    /// Aligned with nonpk_partition_key_columns + filtering_columns: the
+    /// NativeType to decode each one's raw ":attrs" value as, or None for a
+    /// real CQL column. See parse_values().
+    alternator_decode_types: Box<[Option<NativeType>]>,
     st_range_scan: PreparedStatement,
     kind: IndexKind,
 }
@@ -340,18 +344,28 @@ impl Statements {
         let target_columns = metadata.target_columns.clone();
         let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
 
+        // Merge in synthesized types for Alternator attributes with no real
+        // column (see IndexMetadata::alternator_attribute_types); real
+        // columns come last so they win on any name collision.
         let table_columns = Arc::new(
-            table
-                .columns
-                .iter()
-                .filter_map(|(name, coltype)| {
+            metadata
+                .alternator_attribute_types
+                .keys()
+                .filter_map(|name| Some((name.clone(), metadata.alternator_native_type(name)?)))
+                .chain(table.columns.iter().filter_map(|(name, coltype)| {
                     if let ColumnType::Native(typ) = &coltype.typ {
                         Some((ColumnName::from(name.clone()), typ.clone()))
                     } else {
                         None
                     }
-                })
+                }))
                 .collect(),
+        );
+        let alternator_decode_types = alternator_decode_types(
+            nonpk_partition_key_columns
+                .iter()
+                .chain(filtering_columns.iter()),
+            &metadata,
         );
         let st_partition_key_list = table
             .partition_key
@@ -389,6 +403,7 @@ impl Statements {
             target_columns,
             filtering_columns,
             table_columns,
+            alternator_decode_types,
             st_range_scan,
             session_rx,
             kind: metadata.kind.clone(),
@@ -569,6 +584,7 @@ impl Statements {
         let target_columns_offset = self.primary_key_columns.len().get();
         let target_columns_len = self.target_columns.len();
         let kind = self.kind.clone();
+        let alternator_decode_types = self.alternator_decode_types.clone();
 
         // wait for an active session
         let session = {
@@ -604,6 +620,7 @@ impl Statements {
                     None,
                     target_columns_len,
                     &kind,
+                    &alternator_decode_types,
                 )
                 .inspect_err(|err| error!("Error while parsing values: {err}"))
                 .ok()?;
@@ -625,11 +642,24 @@ impl Statements {
     }
 }
 
+/// Builds parse_values()'s alternator_decode_types parameter: for each of
+/// `columns`, its NativeType from `metadata.alternator_native_type()`.
+pub(crate) fn alternator_decode_types<'a>(
+    columns: impl IntoIterator<Item = &'a ColumnName>,
+    metadata: &IndexMetadata,
+) -> Box<[Option<NativeType>]> {
+    columns
+        .into_iter()
+        .map(|column| metadata.alternator_native_type(column))
+        .collect()
+}
+
 pub(crate) fn parse_values(
     columns: impl IntoIterator<Item = Option<CqlValue>>,
     default_timestamp: Option<Timestamp>,
     target_columns_len: NonZeroUsize,
     kind: &IndexKind,
+    alternator_decode_types: &[Option<NativeType>],
 ) -> anyhow::Result<NonemptyBox<Timestamped<DbIndexedValue>>> {
     let default_timestamp = default_timestamp.unwrap_or(Timestamp::MIN);
     let values = columns
@@ -649,7 +679,20 @@ pub(crate) fn parse_values(
                     None
                 }
             } else {
-                // filtering columns
+                // filtering columns: a virtual Alternator attribute's raw
+                // value is a tagged blob that needs decoding first.
+                let native_type = alternator_decode_types
+                    .get(idx - target_columns_len.get())
+                    .cloned()
+                    .flatten();
+                let value = value
+                    .map(|value| match (value, native_type) {
+                        (CqlValue::Blob(bytes), Some(native_type)) => {
+                            crate::vector::parse_alternator_scalar(&bytes, &native_type)
+                        }
+                        (value, _) => Ok(value),
+                    })
+                    .transpose()?;
                 value.map(DbIndexedValue::Filtering)
             };
 
@@ -823,6 +866,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         )
         .unwrap();
         let result = result.as_slice();
@@ -848,6 +892,7 @@ mod tests {
             Some(Timestamp::from_millis(1)),
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         )
         .unwrap();
         let result = result.as_slice();
@@ -868,6 +913,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result
@@ -885,6 +931,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result
@@ -906,6 +953,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result
@@ -928,6 +976,7 @@ mod tests {
             None,
             NonZeroUsize::new(3).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -213,13 +213,16 @@ async fn add_index(
         DbIndexPartitioning::Local(partition_key_columns) => Some(partition_key_columns.clone()),
         DbIndexPartitioning::Global => None,
     };
+    // Must match the columns db_index.rs/db_cdc actually fetch a value for,
+    // or Table::new()'s column list goes out of sync with update_columns().
+    let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
     let table = match Table::new(
         key.clone(),
         metadata.primary_key_columns.clone(),
         metadata.partition_key_count,
         partition_key_columns,
         metadata.target_columns.len(),
-        Arc::clone(&metadata.filtering_columns),
+        filtering_columns,
         table_columns,
     ) {
         Ok(table) => Arc::new(RwLock::new(table)),

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -820,6 +820,27 @@ async fn post_index_ann(
             ))
             .await;
 
+        // Filtering-column names whose stored values the caller wants back
+        // alongside the primary keys, instead of having to separately read
+        // every result row from the base table.
+        let return_columns: Vec<crate::ColumnName> = request
+            .return_columns
+            .into_iter()
+            .map(crate::ColumnName::from)
+            .collect();
+        for column in &return_columns {
+            if !filtering_columns.contains(column) {
+                timer.observe_duration();
+
+                let msg = format!(
+                    "Column '{column}' in return_columns is not part of the primary key or filtering columns, and cannot be returned"
+                );
+                debug!("post_index_ann: {msg}");
+                return (StatusCode::BAD_REQUEST, msg).into_response();
+            }
+        }
+        let return_columns: Arc<[crate::ColumnName]> = return_columns.into();
+
         let search_result = if let Some(filter) = request.filter {
             let filter = match try_from_post_index_ann_filter(
                 filter,
@@ -838,11 +859,17 @@ async fn post_index_ann(
                     request.vector.into(),
                     filter,
                     request.limit.into(),
+                    Arc::clone(&return_columns),
                 )
                 .await
         } else {
             index
-                .ann(routed_key, request.vector.into(), request.limit.into())
+                .ann(
+                    routed_key,
+                    request.vector.into(),
+                    request.limit.into(),
+                    Arc::clone(&return_columns),
+                )
                 .await
         };
 
@@ -858,7 +885,7 @@ async fn post_index_ann(
                     (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
                 }
             },
-            Ok((primary_keys, distances)) => {
+            Ok((primary_keys, distances, column_values_per_row)) => {
                 if primary_keys.len() != distances.len() {
                     let msg = format!(
                         "wrong size of an ann response: \
@@ -884,15 +911,35 @@ async fn post_index_ann(
                             debug!("post_index_ann: {err}");
                             (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
                         }
-                        Ok(primary_keys) => (
-                            StatusCode::OK,
-                            response::Json(httpapi::PostIndexAnnResponse {
-                                primary_keys,
-                                distances: distances.into_iter().map(|d| d.into()).collect(),
-                                similarity_scores,
-                            }),
-                        )
-                            .into_response(),
+                        Ok(primary_keys) => {
+                            let column_values: HashMap<
+                                httpapi::ColumnName,
+                                Vec<Option<Value>>,
+                            > = return_columns
+                                .iter()
+                                .map(|col_name| {
+                                    let values = column_values_per_row
+                                        .iter()
+                                        .map(|row_vals| {
+                                            row_vals
+                                                .get(col_name)
+                                                .and_then(|v| try_to_json(v.clone()).ok())
+                                        })
+                                        .collect();
+                                    (col_name.clone().into(), values)
+                                })
+                                .collect();
+                            (
+                                StatusCode::OK,
+                                response::Json(httpapi::PostIndexAnnResponse {
+                                    primary_keys,
+                                    distances: distances.into_iter().map(|d| d.into()).collect(),
+                                    similarity_scores,
+                                    column_values,
+                                }),
+                            )
+                                .into_response()
+                        }
                     }
                 }
             }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -1470,7 +1470,9 @@ fn try_to_json(value: CqlValue) -> anyhow::Result<Value> {
 
         CqlValue::Decimal(value) => Ok(Value::String(BigDecimal::from(value).to_string())),
 
-        _ => unimplemented!(),
+        CqlValue::Inet(value) => Ok(Value::String(value.to_string())),
+
+        other => bail!("unsupported CqlValue variant for JSON conversion: {other:?}"),
     }
 }
 
@@ -2396,6 +2398,24 @@ mod tests {
             .unwrap(),
             Value::String("-98765432109876543210.123456789".to_string())
         );
+
+        assert_eq!(
+            try_to_json(CqlValue::Inet(
+                "192.168.1.1".parse::<std::net::IpAddr>().unwrap()
+            ))
+            .unwrap(),
+            Value::String("192.168.1.1".to_string())
+        );
+        assert_eq!(
+            try_to_json(CqlValue::Inet("::1".parse::<std::net::IpAddr>().unwrap())).unwrap(),
+            Value::String("::1".to_string())
+        );
+
+        // Counter can't actually reach try_to_json in practice (it can't be
+        // a primary-key or filtering-column type), but it's convenient here
+        // to prove that an unhandled variant returns a regular error instead
+        // of panicking the server.
+        assert!(try_to_json(CqlValue::Counter(scylla::value::Counter(1))).is_err());
     }
 
     #[test]

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -747,6 +747,15 @@ impl IndexMetadata {
             ),
         }
     }
+
+    /// The subset of `filtering_columns` not already in `primary_key_columns`.
+    /// Table::new() stores a primary-key column as Column::PrimaryKey, not a
+    /// value slot, so it can't also be fetched/stored as a filtering column.
+    fn nonpk_filtering_columns(&self) -> impl Iterator<Item = &ColumnName> {
+        self.filtering_columns
+            .iter()
+            .filter(|col| !self.primary_key_columns.contains(col))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -64,12 +64,14 @@ pub use crate::vector::Vector;
 use crate::vs_index::VsIndexFactory;
 use db::Db;
 use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
 use scylla::serialize::SerializationError;
 use scylla::serialize::value::SerializeValue;
 use scylla::serialize::writers::CellWriter;
 use scylla::serialize::writers::WrittenCellProof;
 use scylla::value::CqlValue;
 use scylla_cdc::CqlIdentifier;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::net::SocketAddr;
@@ -714,6 +716,11 @@ pub struct IndexMetadata {
     pub target_columns: NonemptyArc<ColumnName>,
     pub partitioning: DbIndexPartitioning,
     pub filtering_columns: Arc<[ColumnName]>,
+    /// For Alternator tables: the declared DynamoDB type ("S", "N" or "B")
+    /// of each partition-key/filtering column with no real column in the
+    /// table's CQL schema (its value lives only in the ":attrs" map).
+    /// Empty for CQL-native tables and for columns that are real columns.
+    pub alternator_attribute_types: Arc<BTreeMap<ColumnName, String>>,
     pub version: IndexVersion,
     pub kind: IndexKind,
 }
@@ -729,6 +736,17 @@ impl IndexMetadata {
 
     pub fn fts(&self) -> Option<&IndexOptionsFts> {
         self.kind.as_fts()
+    }
+
+    /// The NativeType to treat `column` as, if it's a virtual Alternator
+    /// attribute (see alternator_attribute_types) - None otherwise.
+    pub fn alternator_native_type(&self, column: &ColumnName) -> Option<NativeType> {
+        match self.alternator_attribute_types.get(column)?.as_str() {
+            "S" => Some(NativeType::Text),
+            "N" => Some(NativeType::Decimal),
+            "B" => Some(NativeType::Blob),
+            _ => None,
+        }
     }
 
     fn discard_version(&self) -> Self {
@@ -781,6 +799,8 @@ pub struct DbCustomIndex {
     pub target_columns: NonemptyArc<ColumnName>,
     pub partitioning: DbIndexPartitioning,
     pub filtering_columns: Arc<[ColumnName]>,
+    /// See IndexMetadata::alternator_attribute_types.
+    pub alternator_attribute_types: Arc<BTreeMap<ColumnName, String>>,
     pub kind: DbIndexKind,
 }
 

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -210,6 +210,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             target_columns: idx.target_columns,
             partitioning: idx.partitioning,
             filtering_columns: idx.filtering_columns,
+            alternator_attribute_types: idx.alternator_attribute_types,
             version,
             kind,
         };
@@ -402,6 +403,7 @@ mod tests {
     use anyhow::anyhow;
     use futures::FutureExt;
     use rstest::rstest;
+    use std::collections::BTreeMap;
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::num::NonZeroUsize;
@@ -420,6 +422,7 @@ mod tests {
             target_columns: NonemptyArc::new(["embedding"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: NonZeroUsize::new(3).unwrap().into(),
@@ -442,6 +445,7 @@ mod tests {
             target_columns: NonemptyArc::new(["content"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Fts(IndexOptionsFts::default()),
         }
@@ -533,6 +537,7 @@ mod tests {
                 target_columns: NonemptyArc::new(["embedding"]).unwrap(),
                 partitioning: DbIndexPartitioning::Global,
                 filtering_columns: Arc::new([]),
+                alternator_attribute_types: Arc::new(BTreeMap::new()),
                 kind: DbIndexKind::VectorSearch,
             }
         }
@@ -594,6 +599,7 @@ mod tests {
                         target_columns: idx.target_columns.clone(),
                         partitioning: DbIndexPartitioning::Global,
                         filtering_columns: Arc::new([]),
+                        alternator_attribute_types: Arc::new(BTreeMap::new()),
                         kind: idx.kind,
                     })
                     .collect()
@@ -792,6 +798,7 @@ mod tests {
                         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
                         partitioning: DbIndexPartitioning::Global,
                         filtering_columns: Arc::new([]),
+                        alternator_attribute_types: Arc::new(BTreeMap::new()),
                         kind: DbIndexKind::VectorSearch,
                     };
                     tx.send(Ok(vec![index(), index(), index()])).unwrap();
@@ -878,6 +885,7 @@ mod tests {
                     target_columns: NonemptyArc::new(["embedding"]).unwrap(),
                     partitioning: DbIndexPartitioning::Global,
                     filtering_columns: Arc::new([]),
+                    alternator_attribute_types: Arc::new(BTreeMap::new()),
                     kind: DbIndexKind::VectorSearch,
                 }]))
                 .unwrap();
@@ -902,20 +910,24 @@ mod tests {
     fn mock_db_with_fts_index(options: Option<IndexOptionsFts>) -> MockSimDb {
         let mut mock_db = MockSimDb::new();
 
-        mock_db.expect_get_indexes().returning(move |tx| {
-            async move {
-                tx.send(Ok(vec![DbCustomIndex {
-                    keyspace: "ks".to_string().into(),
-                    index: "fts_idx".to_string().into(),
-                    table: "tbl".to_string().into(),
-                    primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
-                    partition_key_count: NonZeroUsize::new(1).unwrap(),
-                    target_columns: NonemptyArc::new(["content"]).unwrap(),
-                    partitioning: DbIndexPartitioning::Global,
-                    filtering_columns: Arc::new([]),
-                    kind: DbIndexKind::FullTextSearch,
-                }]))
-                .unwrap();
+        mock_db.expect_get_indexes().returning({
+            move |tx| {
+                async move {
+                    tx.send(Ok(vec![DbCustomIndex {
+                        keyspace: "ks".to_string().into(),
+                        index: "fts_idx".to_string().into(),
+                        table: "tbl".to_string().into(),
+                        primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+                        partition_key_count: NonZeroUsize::new(1).unwrap(),
+                        target_columns: NonemptyArc::new(["content"]).unwrap(),
+                        partitioning: DbIndexPartitioning::Global,
+                        filtering_columns: Arc::new([]),
+                        alternator_attribute_types: Arc::new(BTreeMap::new()),
+                        kind: DbIndexKind::FullTextSearch,
+                    }]))
+                    .unwrap();
+                }
+                .boxed()
             }
             .boxed()
         });

--- a/crates/vector-store/src/node_state.rs
+++ b/crates/vector-store/src/node_state.rs
@@ -237,6 +237,7 @@ mod tests {
     use crate::KeyspaceName;
     use crate::NonemptyArc;
     use crate::TableName;
+    use std::collections::BTreeMap;
     use std::num::NonZeroUsize;
     use std::sync::Arc;
     use uuid::Uuid;
@@ -251,6 +252,7 @@ mod tests {
             target_columns: NonemptyArc::new(["test_column"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),
@@ -577,6 +579,7 @@ mod tests {
             target_columns: NonemptyArc::new(["test_column"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),
@@ -670,6 +673,7 @@ mod tests {
             target_columns: NonemptyArc::new(["test_column"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -1137,6 +1137,18 @@ pub(crate) trait TableSearch {
         primary_id: PrimaryId,
         restriction: &Restriction,
     ) -> bool;
+
+    /// Return the stored values for the given filtering columns for a single
+    /// row identified by `primary_id`. Columns that have no stored value
+    /// (e.g. the attribute was absent when the row was indexed) are omitted
+    /// from the returned map. Returns an empty map when `columns` is empty
+    /// or the `primary_id` is invalid.
+    fn column_values_for(
+        &self,
+        partition_id: PartitionId,
+        primary_id: PrimaryId,
+        columns: &[ColumnName],
+    ) -> BTreeMap<ColumnName, CqlValue>;
 }
 
 impl TableSearch for Table {
@@ -1273,6 +1285,27 @@ impl TableSearch for Table {
                     .is_some_and(|ord| ord.is_ge())
             }
         }
+    }
+
+    #[hotpath::measure]
+    fn column_values_for(
+        &self,
+        partition_id: PartitionId,
+        primary_id: PrimaryId,
+        columns: &[ColumnName],
+    ) -> BTreeMap<ColumnName, CqlValue> {
+        if !self.is_valid_primary_id(partition_id, primary_id) {
+            return BTreeMap::new();
+        }
+        columns
+            .iter()
+            .filter_map(|col_name| {
+                self.columns
+                    .get(col_name)
+                    .and_then(|col| col.get(primary_id, &self.primary_keys))
+                    .map(|value| (col_name.clone(), value))
+            })
+            .collect()
     }
 }
 

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -1686,6 +1686,131 @@ mod tests {
         }
     }
 
+    /// A local index can declare a filtering column ("ck") that is also one
+    /// of the base table's primary-key columns. Such a column gets its value
+    /// from the primary key, not from a fetched row value. This test upserts
+    /// a row for such an index and checks that the target vector and the
+    /// other filtering column ("f") end up with the correct values - i.e.
+    /// that "ck" being both a primary-key and a filtering column doesn't
+    /// shift values onto the wrong columns.
+    #[test]
+    fn local_index_filtering_on_primary_key_column_stays_aligned() {
+        use crate::DbIndexPartitioning;
+        use crate::Dimensions;
+        use crate::IndexKind;
+        use crate::IndexMetadata;
+        use crate::IndexOptionsVs;
+        use uuid::Uuid;
+
+        let metadata = IndexMetadata {
+            keyspace_name: "ks".into(),
+            index_name: "idx".into(),
+            table_name: "tbl".into(),
+            // The base table's primary key: "pk" is the partition key, "ck"
+            // a clustering key.
+            primary_key_columns: NonemptyArc::new(["pk", "ck"]).unwrap(),
+            partition_key_count: NonZeroUsize::new(1).unwrap(),
+            target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+            // The local index is partitioned by "pk" alone, so "ck" is not
+            // part of its own partition key either.
+            partitioning: DbIndexPartitioning::Local(NonemptyArc::new(["pk"]).unwrap()),
+            // Declares "ck" (a primary-key column) and "f" (a genuine value
+            // column) as filtering columns.
+            filtering_columns: Arc::new(["ck".into(), "f".into()]),
+            alternator_attribute_types: Default::default(),
+            version: Uuid::new_v4().into(),
+            kind: IndexKind::Vs(IndexOptionsVs {
+                dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),
+                connectivity: Default::default(),
+                expansion_add: Default::default(),
+                expansion_search: Default::default(),
+                space_type: Default::default(),
+                quantization: Default::default(),
+            }),
+        };
+
+        let partition_key_columns = match &metadata.partitioning {
+            DbIndexPartitioning::Local(columns) => Some(columns.clone()),
+            DbIndexPartitioning::Global => None,
+        };
+        let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
+        assert_eq!(filtering_columns.as_ref(), &["f".into()]);
+
+        let index_key = IndexKey::new(&metadata.keyspace_name, &metadata.index_name);
+        let mut table = Table::new(
+            index_key.clone(),
+            metadata.primary_key_columns.clone(),
+            metadata.partition_key_count,
+            partition_key_columns,
+            metadata.target_columns.len(),
+            filtering_columns,
+            Arc::new(
+                [
+                    ("pk".into(), NativeType::Int),
+                    ("ck".into(), NativeType::Int),
+                    ("f".into(), NativeType::Int),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        )
+        .unwrap();
+
+        // A row fetched by the real pipeline: a value for the target vector,
+        // then a value for each *non*-primary-key filtering column - "ck"
+        // has no value of its own here, matching db_index.rs/db_cdc.
+        let primary_key: PrimaryKey = [CqlValue::Int(1), CqlValue::Int(2)].into();
+        let values = NonemptyBox::<Timestamped<DbIndexedValue>>::new([
+            Timestamped::new(
+                Timestamp::from_millis(100),
+                Some(DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into())),
+            ),
+            Timestamped::new(
+                Timestamp::from_millis(100),
+                Some(DbIndexedValue::Filtering(CqlValue::Int(42))),
+            ),
+        ])
+        .unwrap();
+
+        let operations = table
+            .upsert(&index_key, primary_key.clone(), values)
+            .unwrap();
+        assert_eq!(operations.len(), 1);
+        let (primary_id, partition_id) = match operations.first().unwrap() {
+            Operation::AddVector {
+                primary_id,
+                partition_id,
+                vector,
+                is_update: false,
+            } => {
+                assert_eq!(vector, &vec![0.1, 0.2, 0.3].into());
+                (*primary_id, *partition_id)
+            }
+            _ => panic!("Expected AddVector operation"),
+        };
+
+        assert_eq!(
+            table.primary_key(partition_id, primary_id).unwrap(),
+            primary_key
+        );
+        assert!(table.is_valid_for(
+            partition_id,
+            primary_id,
+            &Restriction::Eq {
+                lhs: "ck".into(),
+                rhs: CqlValue::Int(2),
+            }
+        ));
+        assert!(table.is_valid_for(
+            partition_id,
+            primary_id,
+            &Restriction::Eq {
+                lhs: "f".into(),
+                rhs: CqlValue::Int(42),
+            }
+        ));
+    }
+
     #[test]
     fn global_add_remove_multiple_add() {
         let pk1 = PrimaryKey::from([CqlValue::Int(1)]);

--- a/crates/vector-store/src/vector.rs
+++ b/crates/vector-store/src/vector.rs
@@ -6,6 +6,10 @@
 use crate::Dimensions;
 use anyhow::anyhow;
 use anyhow::bail;
+use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::value::DeserializeValue;
 use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
 
@@ -59,6 +63,17 @@ impl TryFrom<CqlValue> for Vector {
     }
 }
 
+// Alternator type tags. These match `enum class alternator_type` in
+// alternator/serialization.hh - do not reorder, these values are written to
+// disk as part of the item encoding.
+/// String (S) values: tag followed by the raw UTF-8 bytes.
+const ALTERNATOR_TYPE_S: u8 = 0;
+/// Bytes (B) values: tag followed by the raw bytes, as-is.
+const ALTERNATOR_TYPE_B: u8 = 1;
+/// Number (N) values: tag followed by the same wire encoding CQL's native
+/// `decimal` type uses (a 4-byte big-endian scale followed by a
+/// variable-length signed big-endian magnitude).
+const ALTERNATOR_TYPE_N: u8 = 3;
 /// Alternator type tag for unoptimized JSON encoding.
 /// Type `0x04` (`NOT_SUPPORTED_YET`) is used for any type that does not have an optimized encoding.
 /// The payload is an unoptimized JSON value.
@@ -68,6 +83,39 @@ const ALTERNATOR_TYPE_JSON: u8 = 4;
 /// The value is serialized as this 1-byte tag followed by sequential 32-bit big-endian floats,
 /// matching the CQL `VECTOR<float, N>` on-wire encoding.
 const ALTERNATOR_TYPE_FLOAT32VECTOR: u8 = 5;
+
+/// Decodes an Alternator-encoded scalar attribute value (a filtering or
+/// partition-key column with no real CQL column) into the `CqlValue`
+/// matching `native_type`. Like the vector column above, the value is
+/// tagged; this checks the tag matches `native_type` and re-deserializes
+/// the rest via the CQL driver, rather than reimplementing e.g. decimal
+/// parsing here.
+pub(crate) fn parse_alternator_scalar(
+    bytes: &[u8],
+    native_type: &NativeType,
+) -> anyhow::Result<CqlValue> {
+    let expected_tag = match native_type {
+        NativeType::Text | NativeType::Ascii => ALTERNATOR_TYPE_S,
+        NativeType::Blob => ALTERNATOR_TYPE_B,
+        NativeType::Decimal => ALTERNATOR_TYPE_N,
+        other => bail!(
+            "unsupported native type {other:?} for an Alternator filtering/partition-key attribute"
+        ),
+    };
+    let Some((&tag, payload)) = bytes.split_first() else {
+        bail!("empty blob for Alternator attribute value");
+    };
+    if tag != expected_tag {
+        bail!(
+            "Alternator attribute value has type tag {tag:#04x}, but column is declared as \
+            {native_type:?} (expected tag {expected_tag:#04x})"
+        );
+    }
+    let column_type = ColumnType::Native(native_type.clone());
+    CqlValue::deserialize(&column_type, Some(FrameSlice::new_borrowed(payload))).map_err(|err| {
+        anyhow!("failed to decode Alternator attribute value as {native_type:?}: {err}")
+    })
+}
 
 /// Parses an Alternator-encoded vector stored as raw bytes.
 ///
@@ -131,6 +179,7 @@ fn parse_alternator_list_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scylla::value::CqlDecimal;
 
     /// Prepend the [`ALTERNATOR_TYPE_JSON`] tag to a DynamoDB JSON string,
     /// mirroring how Alternator serialises List values.
@@ -229,5 +278,66 @@ mod tests {
         bytes.extend_from_slice(&[0x00, 0x01, 0x02, 0x03, 0x04]);
         let value = CqlValue::Blob(bytes);
         assert!(Vector::try_from(value).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_text() {
+        let mut bytes = vec![ALTERNATOR_TYPE_S];
+        bytes.extend_from_slice(b"hello");
+        let result = parse_alternator_scalar(&bytes, &NativeType::Text).unwrap();
+        assert_eq!(result, CqlValue::Text("hello".to_string()));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_blob() {
+        let mut bytes = vec![ALTERNATOR_TYPE_B];
+        bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let result = parse_alternator_scalar(&bytes, &NativeType::Blob).unwrap();
+        assert_eq!(result, CqlValue::Blob(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_number() {
+        // 123 encoded as unscaled magnitude 0x7B with scale 0.
+        let decimal = CqlDecimal::from_signed_be_bytes_and_exponent(vec![0x7B], 0);
+        let (varint_bytes, scale) = decimal.as_signed_be_bytes_slice_and_exponent();
+        let mut bytes = vec![ALTERNATOR_TYPE_N];
+        bytes.extend_from_slice(&scale.to_be_bytes());
+        bytes.extend_from_slice(varint_bytes);
+        let result = parse_alternator_scalar(&bytes, &NativeType::Decimal).unwrap();
+        assert_eq!(result, CqlValue::Decimal(decimal));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_empty() {
+        assert!(parse_alternator_scalar(&[], &NativeType::Text).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_mismatched_tag() {
+        // Tagged as a string (S), but the column is declared as Blob (B).
+        let mut bytes = vec![ALTERNATOR_TYPE_S];
+        bytes.extend_from_slice(b"hello");
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Blob).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_malformed_number() {
+        // Tag matches, but only 2 bytes follow - not enough for the 4-byte scale.
+        let bytes = vec![ALTERNATOR_TYPE_N, 0x00, 0x00];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Decimal).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_malformed_text() {
+        // Tag matches, but the payload is not valid UTF-8.
+        let bytes = vec![ALTERNATOR_TYPE_S, 0xFF, 0xFE];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Text).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_unsupported_native_type() {
+        let bytes = vec![ALTERNATOR_TYPE_S, b'x'];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Int).is_err());
     }
 }

--- a/crates/vector-store/src/vs_index/actor.rs
+++ b/crates/vector-store/src/vs_index/actor.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::AsyncInProgress;
+use crate::ColumnName;
 use crate::Distance;
 use crate::Filter;
 use crate::IndexKey;
@@ -12,10 +13,17 @@ use crate::PrimaryKey;
 use crate::Vector;
 use crate::table::PartitionId;
 use crate::table::PrimaryId;
+use scylla::value::CqlValue;
+use std::collections::BTreeMap;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
-pub(crate) type AnnR = anyhow::Result<(Vec<PrimaryKey>, Vec<Distance>)>;
+pub(crate) type AnnR = anyhow::Result<(
+    Vec<PrimaryKey>,
+    Vec<Distance>,
+    Vec<BTreeMap<ColumnName, CqlValue>>,
+)>;
 pub(crate) type CountR = anyhow::Result<usize>;
 
 pub enum VsIndexModify {
@@ -40,6 +48,7 @@ pub enum VsIndexSearch {
         index_key: IndexKey,
         embedding: Vector,
         limit: Limit,
+        return_columns: Arc<[ColumnName]>,
         tx: oneshot::Sender<AnnR>,
     },
     FilteredAnn {
@@ -47,6 +56,7 @@ pub enum VsIndexSearch {
         embedding: Vector,
         filter: Filter,
         limit: Limit,
+        return_columns: Arc<[ColumnName]>,
         tx: oneshot::Sender<AnnR>,
     },
     Count {
@@ -78,13 +88,20 @@ pub(crate) trait VsIndexModifyExt {
 }
 
 pub(crate) trait VsIndexSearchExt {
-    async fn ann(&self, index_key: IndexKey, embedding: Vector, limit: Limit) -> AnnR;
+    async fn ann(
+        &self,
+        index_key: IndexKey,
+        embedding: Vector,
+        limit: Limit,
+        return_columns: Arc<[ColumnName]>,
+    ) -> AnnR;
     async fn filtered_ann(
         &self,
         index_key: IndexKey,
         embedding: Vector,
         filter: Filter,
         limit: Limit,
+        return_columns: Arc<[ColumnName]>,
     ) -> AnnR;
     async fn count(&self, index_key: IndexKey) -> CountR;
 }
@@ -134,12 +151,19 @@ impl VsIndexModifyExt for mpsc::Sender<VsIndexModify> {
 
 impl VsIndexSearchExt for mpsc::Sender<VsIndexSearch> {
     #[hotpath::measure]
-    async fn ann(&self, index_key: IndexKey, embedding: Vector, limit: Limit) -> AnnR {
+    async fn ann(
+        &self,
+        index_key: IndexKey,
+        embedding: Vector,
+        limit: Limit,
+        return_columns: Arc<[ColumnName]>,
+    ) -> AnnR {
         let (tx, rx) = oneshot::channel();
         self.send(VsIndexSearch::Ann {
             index_key,
             embedding,
             limit,
+            return_columns,
             tx,
         })
         .await?;
@@ -153,6 +177,7 @@ impl VsIndexSearchExt for mpsc::Sender<VsIndexSearch> {
         embedding: Vector,
         filter: Filter,
         limit: Limit,
+        return_columns: Arc<[ColumnName]>,
     ) -> AnnR {
         let (tx, rx) = oneshot::channel();
         self.send(VsIndexSearch::FilteredAnn {
@@ -160,6 +185,7 @@ impl VsIndexSearchExt for mpsc::Sender<VsIndexSearch> {
             embedding,
             filter,
             limit,
+            return_columns,
             tx,
         })
         .await?;

--- a/crates/vector-store/src/vs_index/diskann/mod.rs
+++ b/crates/vector-store/src/vs_index/diskann/mod.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+use crate::ColumnName;
 use crate::Config;
 use crate::Dimensions;
 use crate::DiskannAlpha;
@@ -48,7 +49,6 @@ use diskann::provider::DataProvider;
 use diskann::provider::Delete;
 use diskann::provider::SetElement;
 use diskann_vector::distance::Metric;
-use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::num::NonZeroUsize;
@@ -255,16 +255,17 @@ where
             index_key,
             embedding,
             limit,
+            return_columns,
             tx,
         }) => {
             let Some((partition_id, _)) = table.read().unwrap().partition_id(&index_key, None)
             else {
                 warn!("partition id not found for index key {index_key} during ann");
-                _ = tx.send(Ok((vec![], vec![])));
+                _ = tx.send(Ok((vec![], vec![], vec![])));
                 return None;
             };
             let Some(partition) = partitions.get(&partition_id).cloned() else {
-                _ = tx.send(Ok((vec![], vec![])));
+                _ = tx.send(Ok((vec![], vec![], vec![])));
                 return None;
             };
             let size = Arc::clone(sizes.entry(partition_id.index_id()).or_default());
@@ -275,6 +276,7 @@ where
                     index_key,
                     embedding,
                     limit,
+                    return_columns,
                     tx,
                 }),
             ))
@@ -370,6 +372,7 @@ async fn process<T, B>(
         Message::Search(VsIndexSearch::Ann {
             embedding,
             limit,
+            return_columns,
             tx,
             ..
         }) => {
@@ -382,6 +385,7 @@ async fn process<T, B>(
                         &params,
                         embedding,
                         limit,
+                        return_columns,
                     )
                     .await,
                 );
@@ -493,6 +497,7 @@ async fn ann<T, B>(
     params: &DiskannParams,
     embedding: Vector,
     limit: Limit,
+    return_columns: Arc<[ColumnName]>,
 ) -> AnnR
 where
     T: TableSearch + Send + Sync + 'static,
@@ -504,22 +509,28 @@ where
 
     let partition_id = partition.partition_id;
     let table = table.read().unwrap();
-    let (primary_keys, distances) = itertools::process_results(
-        matches.filter_map_ok(|(primary_id, distance)| {
-            table
-                .primary_key(partition_id, primary_id)
-                .or_else(|| {
-                    debug!(
-                        "not defined primary key for partition_id {partition_id:?} \
-                                    and primary_id {primary_id:?}",
-                    );
-                    None
-                })
-                .map(|primary_key| (primary_key, distance))
-        }),
-        |it| it.unzip(),
-    )?;
-    Ok((primary_keys, distances))
+    let mut primary_keys = Vec::new();
+    let mut distances = Vec::new();
+    let mut column_values_vec = Vec::new();
+    for result in matches {
+        let (primary_id, distance) = result?;
+        let Some(primary_key) = table.primary_key(partition_id, primary_id) else {
+            debug!(
+                "not defined primary key for partition_id {partition_id:?} \
+                            and primary_id {primary_id:?}",
+            );
+            continue;
+        };
+        let col_vals = if return_columns.is_empty() {
+            BTreeMap::new()
+        } else {
+            table.column_values_for(partition_id, primary_id, &return_columns)
+        };
+        primary_keys.push(primary_key);
+        distances.push(distance);
+        column_values_vec.push(col_vals);
+    }
+    Ok((primary_keys, distances, column_values_vec))
 }
 
 #[hotpath::measure]

--- a/crates/vector-store/src/vs_index/opensearch.rs
+++ b/crates/vector-store/src/vs_index/opensearch.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::Connectivity;
 use crate::Dimensions;
 use crate::Distance;
@@ -297,11 +298,20 @@ async fn process(
         Message::Search(VsIndexSearch::Ann {
             embedding,
             limit,
+            return_columns,
             tx,
             ..
         }) => {
             ann(
-                index_key, tx, embedding, dimensions, limit, space_type, table, client,
+                index_key,
+                tx,
+                embedding,
+                dimensions,
+                limit,
+                space_type,
+                return_columns,
+                table,
+                client,
             )
             .await
         }
@@ -362,6 +372,7 @@ async fn ann(
     dimensions: Dimensions,
     limit: Limit,
     space_type: SpaceType,
+    return_columns: Arc<[ColumnName]>,
     table: Arc<RwLock<impl TableSearch>>,
     client: Arc<OpenSearch>,
 ) {
@@ -419,7 +430,7 @@ async fn ann(
     let index_id = IndexIdGenerator::new().next(true).unwrap();
     let partition_id = PartitionId::global(index_id);
 
-    let hits = {
+    let (keys, scores, column_values_vec) = {
         let table = table.read().unwrap();
         hits.unwrap()
             .iter()
@@ -428,12 +439,16 @@ async fn ann(
                 let score = hit["_score"].as_f64().unwrap();
                 let primary_id = PrimaryId::from(id.parse::<u64>().unwrap());
                 let primary_key = table.primary_key(partition_id, primary_id).unwrap();
-                (primary_key, score)
+                let col_vals = if return_columns.is_empty() {
+                    Default::default()
+                } else {
+                    table.column_values_for(partition_id, primary_id, &return_columns)
+                };
+                (primary_key, score, col_vals)
             })
-            .collect::<Vec<_>>()
+            .collect::<(Vec<_>, Vec<_>, Vec<_>)>()
     };
 
-    let (keys, scores): (Vec<_>, Vec<_>) = hits.iter().cloned().unzip();
     let distances: anyhow::Result<Vec<_>> = scores
         .iter()
         .map(|score| Distance::try_from((*score as f32, space_type, Some(dimensions))))
@@ -447,7 +462,7 @@ async fn ann(
     };
 
     tx_ann
-        .send(Ok((keys, distances)))
+        .send(Ok((keys, distances, column_values_vec)))
         .unwrap_or_else(|_| trace!("ann: unable to send response"));
 }
 

--- a/crates/vector-store/src/vs_index/usearch.rs
+++ b/crates/vector-store/src/vs_index/usearch.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::Config;
 use crate::Dimensions;
 use crate::Distance;
@@ -32,7 +33,6 @@ use crate::vs_index::validator;
 use crate::worker::Worker;
 use crate::worker::WorkerExt;
 use anyhow::anyhow;
-use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -782,12 +782,13 @@ where
             index_key,
             embedding,
             limit,
+            return_columns,
             tx,
         }) => {
             let Some((partition_id, _)) = table.read().unwrap().partition_id(&index_key, None)
             else {
                 warn!("partition id not found for index key {index_key:?} during ann");
-                _ = tx.send(Ok((vec![], vec![])));
+                _ = tx.send(Ok((vec![], vec![], vec![])));
                 return None;
             };
             let index_id = partition_id.index_id();
@@ -797,7 +798,7 @@ where
                 .map(|(state, partition)| (state, Arc::clone(partition)))
             else {
                 warn!("state or partition not found for index key {index_key:?} during ann");
-                _ = tx.send(Ok((vec![], vec![])));
+                _ = tx.send(Ok((vec![], vec![], vec![])));
                 return None;
             };
             Some((
@@ -806,6 +807,7 @@ where
                 Message::Search(VsIndexSearch::Ann {
                     embedding,
                     limit,
+                    return_columns,
                     tx,
                     index_key,
                 }),
@@ -817,6 +819,7 @@ where
             embedding,
             filter,
             limit,
+            return_columns,
             tx,
         }) => {
             let Some((partition_id, restrictions)) = table
@@ -825,7 +828,7 @@ where
                 .partition_id(&index_key, Some(filter.restrictions))
             else {
                 debug!("partition id not found for index key {index_key:?} during filtered ann");
-                _ = tx.send(Ok((vec![], vec![])));
+                _ = tx.send(Ok((vec![], vec![], vec![])));
                 return None;
             };
             let index_id = partition_id.index_id();
@@ -838,7 +841,7 @@ where
                     "state or partition not found for index key {index_key:?} \
                         during filtered ann"
                 );
-                _ = tx.send(Ok((vec![], vec![])));
+                _ = tx.send(Ok((vec![], vec![], vec![])));
                 return None;
             };
             let msg = if let Some(restrictions) = restrictions {
@@ -849,6 +852,7 @@ where
                         restrictions,
                         allow_filtering: filter.allow_filtering,
                     },
+                    return_columns,
                     tx,
                     index_key,
                 }
@@ -856,6 +860,7 @@ where
                 VsIndexSearch::Ann {
                     embedding,
                     limit,
+                    return_columns,
                     tx,
                     index_key,
                 }
@@ -969,11 +974,12 @@ fn process<I, T>(
         Message::Search(VsIndexSearch::Ann {
             embedding,
             limit,
+            return_columns,
             tx,
             ..
         }) => {
             if let Some(tx) = validate_dimensions(tx, &embedding, dimensions) {
-                ann(partition, tx, &table, embedding, limit);
+                ann(partition, tx, &table, embedding, limit, return_columns);
             }
         }
 
@@ -981,11 +987,20 @@ fn process<I, T>(
             embedding,
             limit,
             filter,
+            return_columns,
             tx,
             ..
         }) => {
             if let Some(tx) = validate_dimensions(tx, &embedding, dimensions) {
-                filtered_ann(partition, tx, &table, embedding, filter, limit);
+                filtered_ann(
+                    partition,
+                    tx,
+                    &table,
+                    embedding,
+                    filter,
+                    limit,
+                    return_columns,
+                );
             }
         }
 
@@ -1071,6 +1086,7 @@ fn ann<I>(
     table: &Arc<RwLock<impl TableSearch>>,
     embedding: Vector,
     limit: Limit,
+    return_columns: Arc<[ColumnName]>,
 ) where
     I: UsearchIndex + Send + Sync + 'static,
 {
@@ -1082,23 +1098,35 @@ fn ann<I>(
                 .map_err(|err| anyhow!("ann: search failed: {err}"))
                 .and_then(|matches| {
                     let table = table.read().unwrap();
-                    let (primary_keys, distances) = itertools::process_results(
-                        matches.filter_map_ok(|(primary_id, distance)| {
-                            table
-                                .primary_key(partition.partition_id, primary_id)
-                                .or_else(|| {
-                                    debug!(
-                                        "not defined primary key for partition_id {partition_id:?} \
-                                        and primary_id {primary_id:?}",
-                                        partition_id = partition.partition_id,
-                                    );
-                                    None
-                                })
-                                .map(|primary_key| (primary_key, distance))
-                        }),
-                        |it| it.unzip(),
-                    )?;
-                    Ok((primary_keys, distances))
+                    let mut primary_keys = Vec::new();
+                    let mut distances = Vec::new();
+                    let mut column_values_vec = Vec::new();
+                    for result in matches {
+                        let (primary_id, distance) = result?;
+                        let Some(primary_key) =
+                            table.primary_key(partition.partition_id, primary_id)
+                        else {
+                            debug!(
+                                "not defined primary key for partition_id {partition_id:?} \
+                                and primary_id {primary_id:?}",
+                                partition_id = partition.partition_id,
+                            );
+                            continue;
+                        };
+                        let col_vals = if return_columns.is_empty() {
+                            BTreeMap::new()
+                        } else {
+                            table.column_values_for(
+                                partition.partition_id,
+                                primary_id,
+                                &return_columns,
+                            )
+                        };
+                        primary_keys.push(primary_key);
+                        distances.push(distance);
+                        column_values_vec.push(col_vals);
+                    }
+                    Ok((primary_keys, distances, column_values_vec))
                 }),
         )
         .unwrap_or_else(|_| trace!("ann: unable to send response"));
@@ -1112,6 +1140,7 @@ fn filtered_ann<I>(
     embedding: Vector,
     filter: Filter,
     limit: Limit,
+    return_columns: Arc<[ColumnName]>,
 ) where
     I: UsearchIndex + Send + Sync + 'static,
 {
@@ -1131,23 +1160,35 @@ fn filtered_ann<I>(
                 .map_err(|err| anyhow!("ann: search failed: {err}"))
                 .and_then(|matches| {
                     let table = table.read().unwrap();
-                    let (primary_keys, distances) = itertools::process_results(
-                        matches.filter_map_ok(|(primary_id, distance)| {
-                            table
-                                .primary_key(partition.partition_id, primary_id)
-                                .or_else(|| {
-                                    debug!(
-                                        "not defined primary key for partition_id {partition_id:?} \
-                                        and primary_id {primary_id:?}",
-                                        partition_id = partition.partition_id,
-                                    );
-                                    None
-                                })
-                                .map(|primary_key| (primary_key, distance))
-                        }),
-                        |it| it.unzip(),
-                    )?;
-                    Ok((primary_keys, distances))
+                    let mut primary_keys = Vec::new();
+                    let mut distances = Vec::new();
+                    let mut column_values_vec = Vec::new();
+                    for result in matches {
+                        let (primary_id, distance) = result?;
+                        let Some(primary_key) =
+                            table.primary_key(partition.partition_id, primary_id)
+                        else {
+                            debug!(
+                                "not defined primary key for partition_id {partition_id:?} \
+                                and primary_id {primary_id:?}",
+                                partition_id = partition.partition_id,
+                            );
+                            continue;
+                        };
+                        let col_vals = if return_columns.is_empty() {
+                            BTreeMap::new()
+                        } else {
+                            table.column_values_for(
+                                partition.partition_id,
+                                primary_id,
+                                &return_columns,
+                            )
+                        };
+                        primary_keys.push(primary_key);
+                        distances.push(distance);
+                        column_values_vec.push(col_vals);
+                    }
+                    Ok((primary_keys, distances, column_values_vec))
                 }),
         )
         .unwrap_or_else(|_| trace!("ann: unable to send response"));
@@ -1274,6 +1315,7 @@ mod tests {
                             index_key.clone(),
                             vec![0.0f32; dimensions.get()].into(),
                             limit,
+                            Arc::new([]),
                         )
                         .await;
                 }
@@ -1373,11 +1415,12 @@ mod tests {
             .once()
             .returning(|_, _| Some([CqlValue::Int(2)].into()));
 
-        let (primary_keys, distances) = search
+        let (primary_keys, distances, _) = search
             .ann(
                 index_key.clone(),
                 vec![2.2, -2.2, 2.2].into(),
                 NonZeroUsize::new(1).unwrap().into(),
+                Arc::new([]),
             )
             .await
             .unwrap();
@@ -1415,6 +1458,7 @@ mod tests {
                     index_key.clone(),
                     vec![2.2, -2.2, 2.2].into(),
                     NonZeroUsize::new(1).unwrap().into(),
+                    Arc::new([]),
                 )
                 .await
                 .unwrap()
@@ -1444,11 +1488,12 @@ mod tests {
             .once()
             .returning(|_, _| Some([CqlValue::Int(2)].into()));
 
-        let (primary_keys, distances) = search
+        let (primary_keys, distances, _) = search
             .ann(
                 index_key,
                 vec![2.2, -2.2, 2.2].into(),
                 NonZeroUsize::new(1).unwrap().into(),
+                Arc::new([]),
             )
             .await
             .unwrap();

--- a/crates/vector-store/tests/integration/common.rs
+++ b/crates/vector-store/tests/integration/common.rs
@@ -142,6 +142,7 @@ pub(crate) fn make_index_with_kind(
             .iter()
             .map(|s| ColumnName::from(*s))
             .collect(),
+        alternator_attribute_types: Default::default(),
         version: version.into(),
         kind,
     }

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -357,6 +357,10 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
                                 target_columns: index.metadata.target_columns.clone(),
                                 partitioning: index.metadata.partitioning.clone(),
                                 filtering_columns: index.metadata.filtering_columns.clone(),
+                                alternator_attribute_types: index
+                                    .metadata
+                                    .alternator_attribute_types
+                                    .clone(),
                                 kind: match index.metadata.kind {
                                     IndexKind::Vs(_) => DbIndexKind::VectorSearch,
                                     IndexKind::Fts(_) => DbIndexKind::FullTextSearch,

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -48,6 +48,7 @@ fn fts_index_metadata(primary_key_columns: impl IntoIterator<Item = ColumnName>)
         target_columns: NonemptyArc::new(["content"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Fts(IndexOptionsFts::default()),
     }

--- a/crates/vector-store/tests/integration/https.rs
+++ b/crates/vector-store/tests/integration/https.rs
@@ -100,6 +100,7 @@ async fn test_https_server_responds() {
             filter: None,
             limit: NonZeroUsize::new(1).unwrap().into(),
             routing: true,
+            return_columns: vec![],
         })
         .send()
         .await
@@ -113,6 +114,7 @@ async fn test_https_server_responds() {
             filter: None,
             limit: NonZeroUsize::new(1).unwrap().into(),
             routing: true,
+            return_columns: vec![],
         })
         .send()
         .await

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -63,6 +63,7 @@ async fn memory_limit_during_index_build() {
         target_columns: NonemptyArc::new(["v"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(3).unwrap().into(),

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -41,6 +41,7 @@ async fn simple_create_search_delete_index() {
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(3).unwrap().into(),

--- a/crates/vector-store/tests/integration/routing.rs
+++ b/crates/vector-store/tests/integration/routing.rs
@@ -83,6 +83,7 @@ async fn post_ann_without_routing(client: &HttpClient, index: &IndexMetadata) ->
                 filter: None,
                 limit: NonZeroUsize::new(ANN_LIMIT).unwrap().into(),
                 routing: false,
+                return_columns: vec![],
             },
         )
         .await

--- a/crates/vector-store/tests/integration/vs_index.rs
+++ b/crates/vector-store/tests/integration/vs_index.rs
@@ -127,6 +127,7 @@ pub(crate) async fn setup_store_with_quantization(
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning,
         filtering_columns,
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: dimension,
@@ -329,6 +330,7 @@ async fn failed_db_index_create(#[case] config: Config) {
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(3).unwrap().into(),
@@ -1764,6 +1766,7 @@ async fn similarity_scores_are_decreasing_and_correctly_converted(#[case] config
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(1).unwrap().into(),


### PR DESCRIPTION
Alternator's new DynamoDB Vector Search "SearchSchema" parameters asks a vector index use certain attributes as partition-key/filtering columns even when they have no real CQL column (their value lives only in the ":attrs"
map). 

These three patches make that work end to end:

```
vector-store: allow local/filtered indexes on Alternator tables
```
Stop requiring pk/fc columns to be real CQL columns when the table is an Alternator table.

```
vector-store: fix column/value misalignment for local indexes filtering on a primary-key column
```
Pre-existing bug, not Alternator-specific: two places computed slightly different "filtering columns" lists, which could silently corrupt data when a filtering column was also a primary-key column. This scenario just happens to be exercised by SearchSchema when filtering on a primary key column.

```
vector-store: support Alternator's virtual SearchSchema filtering/partition-key columns
```
Add a way to learn the DynamoDB type of a virtual column and decode its
tagged raw value, so it can actually be stored and filtered on.

Patch 1 lets the index be created, patch 2 fixes a bug that one test exposed, and patch 3 supplies the missing type info to read the values correctly.

All three are needed for SearchSchema filtering to work correctly.

