### PR TITLE
vector-store: support inet primary keys and stop panicking on unsupported types

### DIFF
--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -8,6 +8,7 @@ use crate::common::*;
 use httpapi::KeyspaceName;
 use scylla::client::session::Session;
 use std::collections::HashSet;
+use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::info;
 
@@ -299,6 +300,96 @@ async fn ann_filter_by_clustering_key_gt(actors: Arc<TestActors>) {
         .collect();
 
     assert_eq!(cks, HashSet::from([8, 9]));
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_inet_clustering_key_gt(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, ck INET, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk, ck)",
+        None,
+    )
+    .await;
+
+    let addrs = [
+        "0.0.0.0",
+        "10.0.0.1",
+        "255.255.255.255",
+        "::",
+        "::1",
+        "2001:db8::1",
+    ];
+    for (idx, addr) in addrs.iter().enumerate() {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, ck, v) VALUES (0, '{addr}', ?)"),
+                (&vec![idx as f32, 0.0, 0.0],),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(
+            index_status.count,
+            addrs.len(),
+            "Expected every address to be indexed"
+        );
+    }
+
+    // ScyllaDB owns the ordering, so take the expected rows from a plain query.
+    let expected: HashSet<IpAddr> = get_query_results(
+        format!("SELECT ck FROM {table} WHERE pk = 0 AND ck > '::'"),
+        &session,
+    )
+    .await
+    .rows::<(IpAddr,)>()
+    .expect("failed to get rows")
+    .map(|row| row.expect("failed to get row").0)
+    .collect();
+
+    assert!(
+        expected.iter().any(|addr| addr.is_ipv4()) && expected.iter().any(|addr| addr.is_ipv6()),
+        "Expected both address families above '::', got: {expected:?}"
+    );
+
+    let result: HashSet<IpAddr> = wait_for_value(
+        || async {
+            let result = get_opt_query_results(
+                format!(
+                    "SELECT ck FROM {table} WHERE pk = 0 AND ck > '::' \
+                    ORDER BY v ANN OF [-1.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+                ),
+                &session,
+            )
+            .await;
+            result.filter(|result| result.rows_num() == expected.len())
+        },
+        "Waiting for the inet filtered ANN query to return every matching row",
+        DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await
+    .rows::<(IpAddr,)>()
+    .expect("failed to get rows")
+    .map(|row| row.expect("failed to get row").0)
+    .collect();
+
+    assert_eq!(result, expected);
 
     session
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())

--- a/crates/validator/src/index_create.rs
+++ b/crates/validator/src/index_create.rs
@@ -283,3 +283,84 @@ async fn local_index_based_on_f_columns(actors: Arc<TestActors>) {
 
     info!("finished");
 }
+
+/// Test that an index on a table with a primary key type the service cannot represent is skipped.
+/// Serving such an index would fail every query. Discovery must drop it and keep serving the other indexes.
+#[e2etest::test(group = index_create)]
+async fn index_with_unsupported_primary_key_type_is_skipped(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = common::prepare_connection(&actors).await;
+    let keyspace = common::create_keyspace(&session).await;
+
+    info!("Create an index on a table with an unsupported primary key type");
+    let unsupported_table = common::create_table(
+        &session,
+        "pk FROZEN<TUPLE<INT, INT>> PRIMARY KEY, v VECTOR<FLOAT, 3>",
+        None,
+    )
+    .await;
+    let unsupported_index = common::unique_index_name();
+    session
+        .query_unpaged(
+            format!(
+                "CREATE CUSTOM INDEX {unsupported_index} ON {unsupported_table}(v) \
+                USING 'vector_index'"
+            ),
+            (),
+        )
+        .await
+        .expect("failed to create an index");
+
+    // Discovery reads `system_schema.indexes`, so the skipped index must be there to be skipped.
+    common::wait_for(
+        || async {
+            common::get_query_results(
+                format!(
+                    "SELECT index_name FROM system_schema.indexes \
+                    WHERE keyspace_name = '{keyspace}' AND table_name = '{unsupported_table}' \
+                    AND index_name = '{unsupported_index}'"
+                ),
+                &session,
+            )
+            .await
+            .rows_num()
+                == 1
+        },
+        "the unsupported index to appear in system_schema.indexes",
+        common::DEFAULT_OPERATION_TIMEOUT,
+    )
+    .await;
+
+    info!("Create a valid index in the same keyspace");
+    let table =
+        common::create_table(&session, "pk INT PRIMARY KEY, v VECTOR<FLOAT, 3>", None).await;
+    let index = common::create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
+
+    // The valid index serves only after a discovery pass that already saw the skipped one.
+    wait_for_index(&clients, &index).await;
+
+    for client in &clients {
+        assert!(
+            !client
+                .indexes()
+                .await
+                .iter()
+                .any(|idx| idx.index == unsupported_index),
+            "Expected the unsupported index to be skipped at {url}",
+            url = client.url()
+        );
+        assert!(
+            client
+                .index_status(&keyspace, &unsupported_index)
+                .await
+                .is_err(),
+            "Expected no status for the skipped index at {url}",
+            url = client.url()
+        );
+    }
+
+    cleanup_keyspace(&actors, &keyspace).await;
+
+    info!("finished");
+}

--- a/crates/validator/src/serde.rs
+++ b/crates/validator/src/serde.rs
@@ -49,6 +49,7 @@ async fn test_serialization_deserialization_all_types(actors: Arc<TestActors>) {
         ("decimal", "-98765432109876543210.123456789"),
         ("double", "3.14159"),
         ("float", "2.71828"),
+        ("inet", "'10.0.0.1'"),
         ("int", "42"),
         ("smallint", "123"),
         ("tinyint", "7"),

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -8,6 +8,7 @@ use anyhow::bail;
 use bigdecimal::BigDecimal;
 use num_bigint::BigInt;
 use regex::Regex;
+use scylla::cluster::metadata::ColumnType;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlDecimal;
 use scylla::value::CqlDecimalBorrowed;
@@ -27,6 +28,31 @@ use time::Time;
 use time::format_description::well_known::Iso8601;
 use time::format_description::well_known::iso8601::Config;
 use time::format_description::well_known::iso8601::TimePrecision;
+
+pub(crate) const SUPPORTED: &[NativeType] = &[
+    NativeType::Ascii,
+    NativeType::BigInt,
+    NativeType::Blob,
+    NativeType::Boolean,
+    NativeType::Date,
+    NativeType::Decimal,
+    NativeType::Double,
+    NativeType::Float,
+    NativeType::Inet,
+    NativeType::Int,
+    NativeType::SmallInt,
+    NativeType::Text,
+    NativeType::Time,
+    NativeType::Timestamp,
+    NativeType::Timeuuid,
+    NativeType::TinyInt,
+    NativeType::Uuid,
+    NativeType::Varint,
+];
+
+pub(crate) fn is_supported(column_type: &ColumnType) -> bool {
+    matches!(column_type, ColumnType::Native(typ) if SUPPORTED.contains(typ))
+}
 
 pub(crate) fn to_json(value: CqlValue) -> anyhow::Result<Value> {
     match value {

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -79,7 +79,7 @@ pub(crate) fn to_json(value: CqlValue) -> anyhow::Result<Value> {
 
         CqlValue::Decimal(value) => Ok(Value::String(BigDecimal::from(value).to_string())),
 
-        _ => unimplemented!(),
+        _ => bail!("unsupported CQL type for a primary key column"),
     }
 }
 
@@ -283,7 +283,9 @@ pub(crate) fn cmp(lhs: &CqlValue, rhs: &CqlValue) -> Option<Ordering> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scylla::value::Counter;
     use scylla::value::CqlDecimal;
+    use scylla::value::CqlDuration;
     use uuid::Uuid;
 
     #[test]
@@ -408,6 +410,26 @@ mod tests {
             ))
             .unwrap(),
             Value::String("-98765432109876543210.123456789".to_string())
+        );
+
+        assert!(to_json(CqlValue::Counter(Counter(1))).is_err());
+        assert!(
+            to_json(CqlValue::Duration(CqlDuration {
+                months: 1,
+                days: 2,
+                nanoseconds: 3
+            }))
+            .is_err()
+        );
+        assert!(to_json(CqlValue::List(vec![CqlValue::Int(1)])).is_err());
+        assert!(to_json(CqlValue::Tuple(vec![Some(CqlValue::Int(1))])).is_err());
+        assert!(
+            to_json(CqlValue::UserDefinedType {
+                keyspace: "ks".to_string(),
+                name: "udt".to_string(),
+                fields: vec![],
+            })
+            .is_err()
         );
     }
 

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -10,11 +10,14 @@ use num_bigint::BigInt;
 use regex::Regex;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlDecimal;
+use scylla::value::CqlDecimalBorrowed;
 use scylla::value::CqlTimeuuid;
 use scylla::value::CqlValue;
 use scylla::value::CqlVarint;
+use scylla::value::CqlVarintBorrowed;
 use serde_json::Number;
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::num::NonZero;
 use std::sync::LazyLock;
 use time::Date;
@@ -232,9 +235,55 @@ pub(crate) fn from_json(value: Value, cql_type: &NativeType) -> anyhow::Result<C
     }
 }
 
+/// Compare two CqlValues, returning an Ordering if they are comparable. `None` means "does
+/// not match" to callers, not an error, so a missing arm silently matches no rows.
+pub(crate) fn cmp(lhs: &CqlValue, rhs: &CqlValue) -> Option<Ordering> {
+    match (lhs, rhs) {
+        // Numeric types
+        (CqlValue::TinyInt(a), CqlValue::TinyInt(b)) => Some(a.cmp(b)),
+        (CqlValue::SmallInt(a), CqlValue::SmallInt(b)) => Some(a.cmp(b)),
+        (CqlValue::Int(a), CqlValue::Int(b)) => Some(a.cmp(b)),
+        (CqlValue::BigInt(a), CqlValue::BigInt(b)) => Some(a.cmp(b)),
+        (CqlValue::Float(a), CqlValue::Float(b)) => a.partial_cmp(b),
+        (CqlValue::Double(a), CqlValue::Double(b)) => a.partial_cmp(b),
+        (CqlValue::Counter(a), CqlValue::Counter(b)) => Some(a.0.cmp(&b.0)),
+        // Varint: semantic comparison via num-bigint
+        (CqlValue::Varint(a), CqlValue::Varint(b)) => {
+            let a_bi = BigInt::from(CqlVarintBorrowed::from_signed_bytes_be_slice(
+                a.as_signed_bytes_be_slice(),
+            ));
+            let b_bi = BigInt::from(CqlVarintBorrowed::from_signed_bytes_be_slice(
+                b.as_signed_bytes_be_slice(),
+            ));
+            Some(a_bi.cmp(&b_bi))
+        }
+        (CqlValue::Decimal(a), CqlValue::Decimal(b)) => {
+            let (a_bytes, a_scale) = a.as_signed_be_bytes_slice_and_exponent();
+            let (b_bytes, b_scale) = b.as_signed_be_bytes_slice_and_exponent();
+            let a_bd = BigDecimal::from(
+                CqlDecimalBorrowed::from_signed_be_bytes_slice_and_exponent(a_bytes, a_scale),
+            );
+            let b_bd = BigDecimal::from(
+                CqlDecimalBorrowed::from_signed_be_bytes_slice_and_exponent(b_bytes, b_scale),
+            );
+            Some(a_bd.cmp(&b_bd))
+        }
+        // Text types
+        (CqlValue::Text(a), CqlValue::Text(b)) => Some(a.cmp(b)),
+        (CqlValue::Ascii(a), CqlValue::Ascii(b)) => Some(a.cmp(b)),
+        // Date and Time types (access inner values directly)
+        (CqlValue::Date(a), CqlValue::Date(b)) => Some(a.0.cmp(&b.0)),
+        (CqlValue::Time(a), CqlValue::Time(b)) => Some(a.0.cmp(&b.0)),
+        (CqlValue::Timestamp(a), CqlValue::Timestamp(b)) => Some(a.0.cmp(&b.0)),
+        // Unsupported or mismatched types
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scylla::value::CqlDecimal;
     use uuid::Uuid;
 
     #[test]
@@ -603,6 +652,200 @@ mod tests {
             CqlValue::Decimal(
                 CqlDecimal::try_from("-1.25".parse::<BigDecimal>().unwrap()).unwrap()
             )
+        );
+    }
+
+    #[test]
+    fn cmp_integers() {
+        assert_eq!(
+            cmp(&CqlValue::Int(1), &CqlValue::Int(2)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&CqlValue::Int(2), &CqlValue::Int(2)),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            cmp(&CqlValue::Int(3), &CqlValue::Int(2)),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn cmp_bigints() {
+        assert_eq!(
+            cmp(&CqlValue::BigInt(100), &CqlValue::BigInt(200)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&CqlValue::BigInt(-50), &CqlValue::BigInt(-50)),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn cmp_floats() {
+        assert_eq!(
+            cmp(&CqlValue::Float(1.0), &CqlValue::Float(2.0)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&CqlValue::Float(2.5), &CqlValue::Float(2.5)),
+            Some(Ordering::Equal)
+        );
+        // NaN comparison returns None
+        assert_eq!(cmp(&CqlValue::Float(f32::NAN), &CqlValue::Float(1.0)), None);
+    }
+
+    #[test]
+    fn cmp_doubles() {
+        assert_eq!(
+            cmp(&CqlValue::Double(1.0), &CqlValue::Double(2.0)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&CqlValue::Double(f64::NAN), &CqlValue::Double(1.0)),
+            None
+        );
+    }
+
+    #[test]
+    fn cmp_text() {
+        assert_eq!(
+            cmp(
+                &CqlValue::Text("apple".to_string()),
+                &CqlValue::Text("banana".to_string())
+            ),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(
+                &CqlValue::Text("same".to_string()),
+                &CqlValue::Text("same".to_string())
+            ),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn cmp_ascii() {
+        assert_eq!(
+            cmp(
+                &CqlValue::Ascii("aaa".to_string()),
+                &CqlValue::Ascii("bbb".to_string())
+            ),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn cmp_smallint_and_tinyint() {
+        assert_eq!(
+            cmp(&CqlValue::SmallInt(10), &CqlValue::SmallInt(20)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&CqlValue::TinyInt(5), &CqlValue::TinyInt(3)),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn cmp_mismatched_types_return_none() {
+        assert_eq!(cmp(&CqlValue::Int(1), &CqlValue::BigInt(1)), None);
+        assert_eq!(
+            cmp(&CqlValue::Int(1), &CqlValue::Text("1".to_string())),
+            None
+        );
+        assert_eq!(cmp(&CqlValue::Float(1.0), &CqlValue::Double(1.0)), None);
+    }
+
+    #[test]
+    fn cmp_varint() {
+        use num_bigint::BigInt;
+        use scylla::value::CqlVarint;
+        let make = |s: &str| CqlValue::Varint(CqlVarint::from(s.parse::<BigInt>().unwrap()));
+
+        assert_eq!(
+            cmp(&make("-1000000000000000000000"), &make("0")),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&make("99999999999999999999"), &make("99999999999999999999")),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            cmp(
+                &make("100000000000000000001"),
+                &make("99999999999999999999")
+            ),
+            Some(Ordering::Greater)
+        );
+        // negative values
+        assert_eq!(
+            cmp(
+                &make("-98765432109876543210"),
+                &make("-12345678901234567890")
+            ),
+            Some(Ordering::Less)
+        );
+        assert_eq!(cmp(&make("-1"), &make("1")), Some(Ordering::Less));
+        // large positive vs large negative
+        assert_eq!(
+            cmp(
+                &make("98765432109876543210987654321098765432109876543210"),
+                &make("-98765432109876543210987654321098765432109876543210")
+            ),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn cmp_decimal() {
+        let make = |s: &str| {
+            CqlValue::Decimal(CqlDecimal::try_from(s.parse::<BigDecimal>().unwrap()).unwrap())
+        };
+
+        assert_eq!(
+            cmp(&make("-98765432109876543210.123456789"), &make("0")),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(
+                &make("3.14159265358979323846"),
+                &make("3.14159265358979323846")
+            ),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            cmp(
+                &make("1000000000000000000.000000001"),
+                &make("999999999999999999.999999999")
+            ),
+            Some(Ordering::Greater)
+        );
+        // different scales for semantically equal value: 1.50 == 1.5
+        assert_eq!(cmp(&make("1.50"), &make("1.5")), Some(Ordering::Equal));
+        // negative comparisons
+        assert_eq!(
+            cmp(&make("-0.000000001"), &make("0.000000001")),
+            Some(Ordering::Less)
+        );
+        assert_eq!(cmp(&make("-1.25"), &make("-1.125")), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn cmp_unsupported_types_return_none() {
+        assert_eq!(
+            cmp(
+                &CqlValue::Blob(vec![1, 2, 3]),
+                &CqlValue::Blob(vec![1, 2, 3])
+            ),
+            None
+        );
+        assert_eq!(
+            cmp(&CqlValue::Boolean(true), &CqlValue::Boolean(false)),
+            None
         );
     }
 }

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -18,6 +18,7 @@ use scylla::value::CqlVarintBorrowed;
 use serde_json::Number;
 use serde_json::Value;
 use std::cmp::Ordering;
+use std::net::IpAddr;
 use std::num::NonZero;
 use std::sync::LazyLock;
 use time::Date;
@@ -78,6 +79,8 @@ pub(crate) fn to_json(value: CqlValue) -> anyhow::Result<Value> {
         CqlValue::Varint(value) => Ok(Value::String(BigInt::from(value).to_string())),
 
         CqlValue::Decimal(value) => Ok(Value::String(BigDecimal::from(value).to_string())),
+
+        CqlValue::Inet(value) => Ok(Value::String(value.to_string())),
 
         CqlValue::Empty => {
             bail!("a primary key column holds an empty value, which has no JSON representation")
@@ -157,6 +160,12 @@ pub(crate) fn from_json(value: Value, cql_type: &NativeType) -> anyhow::Result<C
                 Ok(CqlValue::Decimal(CqlDecimal::try_from(bd).map_err(
                     |err| anyhow!("Decimal value out of range: {err}"),
                 )?))
+            }
+            NativeType::Inet => {
+                let addr: IpAddr = value
+                    .parse()
+                    .map_err(|err| anyhow!("Failed to parse Inet from string '{value}': {err}"))?;
+                Ok(CqlValue::Inet(addr))
             }
             _ => bail!("Cannot convert string to CqlValue::{cql_type:?}, unsupported type"),
         },
@@ -279,8 +288,19 @@ pub(crate) fn cmp(lhs: &CqlValue, rhs: &CqlValue) -> Option<Ordering> {
         (CqlValue::Date(a), CqlValue::Date(b)) => Some(a.0.cmp(&b.0)),
         (CqlValue::Time(a), CqlValue::Time(b)) => Some(a.0.cmp(&b.0)),
         (CqlValue::Timestamp(a), CqlValue::Timestamp(b)) => Some(a.0.cmp(&b.0)),
+        // Inet type
+        (CqlValue::Inet(a), CqlValue::Inet(b)) => Some(inet_cmp(a, b)),
         // Unsupported or mismatched types
         _ => None,
+    }
+}
+
+fn inet_cmp(lhs: &IpAddr, rhs: &IpAddr) -> Ordering {
+    match (lhs, rhs) {
+        (IpAddr::V4(lhs), IpAddr::V4(rhs)) => lhs.octets().cmp(&rhs.octets()),
+        (IpAddr::V6(lhs), IpAddr::V6(rhs)) => lhs.octets().cmp(&rhs.octets()),
+        (IpAddr::V4(lhs), IpAddr::V6(rhs)) => lhs.octets().as_slice().cmp(rhs.octets().as_slice()),
+        (IpAddr::V6(lhs), IpAddr::V4(rhs)) => lhs.octets().as_slice().cmp(rhs.octets().as_slice()),
     }
 }
 
@@ -290,6 +310,8 @@ mod tests {
     use scylla::value::Counter;
     use scylla::value::CqlDecimal;
     use scylla::value::CqlDuration;
+    use std::net::Ipv4Addr;
+    use std::net::Ipv6Addr;
     use uuid::Uuid;
 
     #[test]
@@ -414,6 +436,22 @@ mod tests {
             ))
             .unwrap(),
             Value::String("-98765432109876543210.123456789".to_string())
+        );
+
+        assert_eq!(
+            to_json(CqlValue::Inet(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))).unwrap(),
+            Value::String("10.0.0.1".to_string())
+        );
+        assert_eq!(
+            to_json(CqlValue::Inet(IpAddr::V6(Ipv6Addr::LOCALHOST))).unwrap(),
+            Value::String("::1".to_string())
+        );
+        assert_eq!(
+            to_json(CqlValue::Inet(IpAddr::V6(Ipv6Addr::new(
+                0x2001, 0xdb8, 0, 0, 0, 0, 0, 1
+            ))))
+            .unwrap(),
+            Value::String("2001:db8::1".to_string())
         );
 
         assert!(to_json(CqlValue::Counter(Counter(1))).is_err());
@@ -680,6 +718,22 @@ mod tests {
                 CqlDecimal::try_from("-1.25".parse::<BigDecimal>().unwrap()).unwrap()
             )
         );
+
+        assert_eq!(
+            from_json(Value::String("10.0.0.1".to_string()), &NativeType::Inet).unwrap(),
+            CqlValue::Inet(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        );
+        assert_eq!(
+            from_json(Value::String("::1".to_string()), &NativeType::Inet).unwrap(),
+            CqlValue::Inet(IpAddr::V6(Ipv6Addr::LOCALHOST))
+        );
+        assert_eq!(
+            from_json(Value::String("2001:db8::1".to_string()), &NativeType::Inet).unwrap(),
+            CqlValue::Inet(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)))
+        );
+        assert!(from_json(Value::String("not-an-ip".to_string()), &NativeType::Inet).is_err());
+        assert!(from_json(Value::String("10.0.0.256".to_string()), &NativeType::Inet).is_err());
+        assert!(from_json(Value::Number(10.into()), &NativeType::Inet).is_err());
     }
 
     #[test]
@@ -874,5 +928,37 @@ mod tests {
             cmp(&CqlValue::Boolean(true), &CqlValue::Boolean(false)),
             None
         );
+    }
+
+    #[test]
+    fn cmp_inet() {
+        let v4 = |a, b, c, d| CqlValue::Inet(IpAddr::V4(Ipv4Addr::new(a, b, c, d)));
+        let v6 = |s: &str| CqlValue::Inet(IpAddr::V6(s.parse::<Ipv6Addr>().expect("valid addr")));
+
+        assert_eq!(
+            cmp(&v4(10, 0, 0, 1), &v4(10, 0, 0, 1)),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            cmp(&v4(10, 0, 0, 1), &v4(10, 0, 0, 2)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&v4(10, 0, 1, 0), &v4(10, 0, 0, 255)),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(cmp(&v6("::1"), &v6("::2")), Some(Ordering::Less));
+
+        // Serialized byte order.
+        assert_eq!(
+            cmp(&v4(255, 255, 255, 255), &v6("::")),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            cmp(&v6("2001:db8::1"), &v4(255, 255, 255, 255)),
+            Some(Ordering::Less)
+        );
+        // On an equal prefix the shorter IPv4 form sorts first.
+        assert_eq!(cmp(&v4(0, 0, 0, 0), &v6("::")), Some(Ordering::Less));
     }
 }

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -340,6 +340,103 @@ mod tests {
     use std::net::Ipv6Addr;
     use uuid::Uuid;
 
+    pub(crate) fn sample_value(typ: &NativeType) -> CqlValue {
+        match typ {
+            NativeType::Ascii => CqlValue::Ascii("ascii".to_string()),
+            NativeType::BigInt => CqlValue::BigInt(20),
+            NativeType::Blob => CqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef]),
+            NativeType::Boolean => CqlValue::Boolean(true),
+            NativeType::Date => CqlValue::Date(
+                Date::from_calendar_date(2025, time::Month::September, 1)
+                    .expect("valid date")
+                    .into(),
+            ),
+            NativeType::Decimal => CqlValue::Decimal(
+                CqlDecimal::try_from("-1.25".parse::<BigDecimal>().expect("valid decimal"))
+                    .expect("in range"),
+            ),
+            NativeType::Double => CqlValue::Double(101.5),
+            NativeType::Float => CqlValue::Float(201.5),
+            NativeType::Inet => CqlValue::Inet(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1))),
+            NativeType::Int => CqlValue::Int(10),
+            NativeType::SmallInt => CqlValue::SmallInt(30),
+            NativeType::Text => CqlValue::Text("text".to_string()),
+            NativeType::Time => {
+                CqlValue::Time(Time::from_hms(12, 10, 10).expect("valid time").into())
+            }
+            NativeType::Timestamp => CqlValue::Timestamp(
+                OffsetDateTime::from_unix_timestamp(1_700_000_000)
+                    .expect("valid timestamp")
+                    .into(),
+            ),
+            NativeType::Timeuuid => CqlValue::Timeuuid(CqlTimeuuid::from_bytes([
+                0x84, 0x16, 0x85, 0xb2, 0x88, 0x03, 0x11, 0xf0, 0x8d, 0xe9, 0x02, 0x42, 0xac, 0x12,
+                0x00, 0x02,
+            ])),
+            NativeType::TinyInt => CqlValue::TinyInt(40),
+            NativeType::Uuid => {
+                CqlValue::Uuid(Uuid::from_u128(0x1234_5678_9abc_4def_8000_0000_0000_0001))
+            }
+            NativeType::Varint => CqlValue::Varint(CqlVarint::from(
+                "-98765432109876543210"
+                    .parse::<BigInt>()
+                    .expect("valid varint"),
+            )),
+            other => panic!("sample_value: {other:?} is not in SUPPORTED"),
+        }
+    }
+
+    pub(crate) const CMP_UNSUPPORTED: &[NativeType] = &[
+        NativeType::Blob,
+        NativeType::Boolean,
+        NativeType::Timeuuid,
+        NativeType::Uuid,
+    ];
+
+    #[test]
+    fn every_supported_type_is_handled() {
+        for typ in SUPPORTED {
+            let value = sample_value(typ);
+            assert!(
+                is_supported(&ColumnType::Native(typ.clone())),
+                "{typ:?}: is_supported"
+            );
+            let json =
+                to_json(value.clone()).unwrap_or_else(|err| panic!("{typ:?}: to_json: {err}"));
+            let back = from_json(json.clone(), typ)
+                .unwrap_or_else(|err| panic!("{typ:?}: from_json({json}): {err}"));
+            assert_eq!(back, value, "{typ:?}: JSON round trip");
+            if CMP_UNSUPPORTED.contains(typ) {
+                assert_eq!(
+                    cmp(&value, &value),
+                    None,
+                    "{typ:?}: comparable - drop it from CMP_UNSUPPORTED"
+                );
+            } else {
+                assert_eq!(
+                    cmp(&value, &value),
+                    Some(Ordering::Equal),
+                    "{typ:?}: a value must compare equal to itself"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unsupported_types_are_rejected() {
+        assert!(!is_supported(&ColumnType::Native(NativeType::Counter)));
+        assert!(!is_supported(&ColumnType::Native(NativeType::Duration)));
+        assert!(!is_supported(&ColumnType::Tuple(vec![ColumnType::Native(
+            NativeType::Int
+        )])));
+        assert!(!is_supported(&ColumnType::Collection {
+            frozen: true,
+            typ: scylla::cluster::metadata::CollectionType::List(Box::new(ColumnType::Native(
+                NativeType::Int
+            ))),
+        }));
+    }
+
     #[test]
     fn to_json_conversion() {
         assert_eq!(

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use anyhow::anyhow;
+use bigdecimal::BigDecimal;
+use num_bigint::BigInt;
+use scylla::value::CqlValue;
+use serde_json::Number;
+use serde_json::Value;
+use std::num::NonZero;
+use time::Date;
+use time::OffsetDateTime;
+use time::Time;
+use time::format_description::well_known::Iso8601;
+use time::format_description::well_known::iso8601::Config;
+use time::format_description::well_known::iso8601::TimePrecision;
+
+pub(crate) fn to_json(value: CqlValue) -> anyhow::Result<Value> {
+    match value {
+        CqlValue::Ascii(value) => Ok(Value::String(value)),
+        CqlValue::Text(value) => Ok(Value::String(value)),
+
+        CqlValue::Boolean(value) => Ok(Value::Bool(value)),
+
+        CqlValue::Double(value) => {
+            Ok(Value::Number(Number::from_f64(value).ok_or_else(|| {
+                anyhow!("CqlValue::Double should be finite")
+            })?))
+        }
+        CqlValue::Float(value) => Ok(Value::Number(
+            Number::from_f64(value.into())
+                .ok_or_else(|| anyhow!("CqlValue::Float should be finite"))?,
+        )),
+
+        CqlValue::Int(value) => Ok(Value::Number(value.into())),
+        CqlValue::BigInt(value) => Ok(Value::Number(value.into())),
+        CqlValue::SmallInt(value) => Ok(Value::Number(value.into())),
+        CqlValue::TinyInt(value) => Ok(Value::Number(value.into())),
+
+        CqlValue::Uuid(value) => Ok(Value::String(value.into())),
+        CqlValue::Timeuuid(value) => Ok(Value::String((*value.as_ref()).into())),
+
+        CqlValue::Date(value) => Ok(Value::String(
+            TryInto::<Date>::try_into(value)?.format(&Iso8601::DATE)?,
+        )),
+        CqlValue::Time(value) => Ok(Value::String(
+            TryInto::<Time>::try_into(value)?
+                .format(&Iso8601::TIME)?
+                .strip_prefix("T")
+                .ok_or_else(|| anyhow!("CqlValue::Time: wrong formatting detected"))?
+                .to_string(), // remove 'T' prefix added by time crate
+        )),
+        CqlValue::Timestamp(value) => Ok(Value::String(
+            TryInto::<OffsetDateTime>::try_into(value)?.format({
+                const CONFIG: u128 = Config::DEFAULT
+                    .set_time_precision(TimePrecision::Second {
+                        decimal_digits: NonZero::new(3),
+                    })
+                    .encode();
+                &Iso8601::<CONFIG>
+            })?,
+        )),
+
+        CqlValue::Blob(value) => Ok(Value::String(const_hex::encode_prefixed(&value))),
+
+        CqlValue::Varint(value) => Ok(Value::String(BigInt::from(value).to_string())),
+
+        CqlValue::Decimal(value) => Ok(Value::String(BigDecimal::from(value).to_string())),
+
+        _ => unimplemented!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scylla::value::CqlDecimal;
+    use scylla::value::CqlVarint;
+    use uuid::Uuid;
+
+    #[test]
+    fn to_json_conversion() {
+        assert_eq!(
+            to_json(CqlValue::Ascii("ascii".to_string())).unwrap(),
+            Value::String("ascii".to_string())
+        );
+        assert_eq!(
+            to_json(CqlValue::Text("text".to_string())).unwrap(),
+            Value::String("text".to_string())
+        );
+
+        assert_eq!(to_json(CqlValue::Boolean(true)).unwrap(), Value::Bool(true));
+
+        assert_eq!(
+            to_json(CqlValue::Double(101.)).unwrap(),
+            Value::Number(Number::from_f64(101.).unwrap())
+        );
+        assert_eq!(
+            to_json(CqlValue::Float(201.)).unwrap(),
+            Value::Number(Number::from_f64(201.).unwrap())
+        );
+
+        assert_eq!(
+            to_json(CqlValue::Int(10)).unwrap(),
+            Value::Number(10.into())
+        );
+        assert_eq!(
+            to_json(CqlValue::BigInt(20)).unwrap(),
+            Value::Number(20.into())
+        );
+        assert_eq!(
+            to_json(CqlValue::SmallInt(30)).unwrap(),
+            Value::Number(30.into())
+        );
+        assert_eq!(
+            to_json(CqlValue::TinyInt(40)).unwrap(),
+            Value::Number(40.into())
+        );
+
+        let uuid = Uuid::new_v4();
+        assert_eq!(
+            to_json(CqlValue::Uuid(uuid)).unwrap(),
+            Value::String(uuid.into())
+        );
+        let uuid = Uuid::new_v4();
+        assert_eq!(
+            to_json(CqlValue::Timeuuid(uuid.into())).unwrap(),
+            Value::String(uuid.into())
+        );
+
+        assert_eq!(
+            to_json(CqlValue::Date(
+                Date::from_calendar_date(2025, time::Month::September, 1)
+                    .unwrap()
+                    .into()
+            ))
+            .unwrap(),
+            Value::String("2025-09-01".to_string())
+        );
+        assert_eq!(
+            to_json(CqlValue::Time(Time::from_hms(12, 10, 10).unwrap().into())).unwrap(),
+            Value::String("12:10:10.000000000".to_string())
+        );
+        assert_eq!(
+            to_json(CqlValue::Timestamp(
+                OffsetDateTime::from_unix_timestamp(123456789)
+                    .unwrap()
+                    .into()
+            ))
+            .unwrap(),
+            Value::String(
+                // truncate microseconds
+                OffsetDateTime::from_unix_timestamp(123456789)
+                    .unwrap()
+                    .format({
+                        const CONFIG: u128 = Config::DEFAULT
+                            .set_time_precision(TimePrecision::Second {
+                                decimal_digits: NonZero::new(3),
+                            })
+                            .encode();
+                        &Iso8601::<CONFIG>
+                    })
+                    .unwrap()
+            )
+        );
+        assert!(to_json(CqlValue::Float(f32::NAN)).is_err());
+        assert!(to_json(CqlValue::Double(f64::NAN)).is_err());
+
+        assert_eq!(
+            to_json(CqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])).unwrap(),
+            Value::String("0xdeadbeef".to_string())
+        );
+        assert_eq!(
+            to_json(CqlValue::Blob(vec![])).unwrap(),
+            Value::String("0x".to_string())
+        );
+        assert_eq!(
+            to_json(CqlValue::Blob(vec![0x00])).unwrap(),
+            Value::String("0x00".to_string())
+        );
+
+        assert_eq!(
+            to_json(CqlValue::Varint(CqlVarint::from(
+                "-98765432109876543210987654321098765432109876543210"
+                    .parse::<BigInt>()
+                    .unwrap()
+            )))
+            .unwrap(),
+            Value::String("-98765432109876543210987654321098765432109876543210".to_string())
+        );
+
+        assert_eq!(
+            to_json(CqlValue::Decimal(
+                CqlDecimal::try_from(
+                    "-98765432109876543210.123456789"
+                        .parse::<BigDecimal>()
+                        .unwrap()
+                )
+                .unwrap()
+            ))
+            .unwrap(),
+            Value::String("-98765432109876543210.123456789".to_string())
+        );
+    }
+}

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -79,6 +79,10 @@ pub(crate) fn to_json(value: CqlValue) -> anyhow::Result<Value> {
 
         CqlValue::Decimal(value) => Ok(Value::String(BigDecimal::from(value).to_string())),
 
+        CqlValue::Empty => {
+            bail!("a primary key column holds an empty value, which has no JSON representation")
+        }
+
         _ => bail!("unsupported CQL type for a primary key column"),
     }
 }
@@ -413,6 +417,7 @@ mod tests {
         );
 
         assert!(to_json(CqlValue::Counter(Counter(1))).is_err());
+        assert!(to_json(CqlValue::Empty).is_err());
         assert!(
             to_json(CqlValue::Duration(CqlDuration {
                 months: 1,

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -4,12 +4,19 @@
  */
 
 use anyhow::anyhow;
+use anyhow::bail;
 use bigdecimal::BigDecimal;
 use num_bigint::BigInt;
+use regex::Regex;
+use scylla::cluster::metadata::NativeType;
+use scylla::value::CqlDecimal;
+use scylla::value::CqlTimeuuid;
 use scylla::value::CqlValue;
+use scylla::value::CqlVarint;
 use serde_json::Number;
 use serde_json::Value;
 use std::num::NonZero;
+use std::sync::LazyLock;
 use time::Date;
 use time::OffsetDateTime;
 use time::Time;
@@ -73,11 +80,161 @@ pub(crate) fn to_json(value: CqlValue) -> anyhow::Result<Value> {
     }
 }
 
+pub(crate) fn from_json(value: Value, cql_type: &NativeType) -> anyhow::Result<CqlValue> {
+    match value {
+        Value::String(value) => match cql_type {
+            NativeType::Ascii => Ok(CqlValue::Ascii(value)),
+            NativeType::Text => Ok(CqlValue::Text(value)),
+            NativeType::Uuid => {
+                let uuid = value
+                    .parse()
+                    .map_err(|err| anyhow!("Failed to parse UUID from string '{value}': {err}"))?;
+                Ok(CqlValue::Uuid(uuid))
+            }
+            NativeType::Timeuuid => {
+                let timeuuid: CqlTimeuuid = value.parse().map_err(|err| {
+                    anyhow!("Failed to parse TimeUUID from string '{value}': {err}")
+                })?;
+                Ok(CqlValue::Timeuuid(timeuuid))
+            }
+            NativeType::Date => {
+                let date = Date::parse(&value, &Iso8601::DATE)
+                    .map_err(|err| anyhow!("Failed to parse Date from string '{value}': {err}"))?;
+                Ok(CqlValue::Date(date.into()))
+            }
+            NativeType::Time => {
+                let time = Time::parse(value.strip_prefix("T").unwrap_or(&value), &Iso8601::TIME)
+                    .map_err(|err| {
+                    anyhow!("Failed to parse Time from string '{value}': {err}")
+                })?;
+                Ok(CqlValue::Time(time.into()))
+            }
+            NativeType::Timestamp => {
+                // CQL timestamps may use a space as the date-time separator
+                // (e.g. '2024-01-01 00:00:00.000Z'), but ISO 8601 requires 'T'.
+                // Only normalize when the space occurs at the expected date-time
+                // boundary after a YYYY-MM-DD prefix; otherwise, leave the input
+                // unchanged so that error reporting reflects the original value.
+                static CQL_TIMESTAMP_RE: LazyLock<Regex> =
+                    LazyLock::new(|| Regex::new(r"^(\d{4}-\d{2}-\d{2}) ").expect("valid regex"));
+                let normalized = CQL_TIMESTAMP_RE.replace(&value, "${1}T");
+                let datetime = OffsetDateTime::parse(&normalized, {
+                    const CONFIG: u128 = Config::DEFAULT
+                        .set_time_precision(TimePrecision::Second {
+                            decimal_digits: NonZero::new(3),
+                        })
+                        .encode();
+                    &Iso8601::<CONFIG>
+                })
+                .map_err(|err| anyhow!("Failed to parse Timestamp from string '{value}': {err}"))?;
+                Ok(CqlValue::Timestamp(datetime.into()))
+            }
+            NativeType::Blob => {
+                if !value.starts_with("0x") {
+                    bail!("Blob value must be a '0x'-prefixed hex string");
+                }
+                let bytes = const_hex::decode(&value)
+                    .map_err(|err| anyhow!("Invalid hex in blob value: {err}"))?;
+                Ok(CqlValue::Blob(bytes))
+            }
+            NativeType::Varint => {
+                let bi: BigInt = value.parse().map_err(|err| {
+                    anyhow!("Failed to parse Varint from string '{value}': {err}")
+                })?;
+                Ok(CqlValue::Varint(CqlVarint::from(bi)))
+            }
+            NativeType::Decimal => {
+                let bd: BigDecimal = value.parse().map_err(|err| {
+                    anyhow!("Failed to parse Decimal from string '{value}': {err}")
+                })?;
+                Ok(CqlValue::Decimal(CqlDecimal::try_from(bd).map_err(
+                    |err| anyhow!("Decimal value out of range: {err}"),
+                )?))
+            }
+            _ => bail!("Cannot convert string to CqlValue::{cql_type:?}, unsupported type"),
+        },
+
+        Value::Bool(value) => match cql_type {
+            NativeType::Boolean => Ok(CqlValue::Boolean(value)),
+            _ => bail!("Cannot convert bool to CqlValue::{cql_type:?}, unsupported type"),
+        },
+        Value::Number(value) => match cql_type {
+            NativeType::Double => {
+                Ok(CqlValue::Double(value.as_f64().ok_or_else(|| {
+                    anyhow!("Expected f64 for CqlValue::Double")
+                })?))
+            }
+            NativeType::Float => {
+                Ok(CqlValue::Float({
+                    // there is no TryFrom<f64> for f32, so we use explicit conversion
+                    let value = value
+                        .as_f64()
+                        .ok_or_else(|| anyhow!("Expected f32 (type f64) for CqlValue::Float"))?;
+                    if !value.is_finite() || value < f32::MIN as f64 || value > f32::MAX as f64 {
+                        bail!("Expected f32 for CqlValue::Float: value out of range");
+                    }
+                    let value = value as f32;
+                    if !value.is_finite() {
+                        bail!("Expected finite f32 for CqlValue::Float");
+                    }
+                    value
+                }))
+            }
+            NativeType::Int => Ok(CqlValue::Int(
+                value
+                    .as_i64()
+                    .ok_or_else(|| anyhow!("Expected i32 (type i64) for CqlValue::Int"))?
+                    .try_into()
+                    .map_err(|err| anyhow!("Expected i32 for CqlValue::Int: {err}"))?,
+            )),
+            NativeType::BigInt => {
+                Ok(CqlValue::BigInt(value.as_i64().ok_or_else(|| {
+                    anyhow!("Expected i64 for CqlValue::BigInt")
+                })?))
+            }
+            NativeType::SmallInt => Ok(CqlValue::SmallInt(
+                value
+                    .as_i64()
+                    .ok_or_else(|| anyhow!("Expected i16 (type i64) for CqlValue::SmallInt"))?
+                    .try_into()
+                    .map_err(|err| anyhow!("Expected i16 for CqlValue::SmallInt: {err}"))?,
+            )),
+            NativeType::TinyInt => Ok(CqlValue::TinyInt(
+                value
+                    .as_i64()
+                    .ok_or_else(|| anyhow!("Expected i8 (type i64) for CqlValue::TinyInt"))?
+                    .try_into()
+                    .map_err(|err| anyhow!("Expected i8 for CqlValue::TinyInt: {err}"))?,
+            )),
+            NativeType::Varint => {
+                // Varint is always an integer; reject fractional JSON numbers.
+                let s = value.to_string();
+                let bi: BigInt = s
+                    .parse()
+                    .map_err(|err| anyhow!("Failed to parse Varint from number '{s}': {err}"))?;
+                Ok(CqlValue::Varint(CqlVarint::from(bi)))
+            }
+            NativeType::Decimal => {
+                let s = value.to_string();
+                let bd: BigDecimal = s
+                    .parse()
+                    .map_err(|err| anyhow!("Failed to parse Decimal from number '{s}': {err}"))?;
+                Ok(CqlValue::Decimal(CqlDecimal::try_from(bd).map_err(
+                    |err| anyhow!("Decimal value out of range: {err}"),
+                )?))
+            }
+            _ => bail!("Cannot convert number to CqlValue::{cql_type:?}, unsupported type"),
+        },
+
+        _ => {
+            bail!("Cannot convert JSON value '{value}' to CqlValue::{cql_type:?}, unsupported type")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use scylla::value::CqlDecimal;
-    use scylla::value::CqlVarint;
     use uuid::Uuid;
 
     #[test]
@@ -202,6 +359,250 @@ mod tests {
             ))
             .unwrap(),
             Value::String("-98765432109876543210.123456789".to_string())
+        );
+    }
+
+    #[test]
+    fn from_json_conversion() {
+        assert_eq!(
+            from_json(Value::String("ascii".to_string()), &NativeType::Ascii).unwrap(),
+            CqlValue::Ascii("ascii".to_string())
+        );
+        assert_eq!(
+            from_json(Value::String("text".to_string()), &NativeType::Text).unwrap(),
+            CqlValue::Text("text".to_string())
+        );
+
+        assert_eq!(
+            from_json(Value::Bool(true), &NativeType::Boolean).unwrap(),
+            CqlValue::Boolean(true)
+        );
+
+        assert_eq!(
+            from_json(
+                Value::Number(Number::from_f64(101.).unwrap()),
+                &NativeType::Double
+            )
+            .unwrap(),
+            CqlValue::Double(101.)
+        );
+        assert_eq!(
+            from_json(
+                Value::Number(Number::from_f64(201.).unwrap()),
+                &NativeType::Float
+            )
+            .unwrap(),
+            CqlValue::Float(201.)
+        );
+        assert!(
+            from_json(
+                Value::Number(Number::from_f64((f32::MAX as f64) * 10.).unwrap()),
+                &NativeType::Float
+            )
+            .is_err()
+        );
+        assert!(
+            from_json(
+                Value::Number(Number::from_f64((f32::MIN as f64) * 10.).unwrap()),
+                &NativeType::Float
+            )
+            .is_err()
+        );
+
+        assert_eq!(
+            from_json(Value::Number(10.into()), &NativeType::Int).unwrap(),
+            CqlValue::Int(10)
+        );
+        assert!(
+            from_json(
+                Value::Number((i32::MAX as i64 + 1).into()),
+                &NativeType::Int
+            )
+            .is_err()
+        );
+        assert_eq!(
+            from_json(Value::Number(20.into()), &NativeType::BigInt).unwrap(),
+            CqlValue::BigInt(20)
+        );
+        assert_eq!(
+            from_json(Value::Number(30.into()), &NativeType::SmallInt).unwrap(),
+            CqlValue::SmallInt(30)
+        );
+        assert!(
+            from_json(
+                Value::Number((i16::MAX as i64 + 1).into()),
+                &NativeType::SmallInt
+            )
+            .is_err()
+        );
+        assert_eq!(
+            from_json(Value::Number(40.into()), &NativeType::TinyInt).unwrap(),
+            CqlValue::TinyInt(40)
+        );
+        assert!(
+            from_json(
+                Value::Number((i8::MAX as i64 + 1).into()),
+                &NativeType::TinyInt
+            )
+            .is_err()
+        );
+
+        let uuid = Uuid::new_v4();
+        assert_eq!(
+            from_json(Value::String(uuid.into()), &NativeType::Uuid).unwrap(),
+            CqlValue::Uuid(uuid)
+        );
+        let uuid = Uuid::new_v4();
+        assert_eq!(
+            from_json(Value::String(uuid.into()), &NativeType::Timeuuid).unwrap(),
+            CqlValue::Timeuuid(uuid.into())
+        );
+
+        assert_eq!(
+            from_json(Value::String("2025-09-01".to_string()), &NativeType::Date).unwrap(),
+            CqlValue::Date(
+                Date::from_calendar_date(2025, time::Month::September, 1)
+                    .unwrap()
+                    .into()
+            )
+        );
+        assert_eq!(
+            from_json(
+                Value::String("12:10:10.000000000".to_string()),
+                &NativeType::Time
+            )
+            .unwrap(),
+            CqlValue::Time(Time::from_hms(12, 10, 10).unwrap().into())
+        );
+        assert_eq!(
+            from_json(
+                Value::String(
+                    // truncate microseconds
+                    OffsetDateTime::from_unix_timestamp(123456789)
+                        .unwrap()
+                        .format({
+                            const CONFIG: u128 = Config::DEFAULT
+                                .set_time_precision(TimePrecision::Second {
+                                    decimal_digits: NonZero::new(3),
+                                })
+                                .encode();
+                            &Iso8601::<CONFIG>
+                        })
+                        .unwrap()
+                ),
+                &NativeType::Timestamp
+            )
+            .unwrap(),
+            CqlValue::Timestamp(
+                OffsetDateTime::from_unix_timestamp(123456789)
+                    .unwrap()
+                    .into()
+            )
+        );
+
+        // CQL-style timestamp with space separator and Z offset
+        assert_eq!(
+            from_json(
+                Value::String("2024-01-01 00:00:00.000Z".to_string()),
+                &NativeType::Timestamp
+            )
+            .unwrap(),
+            CqlValue::Timestamp(
+                OffsetDateTime::from_unix_timestamp(1704067200)
+                    .unwrap()
+                    .into()
+            )
+        );
+
+        // CQL-style timestamp with space separator, Z offset, and non-zero time
+        assert_eq!(
+            from_json(
+                Value::String("1970-01-01 00:01:04.000Z".to_string()),
+                &NativeType::Timestamp
+            )
+            .unwrap(),
+            CqlValue::Timestamp(OffsetDateTime::from_unix_timestamp(64).unwrap().into())
+        );
+
+        assert_eq!(
+            from_json(Value::String("0xdeadbeef".to_string()), &NativeType::Blob).unwrap(),
+            CqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])
+        );
+        assert_eq!(
+            from_json(Value::String("0x".to_string()), &NativeType::Blob).unwrap(),
+            CqlValue::Blob(vec![])
+        );
+        assert_eq!(
+            from_json(Value::String("0x00".to_string()), &NativeType::Blob).unwrap(),
+            CqlValue::Blob(vec![0x00])
+        );
+
+        // missing 0x prefix
+        assert!(from_json(Value::String("deadbeef".to_string()), &NativeType::Blob).is_err());
+        // invalid hex characters
+        assert!(from_json(Value::String("0xgg".to_string()), &NativeType::Blob).is_err());
+        // odd-length hex digits (after stripping prefix)
+        assert!(from_json(Value::String("0xabc".to_string()), &NativeType::Blob).is_err());
+
+        // Varint from string
+        assert_eq!(
+            from_json(
+                Value::String("-98765432109876543210987654321098765432109876543210".to_string()),
+                &NativeType::Varint
+            )
+            .unwrap(),
+            CqlValue::Varint(CqlVarint::from(
+                "-98765432109876543210987654321098765432109876543210"
+                    .parse::<BigInt>()
+                    .unwrap()
+            ))
+        );
+        assert!(
+            from_json(
+                Value::String("not_a_number".to_string()),
+                &NativeType::Varint
+            )
+            .is_err()
+        );
+        // Varint from JSON number
+        assert_eq!(
+            from_json(Value::Number((-9876543210i64).into()), &NativeType::Varint).unwrap(),
+            CqlValue::Varint(CqlVarint::from(BigInt::from(-9876543210i64)))
+        );
+
+        // Decimal from string
+        assert_eq!(
+            from_json(
+                Value::String("-98765432109876543210.123456789".to_string()),
+                &NativeType::Decimal
+            )
+            .unwrap(),
+            CqlValue::Decimal(
+                CqlDecimal::try_from(
+                    "-98765432109876543210.123456789"
+                        .parse::<BigDecimal>()
+                        .unwrap()
+                )
+                .unwrap()
+            )
+        );
+        assert!(
+            from_json(
+                Value::String("not_a_decimal".to_string()),
+                &NativeType::Decimal
+            )
+            .is_err()
+        );
+        // Decimal from JSON number
+        assert_eq!(
+            from_json(
+                Value::Number(Number::from_f64(-1.25).unwrap()),
+                &NativeType::Decimal
+            )
+            .unwrap(),
+            CqlValue::Decimal(
+                CqlDecimal::try_from("-1.25".parse::<BigDecimal>().unwrap()).unwrap()
+            )
         );
     }
 }

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -28,6 +28,7 @@ use crate::Positions;
 use crate::Quantization;
 use crate::SpaceType;
 use crate::TableName;
+use crate::cql_types;
 use crate::db_index;
 use crate::db_index::DbIndex;
 use crate::db_index_backend;
@@ -866,6 +867,11 @@ impl Statements {
                     });
                     Ok(options.remove("target").and_then(|target| {
                         let kind = db_index_kind_from_options(&mut options)?;
+                        validate_primary_key_columns(table)
+                            .inspect_err(|err| {
+                                warn!("Skipping index {index_name}: {err}");
+                            })
+                            .ok()?;
                         from_target_option(table, target, kind, is_alternator)
                             .map(
                                 |(partitioning, target_column, filtering_columns)| DbCustomIndex {
@@ -1250,6 +1256,26 @@ fn validate_target_column(
         anyhow!("invalid target option: column {target_name} does not exist in a table")
     })?;
     validate_column_type_for_kind(target_name, &column.typ, kind)
+}
+
+fn validate_primary_key_columns(table: &Table) -> anyhow::Result<()> {
+    for name in table
+        .partition_key
+        .iter()
+        .chain(table.clustering_key.iter())
+    {
+        let column = table.columns.get(name).ok_or(anyhow!(
+            "primary key column {name} does not exist in a table"
+        ))?;
+        if !cql_types::is_supported(&column.typ) {
+            bail!(
+                "unsupported primary key column type: column {name} has type {:?}, \
+                which cannot be represented in an index primary key",
+                column.typ
+            );
+        }
+    }
+    Ok(())
 }
 
 fn validate_column_type_for_kind(

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -14,6 +14,7 @@ use crate::Quantization;
 use crate::Restriction;
 use crate::SimilarityScore;
 use crate::SpaceType;
+use crate::cql_types;
 use crate::distance;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
@@ -68,7 +69,6 @@ use scylla::value::CqlDecimal;
 use scylla::value::CqlTimeuuid;
 use scylla::value::CqlValue;
 use scylla::value::CqlVarint;
-use serde_json::Number;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::num::NonZero;
@@ -1410,68 +1410,12 @@ fn try_collect_primary_keys(
                         .get(idx_column)
                         .expect("primary key index out of bounds after length check")
                 })
-                .map_ok(try_to_json)
+                .map_ok(cql_types::to_json)
                 .map(|primary_key| primary_key.flatten())
                 .collect();
             primary_keys.map(|primary_keys| (column.into(), primary_keys))
         })
         .collect()
-}
-
-fn try_to_json(value: CqlValue) -> anyhow::Result<Value> {
-    match value {
-        CqlValue::Ascii(value) => Ok(Value::String(value)),
-        CqlValue::Text(value) => Ok(Value::String(value)),
-
-        CqlValue::Boolean(value) => Ok(Value::Bool(value)),
-
-        CqlValue::Double(value) => {
-            Ok(Value::Number(Number::from_f64(value).ok_or_else(|| {
-                anyhow!("CqlValue::Double should be finite")
-            })?))
-        }
-        CqlValue::Float(value) => Ok(Value::Number(
-            Number::from_f64(value.into())
-                .ok_or_else(|| anyhow!("CqlValue::Float should be finite"))?,
-        )),
-
-        CqlValue::Int(value) => Ok(Value::Number(value.into())),
-        CqlValue::BigInt(value) => Ok(Value::Number(value.into())),
-        CqlValue::SmallInt(value) => Ok(Value::Number(value.into())),
-        CqlValue::TinyInt(value) => Ok(Value::Number(value.into())),
-
-        CqlValue::Uuid(value) => Ok(Value::String(value.into())),
-        CqlValue::Timeuuid(value) => Ok(Value::String((*value.as_ref()).into())),
-
-        CqlValue::Date(value) => Ok(Value::String(
-            TryInto::<Date>::try_into(value)?.format(&Iso8601::DATE)?,
-        )),
-        CqlValue::Time(value) => Ok(Value::String(
-            TryInto::<Time>::try_into(value)?
-                .format(&Iso8601::TIME)?
-                .strip_prefix("T")
-                .ok_or_else(|| anyhow!("CqlValue::Time: wrong formatting detected"))?
-                .to_string(), // remove 'T' prefix added by time crate
-        )),
-        CqlValue::Timestamp(value) => Ok(Value::String(
-            TryInto::<OffsetDateTime>::try_into(value)?.format({
-                const CONFIG: u128 = Config::DEFAULT
-                    .set_time_precision(TimePrecision::Second {
-                        decimal_digits: NonZero::new(3),
-                    })
-                    .encode();
-                &Iso8601::<CONFIG>
-            })?,
-        )),
-
-        CqlValue::Blob(value) => Ok(Value::String(const_hex::encode_prefixed(&value))),
-
-        CqlValue::Varint(value) => Ok(Value::String(BigInt::from(value).to_string())),
-
-        CqlValue::Decimal(value) => Ok(Value::String(BigDecimal::from(value).to_string())),
-
-        _ => unimplemented!(),
-    }
 }
 
 fn try_from_json(value: Value, cql_type: &NativeType) -> anyhow::Result<CqlValue> {
@@ -1732,6 +1676,7 @@ mod tests {
 
     use super::*;
     use crate::Analyzer;
+    use serde_json::Number;
     use uuid::Uuid;
 
     #[test]
@@ -2267,134 +2212,6 @@ mod tests {
             CqlValue::Decimal(
                 CqlDecimal::try_from("-1.25".parse::<BigDecimal>().unwrap()).unwrap()
             )
-        );
-    }
-
-    #[test]
-    fn try_to_json_conversion() {
-        assert_eq!(
-            try_to_json(CqlValue::Ascii("ascii".to_string())).unwrap(),
-            Value::String("ascii".to_string())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::Text("text".to_string())).unwrap(),
-            Value::String("text".to_string())
-        );
-
-        assert_eq!(
-            try_to_json(CqlValue::Boolean(true)).unwrap(),
-            Value::Bool(true)
-        );
-
-        assert_eq!(
-            try_to_json(CqlValue::Double(101.)).unwrap(),
-            Value::Number(Number::from_f64(101.).unwrap())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::Float(201.)).unwrap(),
-            Value::Number(Number::from_f64(201.).unwrap())
-        );
-
-        assert_eq!(
-            try_to_json(CqlValue::Int(10)).unwrap(),
-            Value::Number(10.into())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::BigInt(20)).unwrap(),
-            Value::Number(20.into())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::SmallInt(30)).unwrap(),
-            Value::Number(30.into())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::TinyInt(40)).unwrap(),
-            Value::Number(40.into())
-        );
-
-        let uuid = Uuid::new_v4();
-        assert_eq!(
-            try_to_json(CqlValue::Uuid(uuid)).unwrap(),
-            Value::String(uuid.into())
-        );
-        let uuid = Uuid::new_v4();
-        assert_eq!(
-            try_to_json(CqlValue::Timeuuid(uuid.into())).unwrap(),
-            Value::String(uuid.into())
-        );
-
-        assert_eq!(
-            try_to_json(CqlValue::Date(
-                Date::from_calendar_date(2025, time::Month::September, 1)
-                    .unwrap()
-                    .into()
-            ))
-            .unwrap(),
-            Value::String("2025-09-01".to_string())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::Time(Time::from_hms(12, 10, 10).unwrap().into())).unwrap(),
-            Value::String("12:10:10.000000000".to_string())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::Timestamp(
-                OffsetDateTime::from_unix_timestamp(123456789)
-                    .unwrap()
-                    .into()
-            ))
-            .unwrap(),
-            Value::String(
-                // truncate microseconds
-                OffsetDateTime::from_unix_timestamp(123456789)
-                    .unwrap()
-                    .format({
-                        const CONFIG: u128 = Config::DEFAULT
-                            .set_time_precision(TimePrecision::Second {
-                                decimal_digits: NonZero::new(3),
-                            })
-                            .encode();
-                        &Iso8601::<CONFIG>
-                    })
-                    .unwrap()
-            )
-        );
-        assert!(try_to_json(CqlValue::Float(f32::NAN)).is_err());
-        assert!(try_to_json(CqlValue::Double(f64::NAN)).is_err());
-
-        assert_eq!(
-            try_to_json(CqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])).unwrap(),
-            Value::String("0xdeadbeef".to_string())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::Blob(vec![])).unwrap(),
-            Value::String("0x".to_string())
-        );
-        assert_eq!(
-            try_to_json(CqlValue::Blob(vec![0x00])).unwrap(),
-            Value::String("0x00".to_string())
-        );
-
-        assert_eq!(
-            try_to_json(CqlValue::Varint(CqlVarint::from(
-                "-98765432109876543210987654321098765432109876543210"
-                    .parse::<BigInt>()
-                    .unwrap()
-            )))
-            .unwrap(),
-            Value::String("-98765432109876543210987654321098765432109876543210".to_string())
-        );
-
-        assert_eq!(
-            try_to_json(CqlValue::Decimal(
-                CqlDecimal::try_from(
-                    "-98765432109876543210.123456789"
-                        .parse::<BigDecimal>()
-                        .unwrap()
-                )
-                .unwrap()
-            ))
-            .unwrap(),
-            Value::String("-98765432109876543210.123456789".to_string())
         );
     }
 

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -34,7 +34,6 @@ use crate::vector;
 use crate::vs_index;
 use crate::vs_index::VsIndexSearch;
 use crate::vs_index::VsIndexSearchExt;
-use anyhow::anyhow;
 use anyhow::bail;
 use axum::Router;
 use axum::extract;
@@ -51,7 +50,6 @@ use axum::response::Response;
 use axum::routing::get;
 use axum::routing::put;
 use axum_server_dual_protocol::Protocol;
-use bigdecimal::BigDecimal;
 use httpapi::DataType;
 use httpapi::FulltextIndexOptions;
 use httpapi::IndexInfo;
@@ -59,29 +57,16 @@ use httpapi::IndexOptions;
 use httpapi::SimilarityFunction;
 use httpapi::VectorIndexOptions;
 use itertools::Itertools;
-use num_bigint::BigInt;
 use prometheus::Encoder;
 use prometheus::ProtobufEncoder;
 use prometheus::TextEncoder;
-use regex::Regex;
 use scylla::cluster::metadata::NativeType;
-use scylla::value::CqlDecimal;
-use scylla::value::CqlTimeuuid;
 use scylla::value::CqlValue;
-use scylla::value::CqlVarint;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::num::NonZero;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::sync::LazyLock;
 use std::sync::RwLock;
-use time::Date;
-use time::OffsetDateTime;
-use time::Time;
-use time::format_description::well_known::Iso8601;
-use time::format_description::well_known::iso8601::Config;
-use time::format_description::well_known::iso8601::TimePrecision;
 use tokio::sync::mpsc::Sender;
 use tower_http::trace::TraceLayer;
 use tracing::debug;
@@ -1229,7 +1214,7 @@ fn try_from_post_index_ann_filter(
                 "Column '{column}' in filter restriction is not part of the table or is not a supported native type",
             )
         };
-        try_from_json(value, native_type)
+        cql_types::from_json(value, native_type)
     };
     Ok(Filter {
         restrictions: json_filter
@@ -1418,158 +1403,6 @@ fn try_collect_primary_keys(
         .collect()
 }
 
-fn try_from_json(value: Value, cql_type: &NativeType) -> anyhow::Result<CqlValue> {
-    match value {
-        Value::String(value) => match cql_type {
-            NativeType::Ascii => Ok(CqlValue::Ascii(value)),
-            NativeType::Text => Ok(CqlValue::Text(value)),
-            NativeType::Uuid => {
-                let uuid = value
-                    .parse()
-                    .map_err(|err| anyhow!("Failed to parse UUID from string '{value}': {err}"))?;
-                Ok(CqlValue::Uuid(uuid))
-            }
-            NativeType::Timeuuid => {
-                let timeuuid: CqlTimeuuid = value.parse().map_err(|err| {
-                    anyhow!("Failed to parse TimeUUID from string '{value}': {err}")
-                })?;
-                Ok(CqlValue::Timeuuid(timeuuid))
-            }
-            NativeType::Date => {
-                let date = Date::parse(&value, &Iso8601::DATE)
-                    .map_err(|err| anyhow!("Failed to parse Date from string '{value}': {err}"))?;
-                Ok(CqlValue::Date(date.into()))
-            }
-            NativeType::Time => {
-                let time = Time::parse(value.strip_prefix("T").unwrap_or(&value), &Iso8601::TIME)
-                    .map_err(|err| {
-                    anyhow!("Failed to parse Time from string '{value}': {err}")
-                })?;
-                Ok(CqlValue::Time(time.into()))
-            }
-            NativeType::Timestamp => {
-                // CQL timestamps may use a space as the date-time separator
-                // (e.g. '2024-01-01 00:00:00.000Z'), but ISO 8601 requires 'T'.
-                // Only normalize when the space occurs at the expected date-time
-                // boundary after a YYYY-MM-DD prefix; otherwise, leave the input
-                // unchanged so that error reporting reflects the original value.
-                static CQL_TIMESTAMP_RE: LazyLock<Regex> =
-                    LazyLock::new(|| Regex::new(r"^(\d{4}-\d{2}-\d{2}) ").expect("valid regex"));
-                let normalized = CQL_TIMESTAMP_RE.replace(&value, "${1}T");
-                let datetime = OffsetDateTime::parse(&normalized, {
-                    const CONFIG: u128 = Config::DEFAULT
-                        .set_time_precision(TimePrecision::Second {
-                            decimal_digits: NonZero::new(3),
-                        })
-                        .encode();
-                    &Iso8601::<CONFIG>
-                })
-                .map_err(|err| anyhow!("Failed to parse Timestamp from string '{value}': {err}"))?;
-                Ok(CqlValue::Timestamp(datetime.into()))
-            }
-            NativeType::Blob => {
-                if !value.starts_with("0x") {
-                    bail!("Blob value must be a '0x'-prefixed hex string");
-                }
-                let bytes = const_hex::decode(&value)
-                    .map_err(|err| anyhow!("Invalid hex in blob value: {err}"))?;
-                Ok(CqlValue::Blob(bytes))
-            }
-            NativeType::Varint => {
-                let bi: BigInt = value.parse().map_err(|err| {
-                    anyhow!("Failed to parse Varint from string '{value}': {err}")
-                })?;
-                Ok(CqlValue::Varint(CqlVarint::from(bi)))
-            }
-            NativeType::Decimal => {
-                let bd: BigDecimal = value.parse().map_err(|err| {
-                    anyhow!("Failed to parse Decimal from string '{value}': {err}")
-                })?;
-                Ok(CqlValue::Decimal(CqlDecimal::try_from(bd).map_err(
-                    |err| anyhow!("Decimal value out of range: {err}"),
-                )?))
-            }
-            _ => bail!("Cannot convert string to CqlValue::{cql_type:?}, unsupported type"),
-        },
-
-        Value::Bool(value) => match cql_type {
-            NativeType::Boolean => Ok(CqlValue::Boolean(value)),
-            _ => bail!("Cannot convert bool to CqlValue::{cql_type:?}, unsupported type"),
-        },
-        Value::Number(value) => match cql_type {
-            NativeType::Double => {
-                Ok(CqlValue::Double(value.as_f64().ok_or_else(|| {
-                    anyhow!("Expected f64 for CqlValue::Double")
-                })?))
-            }
-            NativeType::Float => {
-                Ok(CqlValue::Float({
-                    // there is no TryFrom<f64> for f32, so we use explicit conversion
-                    let value = value
-                        .as_f64()
-                        .ok_or_else(|| anyhow!("Expected f32 (type f64) for CqlValue::Float"))?;
-                    if !value.is_finite() || value < f32::MIN as f64 || value > f32::MAX as f64 {
-                        bail!("Expected f32 for CqlValue::Float: value out of range");
-                    }
-                    let value = value as f32;
-                    if !value.is_finite() {
-                        bail!("Expected finite f32 for CqlValue::Float");
-                    }
-                    value
-                }))
-            }
-            NativeType::Int => Ok(CqlValue::Int(
-                value
-                    .as_i64()
-                    .ok_or_else(|| anyhow!("Expected i32 (type i64) for CqlValue::Int"))?
-                    .try_into()
-                    .map_err(|err| anyhow!("Expected i32 for CqlValue::Int: {err}"))?,
-            )),
-            NativeType::BigInt => {
-                Ok(CqlValue::BigInt(value.as_i64().ok_or_else(|| {
-                    anyhow!("Expected i64 for CqlValue::BigInt")
-                })?))
-            }
-            NativeType::SmallInt => Ok(CqlValue::SmallInt(
-                value
-                    .as_i64()
-                    .ok_or_else(|| anyhow!("Expected i16 (type i64) for CqlValue::SmallInt"))?
-                    .try_into()
-                    .map_err(|err| anyhow!("Expected i16 for CqlValue::SmallInt: {err}"))?,
-            )),
-            NativeType::TinyInt => Ok(CqlValue::TinyInt(
-                value
-                    .as_i64()
-                    .ok_or_else(|| anyhow!("Expected i8 (type i64) for CqlValue::TinyInt"))?
-                    .try_into()
-                    .map_err(|err| anyhow!("Expected i8 for CqlValue::TinyInt: {err}"))?,
-            )),
-            NativeType::Varint => {
-                // Varint is always an integer; reject fractional JSON numbers.
-                let s = value.to_string();
-                let bi: BigInt = s
-                    .parse()
-                    .map_err(|err| anyhow!("Failed to parse Varint from number '{s}': {err}"))?;
-                Ok(CqlValue::Varint(CqlVarint::from(bi)))
-            }
-            NativeType::Decimal => {
-                let s = value.to_string();
-                let bd: BigDecimal = s
-                    .parse()
-                    .map_err(|err| anyhow!("Failed to parse Decimal from number '{s}': {err}"))?;
-                Ok(CqlValue::Decimal(CqlDecimal::try_from(bd).map_err(
-                    |err| anyhow!("Decimal value out of range: {err}"),
-                )?))
-            }
-            _ => bail!("Cannot convert number to CqlValue::{cql_type:?}, unsupported type"),
-        },
-
-        _ => {
-            bail!("Cannot convert JSON value '{value}' to CqlValue::{cql_type:?}, unsupported type")
-        }
-    }
-}
-
 #[utoipa::path(
     get,
     path = "/api/v1/info",
@@ -1676,8 +1509,6 @@ mod tests {
 
     use super::*;
     use crate::Analyzer;
-    use serde_json::Number;
-    use uuid::Uuid;
 
     #[test]
     fn try_from_post_index_ann_filter_conversion_ok() {
@@ -1968,250 +1799,6 @@ mod tests {
                 &table_columns
             )
             .is_err()
-        );
-    }
-
-    #[test]
-    fn try_from_json_conversion() {
-        assert_eq!(
-            try_from_json(Value::String("ascii".to_string()), &NativeType::Ascii).unwrap(),
-            CqlValue::Ascii("ascii".to_string())
-        );
-        assert_eq!(
-            try_from_json(Value::String("text".to_string()), &NativeType::Text).unwrap(),
-            CqlValue::Text("text".to_string())
-        );
-
-        assert_eq!(
-            try_from_json(Value::Bool(true), &NativeType::Boolean).unwrap(),
-            CqlValue::Boolean(true)
-        );
-
-        assert_eq!(
-            try_from_json(
-                Value::Number(Number::from_f64(101.).unwrap()),
-                &NativeType::Double
-            )
-            .unwrap(),
-            CqlValue::Double(101.)
-        );
-        assert_eq!(
-            try_from_json(
-                Value::Number(Number::from_f64(201.).unwrap()),
-                &NativeType::Float
-            )
-            .unwrap(),
-            CqlValue::Float(201.)
-        );
-        assert!(
-            try_from_json(
-                Value::Number(Number::from_f64((f32::MAX as f64) * 10.).unwrap()),
-                &NativeType::Float
-            )
-            .is_err()
-        );
-        assert!(
-            try_from_json(
-                Value::Number(Number::from_f64((f32::MIN as f64) * 10.).unwrap()),
-                &NativeType::Float
-            )
-            .is_err()
-        );
-
-        assert_eq!(
-            try_from_json(Value::Number(10.into()), &NativeType::Int).unwrap(),
-            CqlValue::Int(10)
-        );
-        assert!(
-            try_from_json(
-                Value::Number((i32::MAX as i64 + 1).into()),
-                &NativeType::Int
-            )
-            .is_err()
-        );
-        assert_eq!(
-            try_from_json(Value::Number(20.into()), &NativeType::BigInt).unwrap(),
-            CqlValue::BigInt(20)
-        );
-        assert_eq!(
-            try_from_json(Value::Number(30.into()), &NativeType::SmallInt).unwrap(),
-            CqlValue::SmallInt(30)
-        );
-        assert!(
-            try_from_json(
-                Value::Number((i16::MAX as i64 + 1).into()),
-                &NativeType::SmallInt
-            )
-            .is_err()
-        );
-        assert_eq!(
-            try_from_json(Value::Number(40.into()), &NativeType::TinyInt).unwrap(),
-            CqlValue::TinyInt(40)
-        );
-        assert!(
-            try_from_json(
-                Value::Number((i8::MAX as i64 + 1).into()),
-                &NativeType::TinyInt
-            )
-            .is_err()
-        );
-
-        let uuid = Uuid::new_v4();
-        assert_eq!(
-            try_from_json(Value::String(uuid.into()), &NativeType::Uuid).unwrap(),
-            CqlValue::Uuid(uuid)
-        );
-        let uuid = Uuid::new_v4();
-        assert_eq!(
-            try_from_json(Value::String(uuid.into()), &NativeType::Timeuuid).unwrap(),
-            CqlValue::Timeuuid(uuid.into())
-        );
-
-        assert_eq!(
-            try_from_json(Value::String("2025-09-01".to_string()), &NativeType::Date).unwrap(),
-            CqlValue::Date(
-                Date::from_calendar_date(2025, time::Month::September, 1)
-                    .unwrap()
-                    .into()
-            )
-        );
-        assert_eq!(
-            try_from_json(
-                Value::String("12:10:10.000000000".to_string()),
-                &NativeType::Time
-            )
-            .unwrap(),
-            CqlValue::Time(Time::from_hms(12, 10, 10).unwrap().into())
-        );
-        assert_eq!(
-            try_from_json(
-                Value::String(
-                    // truncate microseconds
-                    OffsetDateTime::from_unix_timestamp(123456789)
-                        .unwrap()
-                        .format({
-                            const CONFIG: u128 = Config::DEFAULT
-                                .set_time_precision(TimePrecision::Second {
-                                    decimal_digits: NonZero::new(3),
-                                })
-                                .encode();
-                            &Iso8601::<CONFIG>
-                        })
-                        .unwrap()
-                ),
-                &NativeType::Timestamp
-            )
-            .unwrap(),
-            CqlValue::Timestamp(
-                OffsetDateTime::from_unix_timestamp(123456789)
-                    .unwrap()
-                    .into()
-            )
-        );
-
-        // CQL-style timestamp with space separator and Z offset
-        assert_eq!(
-            try_from_json(
-                Value::String("2024-01-01 00:00:00.000Z".to_string()),
-                &NativeType::Timestamp
-            )
-            .unwrap(),
-            CqlValue::Timestamp(
-                OffsetDateTime::from_unix_timestamp(1704067200)
-                    .unwrap()
-                    .into()
-            )
-        );
-
-        // CQL-style timestamp with space separator, Z offset, and non-zero time
-        assert_eq!(
-            try_from_json(
-                Value::String("1970-01-01 00:01:04.000Z".to_string()),
-                &NativeType::Timestamp
-            )
-            .unwrap(),
-            CqlValue::Timestamp(OffsetDateTime::from_unix_timestamp(64).unwrap().into())
-        );
-
-        assert_eq!(
-            try_from_json(Value::String("0xdeadbeef".to_string()), &NativeType::Blob).unwrap(),
-            CqlValue::Blob(vec![0xde, 0xad, 0xbe, 0xef])
-        );
-        assert_eq!(
-            try_from_json(Value::String("0x".to_string()), &NativeType::Blob).unwrap(),
-            CqlValue::Blob(vec![])
-        );
-        assert_eq!(
-            try_from_json(Value::String("0x00".to_string()), &NativeType::Blob).unwrap(),
-            CqlValue::Blob(vec![0x00])
-        );
-
-        // missing 0x prefix
-        assert!(try_from_json(Value::String("deadbeef".to_string()), &NativeType::Blob).is_err());
-        // invalid hex characters
-        assert!(try_from_json(Value::String("0xgg".to_string()), &NativeType::Blob).is_err());
-        // odd-length hex digits (after stripping prefix)
-        assert!(try_from_json(Value::String("0xabc".to_string()), &NativeType::Blob).is_err());
-
-        // Varint from string
-        assert_eq!(
-            try_from_json(
-                Value::String("-98765432109876543210987654321098765432109876543210".to_string()),
-                &NativeType::Varint
-            )
-            .unwrap(),
-            CqlValue::Varint(CqlVarint::from(
-                "-98765432109876543210987654321098765432109876543210"
-                    .parse::<BigInt>()
-                    .unwrap()
-            ))
-        );
-        assert!(
-            try_from_json(
-                Value::String("not_a_number".to_string()),
-                &NativeType::Varint
-            )
-            .is_err()
-        );
-        // Varint from JSON number
-        assert_eq!(
-            try_from_json(Value::Number((-9876543210i64).into()), &NativeType::Varint).unwrap(),
-            CqlValue::Varint(CqlVarint::from(BigInt::from(-9876543210i64)))
-        );
-
-        // Decimal from string
-        assert_eq!(
-            try_from_json(
-                Value::String("-98765432109876543210.123456789".to_string()),
-                &NativeType::Decimal
-            )
-            .unwrap(),
-            CqlValue::Decimal(
-                CqlDecimal::try_from(
-                    "-98765432109876543210.123456789"
-                        .parse::<BigDecimal>()
-                        .unwrap()
-                )
-                .unwrap()
-            )
-        );
-        assert!(
-            try_from_json(
-                Value::String("not_a_decimal".to_string()),
-                &NativeType::Decimal
-            )
-            .is_err()
-        );
-        // Decimal from JSON number
-        assert_eq!(
-            try_from_json(
-                Value::Number(Number::from_f64(-1.25).unwrap()),
-                &NativeType::Decimal
-            )
-            .unwrap(),
-            CqlValue::Decimal(
-                CqlDecimal::try_from("-1.25".parse::<BigDecimal>().unwrap()).unwrap()
-            )
         );
     }
 

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -6,6 +6,7 @@
 mod alternator;
 mod async_in_progress;
 mod config_manager;
+mod cql_types;
 pub mod db;
 mod db_cdc;
 pub mod db_index;

--- a/crates/vector-store/src/table/mod.rs
+++ b/crates/vector-store/src/table/mod.rs
@@ -21,27 +21,24 @@ use crate::PrimaryKey;
 use crate::Restriction;
 use crate::Timestamp;
 use crate::Vector;
+use crate::cql_types;
 use crate::primary_key::normalize;
 use crate::table::chunk_timestamps::ChunkTimestampsExclusive;
 use crate::timestamp::Timestamped;
 use anyhow::anyhow;
 use anyhow::bail;
-use bigdecimal::BigDecimal;
 use chunk_timestamps::ChunkTimestamps;
 use column::Column;
 use column_vec::ColumnVec;
 use column_vec_chunks::ColumnVecChunks;
 use itertools::Itertools;
-use num_bigint::BigInt;
 pub(crate) use partition_id::IndexId;
 pub(crate) use partition_id::IndexIdGenerator;
 pub use partition_id::PartitionId;
 use primary_id::Epoch;
 pub use primary_id::PrimaryId;
 use scylla::cluster::metadata::NativeType;
-use scylla::value::CqlDecimalBorrowed;
 use scylla::value::CqlValue;
-use scylla::value::CqlVarintBorrowed;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -1201,7 +1198,7 @@ impl TableSearch for Table {
                 .and_then(|column| column.get(primary_id, &self.primary_keys))
                 .and_then(|value| {
                     rhs.iter()
-                        .filter_map(|rhs| cql_cmp(&value, rhs))
+                        .filter_map(|rhs| cql_types::cmp(&value, rhs))
                         .any(|ord| ord.is_eq())
                         .then_some(())
                 })
@@ -1244,9 +1241,9 @@ impl TableSearch for Table {
                 lhs.and_then(|lhs| {
                     rhs.iter()
                         .any(|rhs| {
-                            lhs.iter()
-                                .zip(rhs.iter())
-                                .all(|(lhs, rhs)| cql_cmp(lhs, rhs).is_some_and(|ord| ord.is_eq()))
+                            lhs.iter().zip(rhs.iter()).all(|(lhs, rhs)| {
+                                cql_types::cmp(lhs, rhs).is_some_and(|ord| ord.is_eq())
+                            })
                         })
                         .then_some(())
                 })
@@ -1315,51 +1312,6 @@ fn partition_key_from_restrictions(
         })
 }
 
-/// Compare two CqlValues, returning an Ordering if they are comparable.
-/// Only Numeric, Text, Date, Time, and Timestamp types support comparison operators.
-fn cql_cmp(lhs: &CqlValue, rhs: &CqlValue) -> Option<Ordering> {
-    match (lhs, rhs) {
-        // Numeric types
-        (CqlValue::TinyInt(a), CqlValue::TinyInt(b)) => Some(a.cmp(b)),
-        (CqlValue::SmallInt(a), CqlValue::SmallInt(b)) => Some(a.cmp(b)),
-        (CqlValue::Int(a), CqlValue::Int(b)) => Some(a.cmp(b)),
-        (CqlValue::BigInt(a), CqlValue::BigInt(b)) => Some(a.cmp(b)),
-        (CqlValue::Float(a), CqlValue::Float(b)) => a.partial_cmp(b),
-        (CqlValue::Double(a), CqlValue::Double(b)) => a.partial_cmp(b),
-        (CqlValue::Counter(a), CqlValue::Counter(b)) => Some(a.0.cmp(&b.0)),
-        // Varint: semantic comparison via num-bigint
-        (CqlValue::Varint(a), CqlValue::Varint(b)) => {
-            let a_bi = BigInt::from(CqlVarintBorrowed::from_signed_bytes_be_slice(
-                a.as_signed_bytes_be_slice(),
-            ));
-            let b_bi = BigInt::from(CqlVarintBorrowed::from_signed_bytes_be_slice(
-                b.as_signed_bytes_be_slice(),
-            ));
-            Some(a_bi.cmp(&b_bi))
-        }
-        (CqlValue::Decimal(a), CqlValue::Decimal(b)) => {
-            let (a_bytes, a_scale) = a.as_signed_be_bytes_slice_and_exponent();
-            let (b_bytes, b_scale) = b.as_signed_be_bytes_slice_and_exponent();
-            let a_bd = BigDecimal::from(
-                CqlDecimalBorrowed::from_signed_be_bytes_slice_and_exponent(a_bytes, a_scale),
-            );
-            let b_bd = BigDecimal::from(
-                CqlDecimalBorrowed::from_signed_be_bytes_slice_and_exponent(b_bytes, b_scale),
-            );
-            Some(a_bd.cmp(&b_bd))
-        }
-        // Text types
-        (CqlValue::Text(a), CqlValue::Text(b)) => Some(a.cmp(b)),
-        (CqlValue::Ascii(a), CqlValue::Ascii(b)) => Some(a.cmp(b)),
-        // Date and Time types (access inner values directly)
-        (CqlValue::Date(a), CqlValue::Date(b)) => Some(a.0.cmp(&b.0)),
-        (CqlValue::Time(a), CqlValue::Time(b)) => Some(a.0.cmp(&b.0)),
-        (CqlValue::Timestamp(a), CqlValue::Timestamp(b)) => Some(a.0.cmp(&b.0)),
-        // Unsupported or mismatched types
-        _ => None,
-    }
-}
-
 /// Compare a column value for a given primary_id with a CqlValue.
 fn cql_cmp_single(
     columns: &BTreeMap<ColumnName, Column>,
@@ -1371,7 +1323,7 @@ fn cql_cmp_single(
     columns
         .get(lhs)
         .and_then(|column| column.get(primary_id, primary_keys))
-        .and_then(|value| cql_cmp(&value, rhs))
+        .and_then(|value| cql_types::cmp(&value, rhs))
 }
 
 /// Returns the ordering of the first non-equal pair, or None if all pairs are equal.
@@ -1420,7 +1372,6 @@ pub(crate) enum Operation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use scylla::value::CqlDecimal;
 
     #[test]
     fn flow() {
@@ -2383,206 +2334,6 @@ mod tests {
         );
         let values = NonemptyBox::new([value1, value2]).unwrap();
         assert!(split_values_filtering(values).is_err());
-    }
-
-    #[test]
-    fn cql_cmp_integers() {
-        assert_eq!(
-            cql_cmp(&CqlValue::Int(1), &CqlValue::Int(2)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(&CqlValue::Int(2), &CqlValue::Int(2)),
-            Some(Ordering::Equal)
-        );
-        assert_eq!(
-            cql_cmp(&CqlValue::Int(3), &CqlValue::Int(2)),
-            Some(Ordering::Greater)
-        );
-    }
-
-    #[test]
-    fn cql_cmp_bigints() {
-        assert_eq!(
-            cql_cmp(&CqlValue::BigInt(100), &CqlValue::BigInt(200)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(&CqlValue::BigInt(-50), &CqlValue::BigInt(-50)),
-            Some(Ordering::Equal)
-        );
-    }
-
-    #[test]
-    fn cql_cmp_floats() {
-        assert_eq!(
-            cql_cmp(&CqlValue::Float(1.0), &CqlValue::Float(2.0)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(&CqlValue::Float(2.5), &CqlValue::Float(2.5)),
-            Some(Ordering::Equal)
-        );
-        // NaN comparison returns None
-        assert_eq!(
-            cql_cmp(&CqlValue::Float(f32::NAN), &CqlValue::Float(1.0)),
-            None
-        );
-    }
-
-    #[test]
-    fn cql_cmp_doubles() {
-        assert_eq!(
-            cql_cmp(&CqlValue::Double(1.0), &CqlValue::Double(2.0)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(&CqlValue::Double(f64::NAN), &CqlValue::Double(1.0)),
-            None
-        );
-    }
-
-    #[test]
-    fn cql_cmp_text() {
-        assert_eq!(
-            cql_cmp(
-                &CqlValue::Text("apple".to_string()),
-                &CqlValue::Text("banana".to_string())
-            ),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(
-                &CqlValue::Text("same".to_string()),
-                &CqlValue::Text("same".to_string())
-            ),
-            Some(Ordering::Equal)
-        );
-    }
-
-    #[test]
-    fn cql_cmp_ascii() {
-        assert_eq!(
-            cql_cmp(
-                &CqlValue::Ascii("aaa".to_string()),
-                &CqlValue::Ascii("bbb".to_string())
-            ),
-            Some(Ordering::Less)
-        );
-    }
-
-    #[test]
-    fn cql_cmp_smallint_and_tinyint() {
-        assert_eq!(
-            cql_cmp(&CqlValue::SmallInt(10), &CqlValue::SmallInt(20)),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(&CqlValue::TinyInt(5), &CqlValue::TinyInt(3)),
-            Some(Ordering::Greater)
-        );
-    }
-
-    #[test]
-    fn cql_cmp_mismatched_types_return_none() {
-        assert_eq!(cql_cmp(&CqlValue::Int(1), &CqlValue::BigInt(1)), None);
-        assert_eq!(
-            cql_cmp(&CqlValue::Int(1), &CqlValue::Text("1".to_string())),
-            None
-        );
-        assert_eq!(cql_cmp(&CqlValue::Float(1.0), &CqlValue::Double(1.0)), None);
-    }
-
-    #[test]
-    fn cql_cmp_varint() {
-        use num_bigint::BigInt;
-        use scylla::value::CqlVarint;
-        let make = |s: &str| CqlValue::Varint(CqlVarint::from(s.parse::<BigInt>().unwrap()));
-
-        assert_eq!(
-            cql_cmp(&make("-1000000000000000000000"), &make("0")),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(&make("99999999999999999999"), &make("99999999999999999999")),
-            Some(Ordering::Equal)
-        );
-        assert_eq!(
-            cql_cmp(
-                &make("100000000000000000001"),
-                &make("99999999999999999999")
-            ),
-            Some(Ordering::Greater)
-        );
-        // negative values
-        assert_eq!(
-            cql_cmp(
-                &make("-98765432109876543210"),
-                &make("-12345678901234567890")
-            ),
-            Some(Ordering::Less)
-        );
-        assert_eq!(cql_cmp(&make("-1"), &make("1")), Some(Ordering::Less));
-        // large positive vs large negative
-        assert_eq!(
-            cql_cmp(
-                &make("98765432109876543210987654321098765432109876543210"),
-                &make("-98765432109876543210987654321098765432109876543210")
-            ),
-            Some(Ordering::Greater)
-        );
-    }
-
-    #[test]
-    fn cql_cmp_decimal() {
-        let make = |s: &str| {
-            CqlValue::Decimal(CqlDecimal::try_from(s.parse::<BigDecimal>().unwrap()).unwrap())
-        };
-
-        assert_eq!(
-            cql_cmp(&make("-98765432109876543210.123456789"), &make("0")),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(
-                &make("3.14159265358979323846"),
-                &make("3.14159265358979323846")
-            ),
-            Some(Ordering::Equal)
-        );
-        assert_eq!(
-            cql_cmp(
-                &make("1000000000000000000.000000001"),
-                &make("999999999999999999.999999999")
-            ),
-            Some(Ordering::Greater)
-        );
-        // different scales for semantically equal value: 1.50 == 1.5
-        assert_eq!(cql_cmp(&make("1.50"), &make("1.5")), Some(Ordering::Equal));
-        // negative comparisons
-        assert_eq!(
-            cql_cmp(&make("-0.000000001"), &make("0.000000001")),
-            Some(Ordering::Less)
-        );
-        assert_eq!(
-            cql_cmp(&make("-1.25"), &make("-1.125")),
-            Some(Ordering::Less)
-        );
-    }
-
-    #[test]
-    fn cql_cmp_unsupported_types_return_none() {
-        assert_eq!(
-            cql_cmp(
-                &CqlValue::Blob(vec![1, 2, 3]),
-                &CqlValue::Blob(vec![1, 2, 3])
-            ),
-            None
-        );
-        assert_eq!(
-            cql_cmp(&CqlValue::Boolean(true), &CqlValue::Boolean(false)),
-            None
-        );
     }
 
     #[test]

--- a/crates/vector-store/tests/integration/vs_index.rs
+++ b/crates/vector-store/tests/integration/vs_index.rs
@@ -24,6 +24,9 @@ use scylla::value::Counter;
 use scylla::value::CqlValue;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -716,6 +719,128 @@ async fn ann_failed_when_wrong_number_of_primary_keys(#[case] config: Config) {
         "Waiting for index to be return internal server error on ANN",
     )
     .await;
+}
+
+/// Regression for VECTOR-878.
+/// An inet primary key must not panic the worker.
+#[rstest]
+#[case::usearch(usearch_test_config())]
+#[case::diskann(diskann_test_config())]
+#[tokio::test]
+async fn ann_returns_inet_primary_key(#[case] config: Config) {
+    crate::enable_tracing();
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        config,
+        DbIndexPartitioning::Global,
+        vec!["addr".into()],
+        1,
+        [("addr".into(), NativeType::Inet)],
+        Some(db_basic::scan_fn_vectors([
+            (
+                [CqlValue::Inet(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))].into(),
+                Some(vec![1., 0., 0.].into()),
+                [].into(),
+                Timestamp::from_millis(10),
+            ),
+            (
+                [CqlValue::Inet(IpAddr::V6(Ipv6Addr::new(
+                    0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                )))]
+                .into(),
+                Some(vec![0., 1., 0.].into()),
+                [].into(),
+                Timestamp::from_millis(10),
+            ),
+        ])),
+        None,
+        Some(2),
+    )
+    .await;
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
+    let (primary_keys, distances, _) = client
+        .ann(
+            &keyspace_name,
+            &index_name,
+            vec![1.0, 0.0, 0.0].into(),
+            None,
+            NonZeroUsize::new(2).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(distances.len(), 2);
+    let addrs = primary_keys.get(&"addr".into()).unwrap();
+    assert_eq!(addrs.len(), 2);
+
+    // Nearest neighbour is the IPv4 row.
+    assert_eq!(addrs.first().unwrap().as_str().unwrap(), "10.0.0.1");
+    assert_eq!(
+        addrs
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect::<HashSet<_>>(),
+        ["10.0.0.1", "2001:db8::1"].into_iter().collect()
+    );
+}
+
+/// An `inet` filter must match rows, not silently exclude them.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn ann_filter_inet_eq() {
+    crate::enable_tracing();
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        usearch_test_config(),
+        DbIndexPartitioning::Global,
+        vec!["addr".into()],
+        1,
+        [("addr".into(), NativeType::Inet)],
+        Some(db_basic::scan_fn_vectors([
+            (
+                [CqlValue::Inet(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))].into(),
+                Some(vec![1., 0., 0.].into()),
+                [].into(),
+                Timestamp::from_millis(10),
+            ),
+            (
+                [CqlValue::Inet(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)))].into(),
+                Some(vec![0., 1., 0.].into()),
+                [].into(),
+                Timestamp::from_millis(10),
+            ),
+        ])),
+        None,
+        Some(2),
+    )
+    .await;
+
+    let addr_column: httpapi::ColumnName = "addr".into();
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
+    let (primary_keys, distances, _) = client
+        .ann(
+            &keyspace_name,
+            &index_name,
+            vec![1.0, 0.0, 0.0].into(),
+            Some(PostIndexAnnFilter {
+                restrictions: vec![PostIndexAnnRestriction::Eq {
+                    lhs: addr_column.clone(),
+                    rhs: "10.0.0.2".into(),
+                }],
+                allow_filtering: true,
+            }),
+            NonZeroUsize::new(10).unwrap().into(),
+        )
+        .await;
+
+    // Exactly the filtered row, not an empty result set.
+    assert_eq!(distances.len(), 1);
+    let addrs = primary_keys.get(&addr_column).unwrap();
+    assert_eq!(addrs.len(), 1);
+    assert_eq!(addrs.first().unwrap().as_str().unwrap(), "10.0.0.2");
 }
 
 /// Regression for VECTOR-878.

--- a/crates/vector-store/tests/integration/vs_index.rs
+++ b/crates/vector-store/tests/integration/vs_index.rs
@@ -20,6 +20,7 @@ use httpclient::HttpClient;
 use reqwest::StatusCode;
 use rstest::rstest;
 use scylla::cluster::metadata::NativeType;
+use scylla::value::Counter;
 use scylla::value::CqlValue;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -715,6 +716,51 @@ async fn ann_failed_when_wrong_number_of_primary_keys(#[case] config: Config) {
         "Waiting for index to be return internal server error on ANN",
     )
     .await;
+}
+
+/// Regression for VECTOR-878.
+/// An unsupported key type must fail the request, not panic the worker.
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn ann_returns_error_for_unsupported_primary_key_type() {
+    crate::enable_tracing();
+    let (index, client, _db, _server, _node_state) = setup_store_and_wait_for_index(
+        usearch_test_config(),
+        DbIndexPartitioning::Global,
+        vec!["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        Some(db_basic::scan_fn_vectors([(
+            [CqlValue::Counter(Counter(1))].into(),
+            Some(vec![1., 1., 1.].into()),
+            [].into(),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+        Some(1),
+    )
+    .await;
+
+    let keyspace_name = index.keyspace_name.clone().into();
+    let index_name = index.index_name.clone().into();
+
+    let response = client
+        .post_ann(
+            &keyspace_name,
+            &index_name,
+            vec![1.0, 1.0, 1.0].into(),
+            None,
+            NonZeroUsize::new(1).unwrap().into(),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let message = response.text().await.unwrap();
+    assert!(
+        message.contains("unsupported CQL type"),
+        "error should report the unsupported type, got: {message}"
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
Vector Store panicked the worker thread instead of returning an error when a primary key column held a type the JSON key codec didn't handle — including `inet`, which is valid CQL but had no support anywhere in the stack. A single row of an unexpected type could take down the query path for an entire index.

This PR:
- Adds full `inet` support: JSON serialization/deserialization of primary keys, and comparison for filter restrictions.
- Replaces the panicking catch-all with a proper HTTP error when converting a key value, and rejects unsupported primary key column types at index discovery (skipping that index with a clear log message instead of crashing on the first query).
- Consolidates CQL type handling — which types are supported, JSON conversion, and comparison — into a single `cql_types` module, replacing logic that was previously duplicated across `httproutes` and `table`.

Blob, boolean, uuid and timeuuid columns still can't be used in filter restrictions; that gap is tracked separately (VECTOR-889) and pinned by a test so it can't regress silently while it's open.

Fixes: VECTOR-878
Refs: VECTOR-889