### PR TITLE
Add mechanisms to support filtering columns in Alternator

### DIFF
--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -131,6 +131,7 @@ fn default_index_metadata(
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(dimensions).unwrap().into(),

--- a/crates/vector-store/src/alternator.rs
+++ b/crates/vector-store/src/alternator.rs
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+//! Decoding for Alternator's `:attrs` map column values.
+//!
+//! Alternator prefixes each attribute value in the `:attrs` map column with
+//! a 1-byte type discriminator, then the value's payload in whatever
+//! encoding that type uses. This module decodes both representations this
+//! crate needs: embedding vectors (see [`crate::vector::Vector`]) and
+//! scalar filtering/partition-key attribute values (see
+//! [`crate::IndexMetadata::alternator_attribute_types`]).
+
+use anyhow::anyhow;
+use anyhow::bail;
+use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::value::DeserializeValue;
+use scylla::value::CqlValue;
+
+// Alternator type tags. These match `enum class alternator_type` in
+// alternator/serialization.hh - do not reorder, these values are written to
+// disk as part of the item encoding.
+/// String (S) values: tag followed by the raw UTF-8 bytes.
+pub(crate) const ALTERNATOR_TYPE_S: u8 = 0;
+/// Bytes (B) values: tag followed by the raw bytes, as-is.
+pub(crate) const ALTERNATOR_TYPE_B: u8 = 1;
+/// Number (N) values: tag followed by the same wire encoding CQL's native
+/// `decimal` type uses (a 4-byte big-endian scale followed by a
+/// variable-length signed big-endian magnitude).
+pub(crate) const ALTERNATOR_TYPE_N: u8 = 3;
+/// Alternator type tag for unoptimized JSON encoding.
+/// Type `0x04` (`NOT_SUPPORTED_YET`) is used for any type that does not have an optimized encoding.
+/// The payload is an unoptimized JSON value.
+pub(crate) const ALTERNATOR_TYPE_JSON: u8 = 4;
+
+/// Alternator type tag for the optimized `FLOAT32VECTOR` type.
+/// The value is serialized as this 1-byte tag followed by sequential 32-bit big-endian floats,
+/// matching the CQL `VECTOR<float, N>` on-wire encoding.
+pub(crate) const ALTERNATOR_TYPE_FLOAT32VECTOR: u8 = 5;
+
+/// Decodes an Alternator-encoded scalar attribute value (a filtering or
+/// partition-key column with no real CQL column) into the `CqlValue`
+/// matching `native_type`. Like the vector column below, the value is
+/// tagged; this checks the tag matches `native_type` and re-deserializes
+/// the rest via the CQL driver, rather than reimplementing e.g. decimal
+/// parsing here.
+pub(crate) fn parse_alternator_scalar(
+    bytes: &[u8],
+    native_type: &NativeType,
+) -> anyhow::Result<CqlValue> {
+    let expected_tag = match native_type {
+        NativeType::Text | NativeType::Ascii => ALTERNATOR_TYPE_S,
+        NativeType::Blob => ALTERNATOR_TYPE_B,
+        NativeType::Decimal => ALTERNATOR_TYPE_N,
+        other => bail!(
+            "unsupported native type {other:?} for an Alternator filtering/partition-key attribute"
+        ),
+    };
+    let Some((&tag, payload)) = bytes.split_first() else {
+        bail!("empty blob for Alternator attribute value");
+    };
+    if tag != expected_tag {
+        bail!(
+            "Alternator attribute value has type tag {tag:#04x}, but column is declared as \
+            {native_type:?} (expected tag {expected_tag:#04x})"
+        );
+    }
+    let column_type = ColumnType::Native(native_type.clone());
+    CqlValue::deserialize(&column_type, Some(FrameSlice::new_borrowed(payload))).map_err(|err| {
+        anyhow!("failed to decode Alternator attribute value as {native_type:?}: {err}")
+    })
+}
+
+/// Parses an Alternator-encoded vector stored as raw bytes.
+///
+/// Alternator prefixes each attribute value in the `:attrs` map column with a 1-byte type discriminator.
+/// Handles two representations based on the discriminator:
+/// - [`ALTERNATOR_TYPE_FLOAT32VECTOR`]: optimized sequential 32-bit big-endian floats.
+/// - [`ALTERNATOR_TYPE_JSON`]: unoptimized JSON representing List values.
+pub(crate) fn parse_alternator_vector(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
+    match bytes.first() {
+        Some(&ALTERNATOR_TYPE_FLOAT32VECTOR) => parse_alternator_vector_binary(&bytes[1..]),
+        Some(&ALTERNATOR_TYPE_JSON) => parse_alternator_list_json(&bytes[1..]),
+        Some(tag) => bail!("unsupported Alternator type tag: {tag:#04x}"),
+        None => bail!("empty blob for Alternator attribute value"),
+    }
+}
+
+/// Parses the optimized Alternator vector encoding: sequential 32-bit big-endian floats.
+fn parse_alternator_vector_binary(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
+    let chunks = bytes.chunks_exact(4);
+
+    if !chunks.remainder().is_empty() {
+        bail!(
+            "invalid Alternator vector encoding: byte length {} is not a multiple of 4",
+            bytes.len()
+        );
+    }
+
+    Ok(chunks
+        .map(|chunk| {
+            let arr: [u8; 4] = chunk.try_into().expect("chunks_exact guarantees 4 bytes");
+            f32::from_be_bytes(arr)
+        })
+        .collect())
+}
+
+/// Parses an Alternator JSON list of numbers: `{"L": [{"N": "..."}, ...]}`.
+fn parse_alternator_list_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
+    #[derive(serde::Deserialize)]
+    struct DynamoDbList {
+        #[serde(rename = "L")]
+        l: Vec<DynamoDbNumber>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct DynamoDbNumber {
+        #[serde(rename = "N")]
+        n: String,
+    }
+
+    let list: DynamoDbList = serde_json::from_slice(bytes)?;
+    list.l
+        .into_iter()
+        .map(|item| {
+            item.n
+                .parse::<f32>()
+                .map_err(|e| anyhow!("invalid value in Alternator list element: {e}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scylla::value::CqlDecimal;
+
+    #[test]
+    fn parse_alternator_scalar_valid_text() {
+        let mut bytes = vec![ALTERNATOR_TYPE_S];
+        bytes.extend_from_slice(b"hello");
+        let result = parse_alternator_scalar(&bytes, &NativeType::Text).unwrap();
+        assert_eq!(result, CqlValue::Text("hello".to_string()));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_blob() {
+        let mut bytes = vec![ALTERNATOR_TYPE_B];
+        bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let result = parse_alternator_scalar(&bytes, &NativeType::Blob).unwrap();
+        assert_eq!(result, CqlValue::Blob(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_number() {
+        // 123 encoded as unscaled magnitude 0x7B with scale 0.
+        let decimal = CqlDecimal::from_signed_be_bytes_and_exponent(vec![0x7B], 0);
+        let (varint_bytes, scale) = decimal.as_signed_be_bytes_slice_and_exponent();
+        let mut bytes = vec![ALTERNATOR_TYPE_N];
+        bytes.extend_from_slice(&scale.to_be_bytes());
+        bytes.extend_from_slice(varint_bytes);
+        let result = parse_alternator_scalar(&bytes, &NativeType::Decimal).unwrap();
+        assert_eq!(result, CqlValue::Decimal(decimal));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_empty() {
+        assert!(parse_alternator_scalar(&[], &NativeType::Text).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_mismatched_tag() {
+        // Tagged as a string (S), but the column is declared as Blob (B).
+        let mut bytes = vec![ALTERNATOR_TYPE_S];
+        bytes.extend_from_slice(b"hello");
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Blob).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_malformed_number() {
+        // Tag matches, but only 2 bytes follow - not enough for the 4-byte scale.
+        let bytes = vec![ALTERNATOR_TYPE_N, 0x00, 0x00];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Decimal).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_malformed_text() {
+        // Tag matches, but the payload is not valid UTF-8.
+        let bytes = vec![ALTERNATOR_TYPE_S, 0xFF, 0xFE];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Text).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_unsupported_native_type() {
+        let bytes = vec![ALTERNATOR_TYPE_S, b'x'];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Int).is_err());
+    }
+}

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -856,6 +856,14 @@ impl Statements {
                         })?;
                     let partition_key_count = NonZeroUsize::new(table.partition_key.len()).unwrap();
                     let is_alternator = KeyspaceName::from(&keyspace_name).is_alternator();
+                    let alternator_attribute_types = Arc::new(if is_alternator {
+                        options
+                            .remove("alternator_attribute_types")
+                            .map(|v| parse_alternator_attribute_types(&v))
+                            .unwrap_or_default()
+                    } else {
+                        BTreeMap::new()
+                    });
                     Ok(options.remove("target").and_then(|target| {
                         let kind = db_index_kind_from_options(&mut options)?;
                         from_target_option(table, target, kind, is_alternator)
@@ -870,6 +878,7 @@ impl Statements {
                                         .expect("target column should be non-empty"),
                                     partitioning,
                                     filtering_columns,
+                                    alternator_attribute_types,
                                     kind,
                                 },
                             )
@@ -1104,6 +1113,39 @@ fn parse_target_option(table: &Table, value: &str) -> anyhow::Result<Option<Targ
         return Ok(Some(convert_legacy_target_option(table, legacy)?));
     };
     Ok(None)
+}
+
+/// Parses an Alternator index's "alternator_attribute_types" option: a JSON
+/// map from attribute name to declared DynamoDB type ("S"/"N"/"B"). While
+/// in Alternator in general attributes do not have a declared type, those
+/// used in SearchSchema (i.e. filtering and hash columns) do have a declared
+/// type, and Alternator stores it here, in alternator_attribute_types.
+fn parse_alternator_attribute_types(value: &str) -> BTreeMap<ColumnName, NativeType> {
+    serde_json::from_str::<BTreeMap<String, String>>(value)
+        .unwrap_or_else(|err| {
+            warn!(
+                "unsupported value '{value}' of the index option 'alternator_attribute_types': {err}, \
+                using the default"
+            );
+            BTreeMap::new()
+        })
+        .into_iter()
+        .filter_map(|(name, dynamodb_type)| {
+            let native_type = match dynamodb_type.as_str() {
+                "S" => NativeType::Text,
+                "N" => NativeType::Decimal,
+                "B" => NativeType::Blob,
+                _ => {
+                    warn!(
+                        "unsupported declared type '{dynamodb_type}' for attribute '{name}' \
+                        in the index option 'alternator_attribute_types', ignoring"
+                    );
+                    return None;
+                }
+            };
+            Some((ColumnName::from(name), native_type))
+        })
+        .collect()
 }
 
 fn convert_legacy_target_option(
@@ -1517,6 +1559,43 @@ pub(crate) mod tests {
     fn db_index_kind_from_options_unknown_returns_none() {
         let mut options = BTreeMap::from([("class_name".to_string(), "unknown_kind".to_string())]);
         assert_eq!(db_index_kind_from_options(&mut options), None);
+    }
+
+    #[test]
+    fn parse_alternator_attribute_types_valid() {
+        let types =
+            parse_alternator_attribute_types(r#"{"color": "S", "price": "N", "thumbnail": "B"}"#);
+        assert_eq!(
+            types,
+            BTreeMap::from([
+                (ColumnName::from("color"), NativeType::Text),
+                (ColumnName::from("price"), NativeType::Decimal),
+                (ColumnName::from("thumbnail"), NativeType::Blob),
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_alternator_attribute_types_empty_object() {
+        assert!(parse_alternator_attribute_types("{}").is_empty());
+    }
+
+    #[test]
+    fn parse_alternator_attribute_types_malformed_json_defaults_to_empty() {
+        assert!(parse_alternator_attribute_types("not json").is_empty());
+        assert!(parse_alternator_attribute_types(r#"{"color": 5}"#).is_empty());
+    }
+
+    #[test]
+    fn parse_alternator_attribute_types_unrecognized_type_is_omitted() {
+        // "BOOL" isn't one of the DynamoDB types we synthesize a NativeType
+        // for - the column is omitted rather than kept with a placeholder,
+        // so it's indistinguishable from a column with no declared type.
+        let types = parse_alternator_attribute_types(r#"{"flag": "BOOL", "color": "S"}"#);
+        assert_eq!(
+            types,
+            BTreeMap::from([(ColumnName::from("color"), NativeType::Text)])
+        );
     }
 
     #[test]

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -855,9 +855,10 @@ impl Statements {
                                 .context(InvalidMetadata)
                         })?;
                     let partition_key_count = NonZeroUsize::new(table.partition_key.len()).unwrap();
+                    let is_alternator = KeyspaceName::from(&keyspace_name).is_alternator();
                     Ok(options.remove("target").and_then(|target| {
                         let kind = db_index_kind_from_options(&mut options)?;
-                        from_target_option(table, target, kind)
+                        from_target_option(table, target, kind, is_alternator)
                             .map(
                                 |(partitioning, target_column, filtering_columns)| DbCustomIndex {
                                     keyspace: keyspace_name.into(),
@@ -1152,21 +1153,26 @@ fn from_target_option(
     table: &Table,
     value: String,
     kind: DbIndexKind,
+    is_alternator: bool,
 ) -> anyhow::Result<(DbIndexPartitioning, ColumnName, Arc<[ColumnName]>)> {
     let Some(target) = parse_target_option(table, &value)? else {
         // Global index with a single target column
         return Ok((DbIndexPartitioning::Global, value.into(), Arc::new([])));
     };
 
-    validate_target_column(table, &target.target_column, kind)?;
+    // Alternator's tc/pk columns may not be real columns in the table.
+    if !is_alternator {
+        validate_target_column(table, &target.target_column, kind)?;
+    }
 
     let partitioning = if target.partition_key_columns.is_empty() {
         DbIndexPartitioning::Global
     } else {
-        if let Some(invalid) = target
-            .partition_key_columns
-            .iter()
-            .find(|pk_col| !table.columns.contains_key(*pk_col))
+        if !is_alternator
+            && let Some(invalid) = target
+                .partition_key_columns
+                .iter()
+                .find(|pk_col| !table.columns.contains_key(*pk_col))
         {
             bail!("invalid target option: pk column {invalid} is not in the table's columns");
         }

--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -22,6 +22,8 @@ use anyhow::anyhow;
 use anyhow::bail;
 use async_trait::async_trait;
 use scylla::client::session::Session;
+use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
 use scylla::value::Row;
@@ -29,6 +31,7 @@ use scylla_cdc::consumer::CDCRow;
 use scylla_cdc::consumer::Consumer;
 use scylla_cdc::consumer::ConsumerFactory;
 use scylla_cdc::consumer::OperationType;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tap::Pipe;
 use tokio::sync::Semaphore;
@@ -50,6 +53,8 @@ struct CdcConsumerData {
     nonpk_partition_key_columns: Box<[ColumnName]>,
     target_columns: NonemptyArc<ColumnName>,
     filtering_columns: Arc<[ColumnName]>,
+    /// See Statements::alternator_decode_types in db_index.rs.
+    alternator_decode_types: Box<[Option<NativeType>]>,
     kind: IndexKind,
     tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
     metrics: Arc<Metrics>,
@@ -106,8 +111,13 @@ impl CdcConsumerData {
             bail!(msg);
         }
 
-        let values =
-            db_index::parse_values(row.columns, Some(timestamp), target_columns_len, &self.kind)?;
+        let values = db_index::parse_values(
+            row.columns,
+            Some(timestamp),
+            target_columns_len,
+            &self.kind,
+            &self.alternator_decode_types,
+        )?;
         _ = self
             .tx
             .send((
@@ -282,6 +292,25 @@ impl CdcConsumerFactory {
             .cloned()
             .collect();
 
+        let real_columns: HashMap<ColumnName, NativeType> = table
+            .columns
+            .iter()
+            .filter_map(|(name, coltype)| {
+                if let ColumnType::Native(typ) = &coltype.typ {
+                    Some((ColumnName::from(name.clone()), typ.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let alternator_decode_types = db_index::alternator_decode_types(
+            nonpk_partition_key_columns
+                .iter()
+                .chain(filtering_columns.iter()),
+            metadata,
+            &real_columns,
+        );
+
         let query = db_index_backend::request_query(
             &metadata.keyspace_name.as_ref().into(),
             &metadata.table_name.as_ref().into(),
@@ -309,6 +338,7 @@ impl CdcConsumerFactory {
             nonpk_partition_key_columns,
             target_columns,
             filtering_columns,
+            alternator_decode_types,
             kind: metadata.kind.clone(),
             tx,
             metrics,

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -284,6 +284,10 @@ struct Statements {
     nonpk_partition_key_columns: Box<[ColumnName]>,
     filtering_columns: Arc<[ColumnName]>,
     table_columns: GetTableColumnsR,
+    /// Aligned with nonpk_partition_key_columns + filtering_columns: the
+    /// NativeType to decode each one's raw ":attrs" value as, or None for a
+    /// real CQL column. See parse_values().
+    alternator_decode_types: Box<[Option<NativeType>]>,
     st_range_scan: PreparedStatement,
     kind: IndexKind,
 }
@@ -340,18 +344,38 @@ impl Statements {
         let target_columns = metadata.target_columns.clone();
         let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
 
+        let real_columns: HashMap<ColumnName, NativeType> = table
+            .columns
+            .iter()
+            .filter_map(|(name, coltype)| {
+                if let ColumnType::Native(typ) = &coltype.typ {
+                    Some((ColumnName::from(name.clone()), typ.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        // Merge in synthesized types for Alternator attributes with no real
+        // column (see IndexMetadata::alternator_attribute_types); real
+        // columns come last so they win on any name collision.
         let table_columns = Arc::new(
-            table
-                .columns
-                .iter()
-                .filter_map(|(name, coltype)| {
-                    if let ColumnType::Native(typ) = &coltype.typ {
-                        Some((ColumnName::from(name.clone()), typ.clone()))
-                    } else {
-                        None
-                    }
-                })
+            metadata
+                .alternator_attribute_types
+                .keys()
+                .filter_map(|name| Some((name.clone(), metadata.alternator_native_type(name)?)))
+                .chain(
+                    real_columns
+                        .iter()
+                        .map(|(name, typ)| (name.clone(), typ.clone())),
+                )
                 .collect(),
+        );
+        let alternator_decode_types = alternator_decode_types(
+            nonpk_partition_key_columns
+                .iter()
+                .chain(filtering_columns.iter()),
+            &metadata,
+            &real_columns,
         );
         let st_partition_key_list = table
             .partition_key
@@ -389,6 +413,7 @@ impl Statements {
             target_columns,
             filtering_columns,
             table_columns,
+            alternator_decode_types,
             st_range_scan,
             session_rx,
             kind: metadata.kind.clone(),
@@ -569,6 +594,7 @@ impl Statements {
         let target_columns_offset = self.primary_key_columns.len().get();
         let target_columns_len = self.target_columns.len();
         let kind = self.kind.clone();
+        let alternator_decode_types = self.alternator_decode_types.clone();
 
         // wait for an active session
         let session = {
@@ -604,6 +630,7 @@ impl Statements {
                     None,
                     target_columns_len,
                     &kind,
+                    &alternator_decode_types,
                 )
                 .inspect_err(|err| error!("Error while parsing values: {err}"))
                 .ok()?;
@@ -625,11 +652,35 @@ impl Statements {
     }
 }
 
+/// Builds parse_values()'s alternator_decode_types parameter: for each of
+/// `columns`, its NativeType from `metadata.alternator_native_type()` - or
+/// None if `column` is a real table column, even if it also has a declared
+/// Alternator type. A real column's raw value is whatever the CQL driver
+/// decoded it as, never a tagged Alternator blob, so it must never be run
+/// through parse_alternator_scalar().
+pub(crate) fn alternator_decode_types<'a>(
+    columns: impl IntoIterator<Item = &'a ColumnName>,
+    metadata: &IndexMetadata,
+    real_columns: &HashMap<ColumnName, NativeType>,
+) -> Box<[Option<NativeType>]> {
+    columns
+        .into_iter()
+        .map(|column| {
+            if real_columns.contains_key(column) {
+                None
+            } else {
+                metadata.alternator_native_type(column)
+            }
+        })
+        .collect()
+}
+
 pub(crate) fn parse_values(
     columns: impl IntoIterator<Item = Option<CqlValue>>,
     default_timestamp: Option<Timestamp>,
     target_columns_len: NonZeroUsize,
     kind: &IndexKind,
+    alternator_decode_types: &[Option<NativeType>],
 ) -> anyhow::Result<NonemptyBox<Timestamped<DbIndexedValue>>> {
     let default_timestamp = default_timestamp.unwrap_or(Timestamp::MIN);
     let values = columns
@@ -649,7 +700,20 @@ pub(crate) fn parse_values(
                     None
                 }
             } else {
-                // filtering columns
+                // filtering columns: a virtual Alternator attribute's raw
+                // value is a tagged blob that needs decoding first.
+                let native_type = alternator_decode_types
+                    .get(idx - target_columns_len.get())
+                    .cloned()
+                    .flatten();
+                let value = value
+                    .map(|value| match (value, native_type) {
+                        (CqlValue::Blob(bytes), Some(native_type)) => {
+                            crate::vector::parse_alternator_scalar(&bytes, &native_type)
+                        }
+                        (value, _) => Ok(value),
+                    })
+                    .transpose()?;
                 value.map(DbIndexedValue::Filtering)
             };
 
@@ -717,6 +781,7 @@ mod tests {
 
     use super::*;
     use crate::Connectivity;
+    use crate::DbIndexPartitioning;
     use crate::Dimensions;
     use crate::ExpansionAdd;
     use crate::ExpansionSearch;
@@ -725,6 +790,8 @@ mod tests {
     use crate::Quantization;
     use crate::SpaceType;
     use std::assert_matches;
+    use std::collections::BTreeMap;
+    use uuid::Uuid;
 
     fn vs_kind() -> IndexKind {
         IndexKind::Vs(IndexOptionsVs {
@@ -823,6 +890,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         )
         .unwrap();
         let result = result.as_slice();
@@ -848,6 +916,7 @@ mod tests {
             Some(Timestamp::from_millis(1)),
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         )
         .unwrap();
         let result = result.as_slice();
@@ -868,6 +937,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result
@@ -885,6 +955,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result
@@ -906,6 +977,7 @@ mod tests {
             None,
             NonZeroUsize::new(1).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result
@@ -928,6 +1000,7 @@ mod tests {
             None,
             NonZeroUsize::new(3).unwrap(),
             &vs_kind(),
+            &[],
         );
         assert_matches!(
             result
@@ -935,5 +1008,112 @@ mod tests {
                 .to_string(),
                 err if err.contains("target len (3) is greater than values len (2)")
         );
+    }
+
+    #[test]
+    fn parse_values_decodes_alternator_filtering_column() {
+        // Tag 0 = ALTERNATOR_TYPE_S (string), per vector.rs.
+        let mut tagged_name = vec![0u8];
+        tagged_name.extend_from_slice(b"red");
+
+        let columns = vec![
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(CqlValue::BigInt(1234567890)),
+            Some(CqlValue::Blob(tagged_name)),
+            Some(CqlValue::BigInt(1234567890)),
+        ];
+        let result = parse_values(
+            columns,
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+            &[Some(NativeType::Text)],
+        )
+        .unwrap();
+        let result = result.as_slice();
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result.get(1).unwrap().value().unwrap(),
+            &DbIndexedValue::Filtering(CqlValue::Text("red".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_values_leaves_real_column_undecoded() {
+        // alternator_decode_types has no entry (None) for this column,
+        // because it's a real CQL column, not a virtual Alternator
+        // attribute - its raw value must pass through unchanged.
+        let columns = vec![
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(CqlValue::BigInt(1234567890)),
+            Some(CqlValue::Int(42)),
+            Some(CqlValue::BigInt(1234567890)),
+        ];
+        let result = parse_values(
+            columns,
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+            &[None],
+        )
+        .unwrap();
+        let result = result.as_slice();
+        assert_eq!(
+            result.get(1).unwrap().value().unwrap(),
+            &DbIndexedValue::Filtering(CqlValue::Int(42))
+        );
+    }
+
+    #[test]
+    fn parse_values_rejects_mismatched_alternator_tag() {
+        // Tag 1 = ALTERNATOR_TYPE_B (bytes), but the column is declared
+        // "S" (Text) - parse_alternator_scalar() must reject this rather
+        // than silently misinterpreting the payload.
+        let columns = vec![
+            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(CqlValue::BigInt(1234567890)),
+            Some(CqlValue::Blob(vec![1u8, 0xDE, 0xAD])),
+            Some(CqlValue::BigInt(1234567890)),
+        ];
+        let result = parse_values(
+            columns,
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+            &[Some(NativeType::Text)],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn alternator_decode_types_excludes_real_columns() {
+        // "color" is both a declared SearchSchema attribute (typed "S") and
+        // a genuine real column in the table (e.g. it's also the base
+        // table's own hash key). Its raw value is whatever the CQL driver
+        // decoded it as, not a tagged Alternator blob, so it must not be
+        // run through parse_alternator_scalar().
+        let metadata = IndexMetadata {
+            keyspace_name: "ks".into(),
+            index_name: "idx".into(),
+            table_name: "tbl".into(),
+            primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+            partition_key_count: NonZeroUsize::new(1).unwrap(),
+            target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+            partitioning: DbIndexPartitioning::Global,
+            filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::from([
+                (ColumnName::from("color"), NativeType::Text),
+                (ColumnName::from("size"), NativeType::Decimal),
+            ])),
+            version: Uuid::new_v4().into(),
+            kind: vs_kind(),
+        };
+        let real_columns = HashMap::from([(ColumnName::from("color"), NativeType::Blob)]);
+        let decode_types = alternator_decode_types(
+            [&ColumnName::from("color"), &ColumnName::from("size")],
+            &metadata,
+            &real_columns,
+        );
+        assert_eq!(&*decode_types, &[None, Some(NativeType::Decimal)]);
     }
 }

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -748,7 +748,7 @@ pub(crate) fn parse_values(
                 let value = value
                     .map(|value| match (value, native_type) {
                         (CqlValue::Blob(bytes), Some(native_type)) => {
-                            crate::vector::parse_alternator_scalar(&bytes, &native_type)
+                            crate::alternator::parse_alternator_scalar(&bytes, &native_type)
                         }
                         (value, _) => Ok(value),
                     })

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -344,6 +344,7 @@ impl Statements {
         let target_columns = metadata.target_columns.clone();
         let filtering_columns: Arc<[_]> = metadata.nonpk_filtering_columns().cloned().collect();
 
+        let is_alternator = KeyspaceIdentifier::from(&metadata.keyspace_name).is_alternator();
         let real_columns: HashMap<ColumnName, NativeType> = table
             .columns
             .iter()
@@ -355,21 +356,14 @@ impl Statements {
                 }
             })
             .collect();
-        // Merge in synthesized types for Alternator attributes with no real
-        // column (see IndexMetadata::alternator_attribute_types); real
-        // columns come last so they win on any name collision.
-        let table_columns = Arc::new(
-            metadata
-                .alternator_attribute_types
-                .keys()
-                .filter_map(|name| Some((name.clone(), metadata.alternator_native_type(name)?)))
-                .chain(
-                    real_columns
-                        .iter()
-                        .map(|(name, typ)| (name.clone(), typ.clone())),
-                )
-                .collect(),
-        );
+        let table_columns = Arc::new(merge_table_columns(
+            &metadata,
+            &filtering_columns,
+            real_columns
+                .iter()
+                .map(|(name, typ)| (name.clone(), typ.clone())),
+            is_alternator,
+        ));
         let alternator_decode_types = alternator_decode_types(
             nonpk_partition_key_columns
                 .iter()
@@ -652,12 +646,57 @@ impl Statements {
     }
 }
 
+/// Builds the `table_columns` lookup Table::new() uses to size and type
+/// in-memory column storage: the table's genuine, natively-typed CQL
+/// columns (`real_columns`), plus synthesized types for Alternator's
+/// virtual SearchSchema attributes (see
+/// IndexMetadata::alternator_attribute_types) and, only for an Alternator
+/// table, a raw-Blob entry for any other filtering column with no real
+/// column (see Alternator's compute_extra_fc_attributes()) so it can still
+/// be stored for projection/return purposes. Real columns win on any name
+/// collision with a synthesized one.
+///
+/// For a CQL-native table (`is_alternator` false), a filtering column with
+/// no real `real_columns` entry gets no entry here either: that's a
+/// genuine misconfiguration (e.g. schema drift), and must still fail
+/// through Table::new()'s "Column {name} not found in table columns"
+/// check rather than be papered over.
+pub(crate) fn merge_table_columns(
+    metadata: &IndexMetadata,
+    filtering_columns: &[ColumnName],
+    real_columns: impl IntoIterator<Item = (ColumnName, NativeType)>,
+    is_alternator: bool,
+) -> HashMap<ColumnName, NativeType> {
+    let real_columns: HashMap<ColumnName, NativeType> = real_columns.into_iter().collect();
+    metadata
+        .alternator_attribute_types
+        .keys()
+        .filter_map(|name| Some((name.clone(), metadata.alternator_native_type(name)?)))
+        .chain(
+            real_columns
+                .iter()
+                .map(|(name, typ)| (name.clone(), typ.clone())),
+        )
+        .chain(
+            filtering_columns
+                .iter()
+                .filter(|name| {
+                    is_alternator
+                        && !metadata.alternator_attribute_types.contains_key(*name)
+                        && !real_columns.contains_key(*name)
+                })
+                .map(|name| (name.clone(), NativeType::Blob)),
+        )
+        .collect()
+}
+
 /// Builds parse_values()'s alternator_decode_types parameter: for each of
 /// `columns`, its NativeType from `metadata.alternator_native_type()` - or
 /// None if `column` is a real table column, even if it also has a declared
-/// Alternator type. A real column's raw value is whatever the CQL driver
-/// decoded it as, never a tagged Alternator blob, so it must never be run
-/// through parse_alternator_scalar().
+/// Alternator type (see merge_table_columns(), which gives real columns the
+/// same precedence for table_columns). A real column's raw value is
+/// whatever the CQL driver decoded it as, never a tagged Alternator blob,
+/// so it must never be run through parse_alternator_scalar().
 pub(crate) fn alternator_decode_types<'a>(
     columns: impl IntoIterator<Item = &'a ColumnName>,
     metadata: &IndexMetadata,
@@ -790,7 +829,6 @@ mod tests {
     use crate::Quantization;
     use crate::SpaceType;
     use std::assert_matches;
-    use std::collections::BTreeMap;
     use uuid::Uuid;
 
     fn vs_kind() -> IndexKind {
@@ -1085,14 +1123,10 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[test]
-    fn alternator_decode_types_excludes_real_columns() {
-        // "color" is both a declared SearchSchema attribute (typed "S") and
-        // a genuine real column in the table (e.g. it's also the base
-        // table's own hash key). Its raw value is whatever the CQL driver
-        // decoded it as, not a tagged Alternator blob, so it must not be
-        // run through parse_alternator_scalar().
-        let metadata = IndexMetadata {
+    fn metadata_with_alternator_types(
+        types: impl IntoIterator<Item = (&'static str, NativeType)>,
+    ) -> IndexMetadata {
+        IndexMetadata {
             keyspace_name: "ks".into(),
             index_name: "idx".into(),
             table_name: "tbl".into(),
@@ -1101,13 +1135,77 @@ mod tests {
             target_columns: NonemptyArc::new(["embedding"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
-            alternator_attribute_types: Arc::new(BTreeMap::from([
-                (ColumnName::from("color"), NativeType::Text),
-                (ColumnName::from("size"), NativeType::Decimal),
-            ])),
+            alternator_attribute_types: Arc::new(
+                types
+                    .into_iter()
+                    .map(|(name, typ)| (ColumnName::from(name), typ))
+                    .collect(),
+            ),
             version: Uuid::new_v4().into(),
             kind: vs_kind(),
-        };
+        }
+    }
+
+    #[test]
+    fn merge_table_columns_cql_missing_filtering_column_is_not_papered_over() {
+        // A filtering column with no real table_columns entry, on a
+        // CQL-native table (is_alternator = false), is a genuine
+        // misconfiguration (e.g. schema drift) - it must NOT get a
+        // synthesized entry, so Table::new() still rejects it with
+        // "Column {name} not found in table columns" instead of silently
+        // treating it as an opaque, always-empty Blob column.
+        let metadata = metadata_with_alternator_types([]);
+        let table_columns =
+            merge_table_columns(&metadata, &["missing".into()], std::iter::empty(), false);
+        assert!(!table_columns.contains_key(&ColumnName::from("missing")));
+    }
+
+    #[test]
+    fn merge_table_columns_alternator_untyped_filtering_column_gets_blob() {
+        // Same missing-column scenario, but on an Alternator table: a
+        // filtering column added purely for a Projection's sake (no
+        // declared type) must still get a table_columns entry, as a raw
+        // Blob, so Table::new() can store it.
+        let metadata = metadata_with_alternator_types([]);
+        let table_columns =
+            merge_table_columns(&metadata, &["photo".into()], std::iter::empty(), true);
+        assert_eq!(
+            table_columns.get(&ColumnName::from("photo")),
+            Some(&NativeType::Blob)
+        );
+    }
+
+    #[test]
+    fn merge_table_columns_real_column_wins_over_synthesized_type() {
+        // "color" is both a declared SearchSchema attribute (typed "S")
+        // and a genuine real column in the table - the real column's type
+        // must win.
+        let metadata = metadata_with_alternator_types([("color", NativeType::Text)]);
+        let table_columns = merge_table_columns(
+            &metadata,
+            &["color".into()],
+            [(ColumnName::from("color"), NativeType::Ascii)],
+            true,
+        );
+        assert_eq!(
+            table_columns.get(&ColumnName::from("color")),
+            Some(&NativeType::Ascii)
+        );
+    }
+
+    #[test]
+    fn alternator_decode_types_excludes_real_columns() {
+        // "color" is both a declared SearchSchema attribute (typed "S") and
+        // a genuine real column in the table (e.g. it's also the base
+        // table's own hash key). Its raw value is whatever the CQL driver
+        // decoded it as, not a tagged Alternator blob, so it must not be
+        // run through parse_alternator_scalar() - unlike merge_table_columns()
+        // above, which only decides the *storage* type, this decides
+        // whether parse_values() attempts to decode the value at all.
+        let metadata = metadata_with_alternator_types([
+            ("color", NativeType::Text),
+            ("size", NativeType::Decimal),
+        ]);
         let real_columns = HashMap::from([(ColumnName::from("color"), NativeType::Blob)]);
         let decode_types = alternator_decode_types(
             [&ColumnName::from("color"), &ColumnName::from("size")],

--- a/crates/vector-store/src/engine.rs
+++ b/crates/vector-store/src/engine.rs
@@ -514,6 +514,7 @@ pub(crate) mod tests {
         use crate::table::TableModify;
         use crate::table::TableSearch;
         use crate::timestamp::Timestamped;
+        use std::collections::BTreeMap;
         use std::num::NonZeroUsize;
         use uuid::Uuid;
 
@@ -532,6 +533,7 @@ pub(crate) mod tests {
             // Declares "ck" (a primary-key column) and "f" (a genuine value column)
             // as filtering columns, exactly as metadata coming from the DB would.
             filtering_columns: Arc::new(["ck".into(), "f".into()]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -64,12 +64,14 @@ pub use crate::vector::Vector;
 use crate::vs_index::VsIndexFactory;
 use db::Db;
 use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
 use scylla::serialize::SerializationError;
 use scylla::serialize::value::SerializeValue;
 use scylla::serialize::writers::CellWriter;
 use scylla::serialize::writers::WrittenCellProof;
 use scylla::value::CqlValue;
 use scylla_cdc::CqlIdentifier;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::net::SocketAddr;
@@ -703,7 +705,7 @@ impl IndexKind {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// Information about an index
 pub struct IndexMetadata {
     pub keyspace_name: KeyspaceName,
@@ -714,8 +716,37 @@ pub struct IndexMetadata {
     pub target_columns: NonemptyArc<ColumnName>,
     pub partitioning: DbIndexPartitioning,
     pub filtering_columns: Arc<[ColumnName]>,
+    /// For Alternator tables: the NativeType to decode each partition-key/
+    /// filtering column with no real column in the table's CQL schema as
+    /// (its value lives only in the ":attrs" map), derived from its
+    /// declared DynamoDB type ("S", "N" or "B"). Empty for CQL-native
+    /// tables and for columns that are real columns.
+    pub alternator_attribute_types: Arc<BTreeMap<ColumnName, NativeType>>,
     pub version: IndexVersion,
     pub kind: IndexKind,
+}
+
+// Manual impl because `NativeType` (in `alternator_attribute_types`) doesn't
+// implement `Hash`. Its variants are all fieldless, so hashing by
+// `mem::discriminant` is exactly as precise as hashing the value itself.
+impl std::hash::Hash for IndexMetadata {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.keyspace_name.hash(state);
+        self.index_name.hash(state);
+        self.table_name.hash(state);
+        self.primary_key_columns.hash(state);
+        self.partition_key_count.hash(state);
+        self.target_columns.hash(state);
+        self.partitioning.hash(state);
+        self.filtering_columns.hash(state);
+        self.alternator_attribute_types.len().hash(state);
+        for (name, native_type) in self.alternator_attribute_types.iter() {
+            name.hash(state);
+            std::mem::discriminant(native_type).hash(state);
+        }
+        self.version.hash(state);
+        self.kind.hash(state);
+    }
 }
 
 impl IndexMetadata {
@@ -781,6 +812,8 @@ pub struct DbCustomIndex {
     pub target_columns: NonemptyArc<ColumnName>,
     pub partitioning: DbIndexPartitioning,
     pub filtering_columns: Arc<[ColumnName]>,
+    /// See IndexMetadata::alternator_attribute_types.
+    pub alternator_attribute_types: Arc<BTreeMap<ColumnName, NativeType>>,
     pub kind: DbIndexKind,
 }
 
@@ -1041,6 +1074,7 @@ mod tests {
             partitioning: DbIndexPartitioning::Local(NonemptyArc::new(["pk"]).unwrap()),
             // "ck" is also a primary-key column; "f" is a genuine value column.
             filtering_columns: Arc::new(["ck".into(), "f".into()]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+mod alternator;
 mod async_in_progress;
 mod config_manager;
 pub mod db;

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -762,6 +762,12 @@ impl IndexMetadata {
         self.kind.as_fts()
     }
 
+    /// The NativeType to treat `column` as, if it's a virtual Alternator
+    /// attribute (see alternator_attribute_types) - None otherwise.
+    pub fn alternator_native_type(&self, column: &ColumnName) -> Option<NativeType> {
+        self.alternator_attribute_types.get(column).cloned()
+    }
+
     fn discard_version(&self) -> Self {
         let mut copy = self.clone();
         copy.version = IndexVersion(Uuid::nil());
@@ -1040,6 +1046,51 @@ mod tests {
     #[test]
     fn analyzer_rejects_unknown_value() {
         assert!("klingon".parse::<Analyzer>().is_err());
+    }
+
+    fn index_metadata_with_alternator_types(
+        types: impl IntoIterator<Item = (&'static str, NativeType)>,
+    ) -> IndexMetadata {
+        IndexMetadata {
+            keyspace_name: "alternator_ks".into(),
+            index_name: "idx".into(),
+            table_name: "tbl".into(),
+            primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+            partition_key_count: NonZeroUsize::new(1).unwrap(),
+            target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+            partitioning: DbIndexPartitioning::Global,
+            filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(
+                types
+                    .into_iter()
+                    .map(|(name, typ)| (ColumnName::from(name), typ))
+                    .collect(),
+            ),
+            version: IndexVersion(Uuid::new_v4()),
+            kind: IndexKind::Vs(IndexOptionsVs {
+                dimensions: NonZeroUsize::new(3).unwrap().into(),
+                connectivity: Default::default(),
+                expansion_add: Default::default(),
+                expansion_search: Default::default(),
+                space_type: SpaceType::Euclidean,
+                quantization: Default::default(),
+            }),
+        }
+    }
+
+    #[test]
+    fn alternator_native_type_none_for_unknown_column() {
+        let metadata = index_metadata_with_alternator_types([("color", NativeType::Text)]);
+        assert_eq!(metadata.alternator_native_type(&"size".into()), None);
+    }
+
+    #[test]
+    fn alternator_native_type_returns_declared_type() {
+        let metadata = index_metadata_with_alternator_types([("color", NativeType::Text)]);
+        assert_eq!(
+            metadata.alternator_native_type(&"color".into()),
+            Some(NativeType::Text)
+        );
     }
 
     #[test]

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -210,6 +210,7 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
             target_columns: idx.target_columns,
             partitioning: idx.partitioning,
             filtering_columns: idx.filtering_columns,
+            alternator_attribute_types: idx.alternator_attribute_types,
             version,
             kind,
         };
@@ -402,6 +403,7 @@ mod tests {
     use anyhow::anyhow;
     use futures::FutureExt;
     use rstest::rstest;
+    use std::collections::BTreeMap;
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::num::NonZeroUsize;
@@ -420,6 +422,7 @@ mod tests {
             target_columns: NonemptyArc::new(["embedding"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: NonZeroUsize::new(3).unwrap().into(),
@@ -442,6 +445,7 @@ mod tests {
             target_columns: NonemptyArc::new(["content"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Fts(IndexOptionsFts::default()),
         }
@@ -533,6 +537,7 @@ mod tests {
                 target_columns: NonemptyArc::new(["embedding"]).unwrap(),
                 partitioning: DbIndexPartitioning::Global,
                 filtering_columns: Arc::new([]),
+                alternator_attribute_types: Arc::new(BTreeMap::new()),
                 kind: DbIndexKind::VectorSearch,
             }
         }
@@ -594,6 +599,7 @@ mod tests {
                         target_columns: idx.target_columns.clone(),
                         partitioning: DbIndexPartitioning::Global,
                         filtering_columns: Arc::new([]),
+                        alternator_attribute_types: Arc::new(BTreeMap::new()),
                         kind: idx.kind,
                     })
                     .collect()
@@ -792,6 +798,7 @@ mod tests {
                         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
                         partitioning: DbIndexPartitioning::Global,
                         filtering_columns: Arc::new([]),
+                        alternator_attribute_types: Arc::new(BTreeMap::new()),
                         kind: DbIndexKind::VectorSearch,
                     };
                     tx.send(Ok(vec![index(), index(), index()])).unwrap();
@@ -878,6 +885,7 @@ mod tests {
                     target_columns: NonemptyArc::new(["embedding"]).unwrap(),
                     partitioning: DbIndexPartitioning::Global,
                     filtering_columns: Arc::new([]),
+                    alternator_attribute_types: Arc::new(BTreeMap::new()),
                     kind: DbIndexKind::VectorSearch,
                 }]))
                 .unwrap();
@@ -913,6 +921,7 @@ mod tests {
                     target_columns: NonemptyArc::new(["content"]).unwrap(),
                     partitioning: DbIndexPartitioning::Global,
                     filtering_columns: Arc::new([]),
+                    alternator_attribute_types: Arc::new(BTreeMap::new()),
                     kind: DbIndexKind::FullTextSearch,
                 }]))
                 .unwrap();

--- a/crates/vector-store/src/node_state.rs
+++ b/crates/vector-store/src/node_state.rs
@@ -237,6 +237,7 @@ mod tests {
     use crate::KeyspaceName;
     use crate::NonemptyArc;
     use crate::TableName;
+    use std::collections::BTreeMap;
     use std::num::NonZeroUsize;
     use std::sync::Arc;
     use uuid::Uuid;
@@ -251,6 +252,7 @@ mod tests {
             target_columns: NonemptyArc::new(["test_column"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),
@@ -577,6 +579,7 @@ mod tests {
             target_columns: NonemptyArc::new(["test_column"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),
@@ -670,6 +673,7 @@ mod tests {
             target_columns: NonemptyArc::new(["test_column"]).unwrap(),
             partitioning: DbIndexPartitioning::Global,
             filtering_columns: Arc::new([]),
+            alternator_attribute_types: Arc::new(BTreeMap::new()),
             version: Uuid::new_v4().into(),
             kind: IndexKind::Vs(IndexOptionsVs {
                 dimensions: Dimensions(NonZeroUsize::new(3).unwrap()),

--- a/crates/vector-store/src/vector.rs
+++ b/crates/vector-store/src/vector.rs
@@ -4,12 +4,9 @@
  */
 
 use crate::Dimensions;
+use crate::alternator;
 use anyhow::anyhow;
 use anyhow::bail;
-use scylla::cluster::metadata::ColumnType;
-use scylla::cluster::metadata::NativeType;
-use scylla::deserialize::FrameSlice;
-use scylla::deserialize::value::DeserializeValue;
 use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
 
@@ -54,7 +51,7 @@ impl TryFrom<CqlValue> for Vector {
                     Ok(f)
                 })
                 .collect(),
-            CqlValue::Blob(bytes) => parse_alternator_vector(&bytes),
+            CqlValue::Blob(bytes) => alternator::parse_alternator_vector(&bytes),
             other => Err(anyhow!(
                 "unsupported CQL type for embedding column: {other:?}"
             )),
@@ -63,123 +60,11 @@ impl TryFrom<CqlValue> for Vector {
     }
 }
 
-// Alternator type tags. These match `enum class alternator_type` in
-// alternator/serialization.hh - do not reorder, these values are written to
-// disk as part of the item encoding.
-/// String (S) values: tag followed by the raw UTF-8 bytes.
-const ALTERNATOR_TYPE_S: u8 = 0;
-/// Bytes (B) values: tag followed by the raw bytes, as-is.
-const ALTERNATOR_TYPE_B: u8 = 1;
-/// Number (N) values: tag followed by the same wire encoding CQL's native
-/// `decimal` type uses (a 4-byte big-endian scale followed by a
-/// variable-length signed big-endian magnitude).
-const ALTERNATOR_TYPE_N: u8 = 3;
-/// Alternator type tag for unoptimized JSON encoding.
-/// Type `0x04` (`NOT_SUPPORTED_YET`) is used for any type that does not have an optimized encoding.
-/// The payload is an unoptimized JSON value.
-const ALTERNATOR_TYPE_JSON: u8 = 4;
-
-/// Alternator type tag for the optimized `FLOAT32VECTOR` type.
-/// The value is serialized as this 1-byte tag followed by sequential 32-bit big-endian floats,
-/// matching the CQL `VECTOR<float, N>` on-wire encoding.
-const ALTERNATOR_TYPE_FLOAT32VECTOR: u8 = 5;
-
-/// Decodes an Alternator-encoded scalar attribute value (a filtering or
-/// partition-key column with no real CQL column) into the `CqlValue`
-/// matching `native_type`. Like the vector column above, the value is
-/// tagged; this checks the tag matches `native_type` and re-deserializes
-/// the rest via the CQL driver, rather than reimplementing e.g. decimal
-/// parsing here.
-pub(crate) fn parse_alternator_scalar(
-    bytes: &[u8],
-    native_type: &NativeType,
-) -> anyhow::Result<CqlValue> {
-    let expected_tag = match native_type {
-        NativeType::Text | NativeType::Ascii => ALTERNATOR_TYPE_S,
-        NativeType::Blob => ALTERNATOR_TYPE_B,
-        NativeType::Decimal => ALTERNATOR_TYPE_N,
-        other => bail!(
-            "unsupported native type {other:?} for an Alternator filtering/partition-key attribute"
-        ),
-    };
-    let Some((&tag, payload)) = bytes.split_first() else {
-        bail!("empty blob for Alternator attribute value");
-    };
-    if tag != expected_tag {
-        bail!(
-            "Alternator attribute value has type tag {tag:#04x}, but column is declared as \
-            {native_type:?} (expected tag {expected_tag:#04x})"
-        );
-    }
-    let column_type = ColumnType::Native(native_type.clone());
-    CqlValue::deserialize(&column_type, Some(FrameSlice::new_borrowed(payload))).map_err(|err| {
-        anyhow!("failed to decode Alternator attribute value as {native_type:?}: {err}")
-    })
-}
-
-/// Parses an Alternator-encoded vector stored as raw bytes.
-///
-/// Alternator prefixes each attribute value in the `:attrs` map column with a 1-byte type discriminator.
-/// Handles two representations based on the discriminator:
-/// - [`ALTERNATOR_TYPE_FLOAT32VECTOR`]: optimized sequential 32-bit big-endian floats.
-/// - [`ALTERNATOR_TYPE_JSON`]: unoptimized JSON representing List values.
-fn parse_alternator_vector(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
-    match bytes.first() {
-        Some(&ALTERNATOR_TYPE_FLOAT32VECTOR) => parse_alternator_vector_binary(&bytes[1..]),
-        Some(&ALTERNATOR_TYPE_JSON) => parse_alternator_list_json(&bytes[1..]),
-        Some(tag) => bail!("unsupported Alternator type tag: {tag:#04x}"),
-        None => bail!("empty blob for Alternator attribute value"),
-    }
-}
-
-/// Parses the optimized Alternator vector encoding: sequential 32-bit big-endian floats.
-fn parse_alternator_vector_binary(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
-    let chunks = bytes.chunks_exact(4);
-
-    if !chunks.remainder().is_empty() {
-        bail!(
-            "invalid Alternator vector encoding: byte length {} is not a multiple of 4",
-            bytes.len()
-        );
-    }
-
-    Ok(chunks
-        .map(|chunk| {
-            let arr: [u8; 4] = chunk.try_into().expect("chunks_exact guarantees 4 bytes");
-            f32::from_be_bytes(arr)
-        })
-        .collect())
-}
-
-/// Parses an Alternator JSON list of numbers: `{"L": [{"N": "..."}, ...]}`.
-fn parse_alternator_list_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
-    #[derive(serde::Deserialize)]
-    struct DynamoDbList {
-        #[serde(rename = "L")]
-        l: Vec<DynamoDbNumber>,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct DynamoDbNumber {
-        #[serde(rename = "N")]
-        n: String,
-    }
-
-    let list: DynamoDbList = serde_json::from_slice(bytes)?;
-    list.l
-        .into_iter()
-        .map(|item| {
-            item.n
-                .parse::<f32>()
-                .map_err(|e| anyhow!("invalid value in Alternator list element: {e}"))
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use scylla::value::CqlDecimal;
+    use alternator::ALTERNATOR_TYPE_FLOAT32VECTOR;
+    use alternator::ALTERNATOR_TYPE_JSON;
 
     /// Prepend the [`ALTERNATOR_TYPE_JSON`] tag to a DynamoDB JSON string,
     /// mirroring how Alternator serialises List values.
@@ -278,66 +163,5 @@ mod tests {
         bytes.extend_from_slice(&[0x00, 0x01, 0x02, 0x03, 0x04]);
         let value = CqlValue::Blob(bytes);
         assert!(Vector::try_from(value).is_err());
-    }
-
-    #[test]
-    fn parse_alternator_scalar_valid_text() {
-        let mut bytes = vec![ALTERNATOR_TYPE_S];
-        bytes.extend_from_slice(b"hello");
-        let result = parse_alternator_scalar(&bytes, &NativeType::Text).unwrap();
-        assert_eq!(result, CqlValue::Text("hello".to_string()));
-    }
-
-    #[test]
-    fn parse_alternator_scalar_valid_blob() {
-        let mut bytes = vec![ALTERNATOR_TYPE_B];
-        bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
-        let result = parse_alternator_scalar(&bytes, &NativeType::Blob).unwrap();
-        assert_eq!(result, CqlValue::Blob(vec![0xDE, 0xAD, 0xBE, 0xEF]));
-    }
-
-    #[test]
-    fn parse_alternator_scalar_valid_number() {
-        // 123 encoded as unscaled magnitude 0x7B with scale 0.
-        let decimal = CqlDecimal::from_signed_be_bytes_and_exponent(vec![0x7B], 0);
-        let (varint_bytes, scale) = decimal.as_signed_be_bytes_slice_and_exponent();
-        let mut bytes = vec![ALTERNATOR_TYPE_N];
-        bytes.extend_from_slice(&scale.to_be_bytes());
-        bytes.extend_from_slice(varint_bytes);
-        let result = parse_alternator_scalar(&bytes, &NativeType::Decimal).unwrap();
-        assert_eq!(result, CqlValue::Decimal(decimal));
-    }
-
-    #[test]
-    fn parse_alternator_scalar_empty() {
-        assert!(parse_alternator_scalar(&[], &NativeType::Text).is_err());
-    }
-
-    #[test]
-    fn parse_alternator_scalar_mismatched_tag() {
-        // Tagged as a string (S), but the column is declared as Blob (B).
-        let mut bytes = vec![ALTERNATOR_TYPE_S];
-        bytes.extend_from_slice(b"hello");
-        assert!(parse_alternator_scalar(&bytes, &NativeType::Blob).is_err());
-    }
-
-    #[test]
-    fn parse_alternator_scalar_malformed_number() {
-        // Tag matches, but only 2 bytes follow - not enough for the 4-byte scale.
-        let bytes = vec![ALTERNATOR_TYPE_N, 0x00, 0x00];
-        assert!(parse_alternator_scalar(&bytes, &NativeType::Decimal).is_err());
-    }
-
-    #[test]
-    fn parse_alternator_scalar_malformed_text() {
-        // Tag matches, but the payload is not valid UTF-8.
-        let bytes = vec![ALTERNATOR_TYPE_S, 0xFF, 0xFE];
-        assert!(parse_alternator_scalar(&bytes, &NativeType::Text).is_err());
-    }
-
-    #[test]
-    fn parse_alternator_scalar_unsupported_native_type() {
-        let bytes = vec![ALTERNATOR_TYPE_S, b'x'];
-        assert!(parse_alternator_scalar(&bytes, &NativeType::Int).is_err());
     }
 }

--- a/crates/vector-store/src/vector.rs
+++ b/crates/vector-store/src/vector.rs
@@ -6,6 +6,10 @@
 use crate::Dimensions;
 use anyhow::anyhow;
 use anyhow::bail;
+use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::value::DeserializeValue;
 use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
 
@@ -59,6 +63,17 @@ impl TryFrom<CqlValue> for Vector {
     }
 }
 
+// Alternator type tags. These match `enum class alternator_type` in
+// alternator/serialization.hh - do not reorder, these values are written to
+// disk as part of the item encoding.
+/// String (S) values: tag followed by the raw UTF-8 bytes.
+const ALTERNATOR_TYPE_S: u8 = 0;
+/// Bytes (B) values: tag followed by the raw bytes, as-is.
+const ALTERNATOR_TYPE_B: u8 = 1;
+/// Number (N) values: tag followed by the same wire encoding CQL's native
+/// `decimal` type uses (a 4-byte big-endian scale followed by a
+/// variable-length signed big-endian magnitude).
+const ALTERNATOR_TYPE_N: u8 = 3;
 /// Alternator type tag for unoptimized JSON encoding.
 /// Type `0x04` (`NOT_SUPPORTED_YET`) is used for any type that does not have an optimized encoding.
 /// The payload is an unoptimized JSON value.
@@ -68,6 +83,39 @@ const ALTERNATOR_TYPE_JSON: u8 = 4;
 /// The value is serialized as this 1-byte tag followed by sequential 32-bit big-endian floats,
 /// matching the CQL `VECTOR<float, N>` on-wire encoding.
 const ALTERNATOR_TYPE_FLOAT32VECTOR: u8 = 5;
+
+/// Decodes an Alternator-encoded scalar attribute value (a filtering or
+/// partition-key column with no real CQL column) into the `CqlValue`
+/// matching `native_type`. Like the vector column above, the value is
+/// tagged; this checks the tag matches `native_type` and re-deserializes
+/// the rest via the CQL driver, rather than reimplementing e.g. decimal
+/// parsing here.
+pub(crate) fn parse_alternator_scalar(
+    bytes: &[u8],
+    native_type: &NativeType,
+) -> anyhow::Result<CqlValue> {
+    let expected_tag = match native_type {
+        NativeType::Text | NativeType::Ascii => ALTERNATOR_TYPE_S,
+        NativeType::Blob => ALTERNATOR_TYPE_B,
+        NativeType::Decimal => ALTERNATOR_TYPE_N,
+        other => bail!(
+            "unsupported native type {other:?} for an Alternator filtering/partition-key attribute"
+        ),
+    };
+    let Some((&tag, payload)) = bytes.split_first() else {
+        bail!("empty blob for Alternator attribute value");
+    };
+    if tag != expected_tag {
+        bail!(
+            "Alternator attribute value has type tag {tag:#04x}, but column is declared as \
+            {native_type:?} (expected tag {expected_tag:#04x})"
+        );
+    }
+    let column_type = ColumnType::Native(native_type.clone());
+    CqlValue::deserialize(&column_type, Some(FrameSlice::new_borrowed(payload))).map_err(|err| {
+        anyhow!("failed to decode Alternator attribute value as {native_type:?}: {err}")
+    })
+}
 
 /// Parses an Alternator-encoded vector stored as raw bytes.
 ///
@@ -131,6 +179,7 @@ fn parse_alternator_list_json(bytes: &[u8]) -> anyhow::Result<Vec<f32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use scylla::value::CqlDecimal;
 
     /// Prepend the [`ALTERNATOR_TYPE_JSON`] tag to a DynamoDB JSON string,
     /// mirroring how Alternator serialises List values.
@@ -229,5 +278,66 @@ mod tests {
         bytes.extend_from_slice(&[0x00, 0x01, 0x02, 0x03, 0x04]);
         let value = CqlValue::Blob(bytes);
         assert!(Vector::try_from(value).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_text() {
+        let mut bytes = vec![ALTERNATOR_TYPE_S];
+        bytes.extend_from_slice(b"hello");
+        let result = parse_alternator_scalar(&bytes, &NativeType::Text).unwrap();
+        assert_eq!(result, CqlValue::Text("hello".to_string()));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_blob() {
+        let mut bytes = vec![ALTERNATOR_TYPE_B];
+        bytes.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let result = parse_alternator_scalar(&bytes, &NativeType::Blob).unwrap();
+        assert_eq!(result, CqlValue::Blob(vec![0xDE, 0xAD, 0xBE, 0xEF]));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_valid_number() {
+        // 123 encoded as unscaled magnitude 0x7B with scale 0.
+        let decimal = CqlDecimal::from_signed_be_bytes_and_exponent(vec![0x7B], 0);
+        let (varint_bytes, scale) = decimal.as_signed_be_bytes_slice_and_exponent();
+        let mut bytes = vec![ALTERNATOR_TYPE_N];
+        bytes.extend_from_slice(&scale.to_be_bytes());
+        bytes.extend_from_slice(varint_bytes);
+        let result = parse_alternator_scalar(&bytes, &NativeType::Decimal).unwrap();
+        assert_eq!(result, CqlValue::Decimal(decimal));
+    }
+
+    #[test]
+    fn parse_alternator_scalar_empty() {
+        assert!(parse_alternator_scalar(&[], &NativeType::Text).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_mismatched_tag() {
+        // Tagged as a string (S), but the column is declared as Blob (B).
+        let mut bytes = vec![ALTERNATOR_TYPE_S];
+        bytes.extend_from_slice(b"hello");
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Blob).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_malformed_number() {
+        // Tag matches, but only 2 bytes follow - not enough for the 4-byte scale.
+        let bytes = vec![ALTERNATOR_TYPE_N, 0x00, 0x00];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Decimal).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_malformed_text() {
+        // Tag matches, but the payload is not valid UTF-8.
+        let bytes = vec![ALTERNATOR_TYPE_S, 0xFF, 0xFE];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Text).is_err());
+    }
+
+    #[test]
+    fn parse_alternator_scalar_unsupported_native_type() {
+        let bytes = vec![ALTERNATOR_TYPE_S, b'x'];
+        assert!(parse_alternator_scalar(&bytes, &NativeType::Int).is_err());
     }
 }

--- a/crates/vector-store/tests/integration/common.rs
+++ b/crates/vector-store/tests/integration/common.rs
@@ -142,6 +142,7 @@ pub(crate) fn make_index_with_kind(
             .iter()
             .map(|s| ColumnName::from(*s))
             .collect(),
+        alternator_attribute_types: Default::default(),
         version: version.into(),
         kind,
     }

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -357,6 +357,10 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
                                 target_columns: index.metadata.target_columns.clone(),
                                 partitioning: index.metadata.partitioning.clone(),
                                 filtering_columns: index.metadata.filtering_columns.clone(),
+                                alternator_attribute_types: index
+                                    .metadata
+                                    .alternator_attribute_types
+                                    .clone(),
                                 kind: match index.metadata.kind {
                                     IndexKind::Vs(_) => DbIndexKind::VectorSearch,
                                     IndexKind::Fts(_) => DbIndexKind::FullTextSearch,

--- a/crates/vector-store/tests/integration/fts.rs
+++ b/crates/vector-store/tests/integration/fts.rs
@@ -48,6 +48,7 @@ fn fts_index_metadata(primary_key_columns: impl IntoIterator<Item = ColumnName>)
         target_columns: NonemptyArc::new(["content"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Fts(IndexOptionsFts::default()),
     }

--- a/crates/vector-store/tests/integration/memory_limit.rs
+++ b/crates/vector-store/tests/integration/memory_limit.rs
@@ -63,6 +63,7 @@ async fn memory_limit_during_index_build() {
         target_columns: NonemptyArc::new(["v"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(3).unwrap().into(),

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -41,6 +41,7 @@ async fn simple_create_search_delete_index() {
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(3).unwrap().into(),

--- a/crates/vector-store/tests/integration/vs_index.rs
+++ b/crates/vector-store/tests/integration/vs_index.rs
@@ -127,6 +127,7 @@ pub(crate) async fn setup_store_with_quantization(
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning,
         filtering_columns,
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: dimension,
@@ -329,6 +330,7 @@ async fn failed_db_index_create(#[case] config: Config) {
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(3).unwrap().into(),
@@ -1764,6 +1766,7 @@ async fn similarity_scores_are_decreasing_and_correctly_converted(#[case] config
         target_columns: NonemptyArc::new(["embedding"]).unwrap(),
         partitioning: DbIndexPartitioning::Global,
         filtering_columns: Arc::new([]),
+        alternator_attribute_types: Default::default(),
         version: Uuid::new_v4().into(),
         kind: IndexKind::Vs(IndexOptionsVs {
             dimensions: NonZeroUsize::new(1).unwrap().into(),


### PR DESCRIPTION
The existing Alternator vector search API does not yet have its version of the new vector store features of filtering columns and partition columns ("local index"). We plan to add support for these features in Alternator as part of implementing the new DynamoDB vector search API (see https://github.com/scylladb/scylladb/pull/31181), so we will need the filtering/partition column code in the vector store to support Alternator tables. 

Unfortunately, there are some holes in this support - whereas the vector store generally supports Alternator tables and their weird requirements (like having "attributes" which are not real columns), some of the filtering code is missing the necessary Alternator support, and this PR adds this missing support, gated by is_alternator() checks.