### PR TITLE
db_cdc: surface the real error when a CDC reader fails to start

### DIFF
--- a/crates/vector-store/src/db_cdc/actor.rs
+++ b/crates/vector-store/src/db_cdc/actor.rs
@@ -325,7 +325,7 @@ impl CdcReaderState {
                 );
             }
             Err(e) => {
-                error!("Failed to create {} CDC reader: {e}", self.name);
+                error!("Failed to create {} CDC reader: {e:#}", self.name);
                 self.set_reader_metric_down();
                 self.error_notify.notify_one();
             }

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -320,15 +320,14 @@ impl CdcConsumerFactory {
                 .chain(filtering_columns.iter()),
             primary_key_columns.iter(),
         );
-        let st_select_values =
-            session
-                .prepare(query)
-                .await
-                .context("request_query")?
-                .pipe(|mut stmt| {
-                    stmt.set_is_idempotent(true);
-                    stmt
-                });
+        let st_select_values = session
+            .prepare(query.as_str())
+            .await
+            .with_context(|| format!("request_query: {}", query.replace('\n', " ").trim()))?
+            .pipe(|mut stmt| {
+                stmt.set_is_idempotent(true);
+                stmt
+            });
 
         Ok(Self(Arc::new(CdcConsumerData {
             session,


### PR DESCRIPTION
    db_cdc: surface the real error when a CDC reader fails to start
    
    CdcReaderState::advance() logged CDC-reader startup failures as
    "Failed to create {name} CDC reader: {e}", but anyhow's `{}` Display
    only prints an Error's top-level context, not the chain underneath it.
    CdcConsumerFactory::new() wraps its prepare() failure in
    `.context("request_query")`, so every such failure - regardless of
    its actual cause - was logged as the single word "request_query", with
    the real driver error (or, as it turns out, no driver error at all -
    see the next commit) discarded.
    
    This made an index that fails to ever leave "Initializing" essentially
    undebuggable from the logs alone: the reader is retried silently on a
    timer, and the one line explaining why kept failing carried no
    information beyond a function name. Diagnosing the bug fixed in the
    next commit required adding this logging first, then rebuilding and
    reproducing, to learn the real query and error were not the problem.
    
    Fix both ends: log the anyhow chain with `{:#}` instead of `{}` so
    nested context survives, and give the `request_query` context an
    actual query string to point at instead of just its own name.
