### PR TITLE
vector-store: fix indexing bug for filtering on a primary-key column

### DIFF
--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -748,6 +748,75 @@ async fn local_index_filter_by_filtering_columns(actors: Arc<TestActors>) {
     info!("finished");
 }
 
+/// Regression test for VECTOR-892: a vector index can declare a filtering
+/// column that is also one of the base table's primary-key columns. But
+/// vector-store used to misalign the stored column values in that case:
+/// every upserted row failed with "cannot insert value into a PrimaryKey
+/// column", so the index stayed fully "built" at 0 rows and ANN queries
+/// against it silently returned nothing.
+///
+/// The order of the declared filtering columns matters: "ck" (the
+/// primary-key column) must come before "f" for the misalignment to
+/// manifest - the other order happens to leave "f" correctly aligned and
+/// just drops "ck", which produces no visible symptom for this test.
+#[e2etest::test(group = filtering)]
+async fn global_index_filter_by_filtering_column_shared_with_primary_key(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, ck INT, f INT, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk, ck)",
+        None,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, ck, f, v) VALUES (1, 2, 10, [0.1, 0.2, 0.3])"),
+            (),
+        )
+        .await
+        .expect("failed to insert data");
+
+    // No .partition_columns() -> global index. "ck" is a clustering-key column.
+    let index = create_index(
+        CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["ck", "f"]),
+    )
+    .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 1, "Expected 1 vector to be indexed");
+    }
+
+    let results = get_query_results(
+        format!(
+            "SELECT pk FROM {table} WHERE ck = 2 AND f = 10 \
+            ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 1 ALLOW FILTERING"
+        ),
+        &session,
+    )
+    .await;
+    assert_eq!(
+        results
+            .rows::<(i32,)>()
+            .expect("failed to get rows")
+            .rows_remaining(),
+        1,
+        "expected the row back"
+    );
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
 /// Test ANN search filtered by partition key equality on a local index.
 ///
 /// Create a local index partitioned by pk. Insert rows across multiple

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -273,12 +273,7 @@ impl CdcConsumerFactory {
             .ok_or_else(|| anyhow!("primary key must have at least one column"))?;
 
         let target_columns = metadata.target_columns.clone();
-        let filtering_columns: Arc<[_]> = metadata
-            .filtering_columns
-            .iter()
-            .filter(|column| !primary_key_columns.contains(column))
-            .cloned()
-            .collect();
+        let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
 
         let nonpk_partition_key_columns: Box<[_]> = metadata
             .nonpk_partition_key_columns()

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -338,12 +338,7 @@ impl Statements {
         );
 
         let target_columns = metadata.target_columns.clone();
-        let filtering_columns: Arc<[_]> = metadata
-            .filtering_columns
-            .iter()
-            .filter(|column| !primary_key_columns.contains(column))
-            .cloned()
-            .collect();
+        let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
 
         let table_columns = Arc::new(
             table

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+use crate::ColumnName;
 use crate::Config;
 use crate::DbIndexPartitioning;
 use crate::IndexKey;
@@ -26,6 +27,8 @@ use crate::table::Table;
 use crate::vs_index::VsIndexConfiguration;
 use crate::vs_index::VsIndexFactory;
 use crate::vs_index::VsIndexSearch;
+use scylla::cluster::metadata::NativeType;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::time::Duration;
@@ -180,6 +183,31 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
+/// Builds the in-memory `Table` for `metadata`, given the native-typed columns of the
+/// underlying CQL table.
+fn build_table(
+    key: &IndexKey,
+    metadata: &IndexMetadata,
+    table_columns: Arc<HashMap<ColumnName, NativeType>>,
+) -> anyhow::Result<Table> {
+    let partition_key_columns = match &metadata.partitioning {
+        DbIndexPartitioning::Local(partition_key_columns) => Some(partition_key_columns.clone()),
+        DbIndexPartitioning::Global => None,
+    };
+    // Must match the columns db_index.rs/db_cdc actually fetch a value for,
+    // or Table::new()'s column list goes out of sync with update_columns().
+    let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
+    Table::new(
+        key.clone(),
+        metadata.primary_key_columns.clone(),
+        metadata.partition_key_count,
+        partition_key_columns,
+        metadata.target_columns.len(),
+        filtering_columns,
+        table_columns,
+    )
+}
+
 async fn add_index(
     metadata: IndexMetadata,
     tx: oneshot::Sender<AddIndexR>,
@@ -209,19 +237,7 @@ async fn add_index(
     };
 
     let table_columns = db_index.get_table_columns().await;
-    let partition_key_columns = match &metadata.partitioning {
-        DbIndexPartitioning::Local(partition_key_columns) => Some(partition_key_columns.clone()),
-        DbIndexPartitioning::Global => None,
-    };
-    let table = match Table::new(
-        key.clone(),
-        metadata.primary_key_columns.clone(),
-        metadata.partition_key_count,
-        partition_key_columns,
-        metadata.target_columns.len(),
-        Arc::clone(&metadata.filtering_columns),
-        table_columns,
-    ) {
+    let table = match build_table(&key, &metadata, table_columns) {
         Ok(table) => Arc::new(RwLock::new(table)),
         Err(err) => {
             debug!("unable to create a table cache for an index {key}: {err}");
@@ -467,5 +483,130 @@ pub(crate) mod tests {
         );
 
         tx
+    }
+
+    /// A local index can declare a filtering column ("ck") that is also one of the base
+    /// table's primary-key columns. This drives build_table() - the code that add_index()
+    /// actually calls - end to end with the real (undeduped) metadata.filtering_columns,
+    /// then upserts a row the way db_index.rs/db_cdc really would (no fetched value for
+    /// "ck", since it comes from the primary key) and checks the target vector and the
+    /// other filtering column ("f") land on the right columns. Unlike
+    /// table::tests::local_index_filtering_on_primary_key_column_stays_aligned, which
+    /// hands Table::new() an already-deduped column list, this test would fail if
+    /// build_table() ever went back to passing metadata.filtering_columns through as-is.
+    #[test]
+    fn build_table_dedupes_filtering_column_shared_with_primary_key() {
+        use crate::Connectivity;
+        use crate::CqlValue;
+        use crate::DbIndexedValue;
+        use crate::Dimensions;
+        use crate::ExpansionAdd;
+        use crate::ExpansionSearch;
+        use crate::IndexOptionsVs;
+        use crate::NonemptyArc;
+        use crate::NonemptyBox;
+        use crate::PrimaryKey;
+        use crate::Quantization;
+        use crate::Restriction;
+        use crate::SpaceType;
+        use crate::Timestamp;
+        use crate::table::Operation;
+        use crate::table::TableModify;
+        use crate::table::TableSearch;
+        use crate::timestamp::Timestamped;
+        use std::num::NonZeroUsize;
+        use uuid::Uuid;
+
+        let metadata = IndexMetadata {
+            keyspace_name: "ks".into(),
+            index_name: "idx".into(),
+            table_name: "tbl".into(),
+            // The base table's primary key: "pk" is the partition key, "ck" a
+            // clustering key.
+            primary_key_columns: NonemptyArc::new(["pk", "ck"]).unwrap(),
+            partition_key_count: NonZeroUsize::new(1).unwrap(),
+            target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+            // The local index is partitioned by "pk" alone, so "ck" is not part of
+            // its own partition key either.
+            partitioning: DbIndexPartitioning::Local(NonemptyArc::new(["pk"]).unwrap()),
+            // Declares "ck" (a primary-key column) and "f" (a genuine value column)
+            // as filtering columns, exactly as metadata coming from the DB would.
+            filtering_columns: Arc::new(["ck".into(), "f".into()]),
+            version: Uuid::new_v4().into(),
+            kind: IndexKind::Vs(IndexOptionsVs {
+                dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),
+                connectivity: Connectivity::default(),
+                expansion_add: ExpansionAdd::default(),
+                expansion_search: ExpansionSearch::default(),
+                space_type: SpaceType::default(),
+                quantization: Quantization::default(),
+            }),
+        };
+
+        let table_columns = Arc::new(
+            [
+                ("pk".into(), NativeType::Int),
+                ("ck".into(), NativeType::Int),
+                ("f".into(), NativeType::Int),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let mut table = build_table(&metadata.key(), &metadata, table_columns).unwrap();
+
+        // A row fetched by the real pipeline: a value for the target vector, then a
+        // value for each *non*-primary-key filtering column - "ck" has no value of
+        // its own here, matching db_index.rs/db_cdc.
+        let primary_key: PrimaryKey = [CqlValue::Int(1), CqlValue::Int(2)].into();
+        let values = NonemptyBox::<Timestamped<DbIndexedValue>>::new([
+            Timestamped::new(
+                Timestamp::from_millis(100),
+                Some(DbIndexedValue::Vector(vec![0.1, 0.2, 0.3].into())),
+            ),
+            Timestamped::new(
+                Timestamp::from_millis(100),
+                Some(DbIndexedValue::Filtering(CqlValue::Int(42))),
+            ),
+        ])
+        .unwrap();
+
+        let operations = table
+            .upsert(&metadata.key(), primary_key.clone(), values)
+            .unwrap();
+        assert_eq!(operations.len(), 1);
+        let (primary_id, partition_id) = match operations.first().unwrap() {
+            Operation::AddVector {
+                primary_id,
+                partition_id,
+                vector,
+                is_update: false,
+            } => {
+                assert_eq!(vector, &vec![0.1, 0.2, 0.3].into());
+                (*primary_id, *partition_id)
+            }
+            _ => panic!("Expected AddVector operation"),
+        };
+
+        assert_eq!(
+            table.primary_key(partition_id, primary_id).unwrap(),
+            primary_key
+        );
+        assert!(table.is_valid_for(
+            partition_id,
+            primary_id,
+            &Restriction::Eq {
+                lhs: "ck".into(),
+                rhs: CqlValue::Int(2),
+            }
+        ));
+        assert!(table.is_valid_for(
+            partition_id,
+            primary_id,
+            &Restriction::Eq {
+                lhs: "f".into(),
+                rhs: CqlValue::Int(42),
+            }
+        ));
     }
 }

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -747,6 +747,15 @@ impl IndexMetadata {
             ),
         }
     }
+
+    /// The subset of `filtering_columns` not already in `primary_key_columns`.
+    /// Table::new() stores a primary-key column as Column::PrimaryKey, not a
+    /// value slot, so it can't also be fetched/stored as a filtering column.
+    fn nonpk_filtering_columns(&self) -> impl Iterator<Item = &ColumnName> {
+        self.filtering_columns
+            .iter()
+            .filter(|col| !self.primary_key_columns.contains(col))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -1017,5 +1026,33 @@ mod tests {
     #[test]
     fn positions_defaults_to_enabled() {
         assert!(*Positions::default().as_ref());
+    }
+
+    #[test]
+    fn nonpk_filtering_columns_excludes_primary_key_columns() {
+        let metadata = IndexMetadata {
+            keyspace_name: "ks".into(),
+            index_name: "idx".into(),
+            table_name: "tbl".into(),
+            // "pk" is the partition key, "ck" a clustering key.
+            primary_key_columns: NonemptyArc::new(["pk", "ck"]).unwrap(),
+            partition_key_count: NonZeroUsize::new(1).unwrap(),
+            target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+            partitioning: DbIndexPartitioning::Local(NonemptyArc::new(["pk"]).unwrap()),
+            // "ck" is also a primary-key column; "f" is a genuine value column.
+            filtering_columns: Arc::new(["ck".into(), "f".into()]),
+            version: Uuid::new_v4().into(),
+            kind: IndexKind::Vs(IndexOptionsVs {
+                dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),
+                connectivity: Default::default(),
+                expansion_add: Default::default(),
+                expansion_search: Default::default(),
+                space_type: Default::default(),
+                quantization: Default::default(),
+            }),
+        };
+
+        let filtering_columns: Vec<_> = metadata.nonpk_filtering_columns().cloned().collect();
+        assert_eq!(filtering_columns, vec!["f".into()]);
     }
 }


### PR DESCRIPTION
This patch fixes a bug where vector indexing silently failed if vector-store filtering was enabled on one of the base table's primary key columns.

For example,
```
	CREATE TABLE ks.tbl (
	    pk INT,
	    ck INT,
	    f  INT,
	    v  VECTOR<FLOAT, 3>,
	    PRIMARY KEY (pk, ck)
	);

	CREATE CUSTOM INDEX idx ON ks.tbl (v, ck, f) USING 'vector_index';
```

Did not index anything, as the indexing code got confused on what it is trying to insert into the index:

engine.rs's add_index() passed the raw, as-declared list of filtering columns straight into the index's in-memory state, unchanged. Separately, the code that fetches each row's actual values (in db_index.rs and db_cdc/consumer.rs) already leaves out any filtering column that is also a primary-key column, since such a column's value comes from the primary key itself, not from a fetched value.

That mismatch meant two lists could end up different lengths: the stored filtering-column names (unfiltered) versus the values actually fetched per row (already filtered). Table::upsert() pairs these up one by one, name with value, in order. Once the lengths diverged, that pairing shifted, so a value meant for one column got attributed to another. Best case, the shifted value landed on a primary-key column and the whole row failed to index ("cannot insert value into PrimaryKey column"); worst case, it landed on a different real column and silently corrupted that column's stored value instead.

I originally discovered this bug while writing test for the new Alternator vector store API with different combinations of base table keys and vector index filtering keys, but as can be seen in the example above - the bug actually affects CQL as well. Any CQL vector index, local or global, that reuses a primary-key column as a filtering column hits this bug.

Fixed by adding IndexMetadata::nonpk_filtering_columns(), used by engine.rs (the actual fix, via a new build_table() helper factored out of add_index() for testability) and substituted for the equivalent ad-hoc filters already present in db_index.rs/db_cdc/consumer.rs (pure dedup there, no behavior change, but removes the risk of the two lists drifting apart again).

This patch also adds unit tests, and an end-to-end CQL test (validator):

- lib.rs: unit test for IndexMetadata::nonpk_filtering_columns() itself.
- engine.rs: unit test driving build_table() with a raw, undeduped filtering-column list - the same shape real index metadata has - and checking that upserting a row lands the target vector and every filtering column's value in the right place. Verified this test fails against the pre-fix code (panics with "Cannot insert value into PrimaryKey column") and passes against the fix.
- validator (crates/validator/src/filtering.rs): a CQL end-to-end regression test, global_index_filter_by_filtering_column_shared_with_primary_key. It creates a table with a composite primary key (pk, ck), a global vector index on "v" that also filters on "ck" (a clustering-key column) and "f" (an ordinary column), inserts a single row, and checks the row comes back from an ANN query restricted by both "ck" and "f". Run against a real ScyllaDB + Vector Store cluster: on the pre-fix code every upsert into the index fails ("Cannot insert value into PrimaryKey column" in the Vector Store log), the index reports as fully built with 0 rows indexed, and the ANN query silently returns nothing; with the fix, the row is indexed and returned correctly.

Fixes VECTOR-892