### PR TITLE
coderabbit: use vector-search-docs as review knowledge base

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -7,6 +7,13 @@
 # settings. Any key not set here falls back to CodeRabbit's own defaults, not to
 # the org settings. Keys previously set in the org UI must therefore be restated
 # here to keep their effect.
+#
+# NOTE ON VISIBILITY: this repository is public, so anything CodeRabbit reads
+# from the private scylladb/vector-search-docs repository can end up quoted in a
+# review comment that the world can read. That repository classifies every
+# knowledge entry by path — knowledge/public/** vs knowledge/private/** — and
+# only the public tree may be referenced from here. Never point any setting in
+# this file at knowledge/private/**.
 
 reviews:
   # Previously set in the org UI; restated so this file does not silently
@@ -19,33 +26,47 @@ knowledge_base:
   # Treat the curated house rules and architecture decisions in the
   # vector-search-docs knowledge base as review criteria. Cross-repository
   # entries use `repo:path` and are read at that repository's default branch
-  # (master). These are additive: CodeRabbit's built-in patterns (CLAUDE.md,
+  # (master). These globs are an explicit allowlist: they name the public tree
+  # only, so the private tree cannot be pulled in through this setting.
+  # Entries are additive — CodeRabbit's built-in patterns (CLAUDE.md,
   # AGENTS.md, .github/instructions/*, ...) still apply.
   code_guidelines:
     enabled: true
     filePatterns:
       # House rules this codebase enforces in review rather than in a document.
-      - "vector-search-docs:knowledge/conventions/*.md"
+      - "vector-search-docs:knowledge/public/conventions/*.md"
       # Architecture decision records for vector search and FTS.
-      - "vector-search-docs:knowledge/decisions/*.md"
+      - "vector-search-docs:knowledge/public/decisions/*.md"
 
-  # Let CodeRabbit search the whole knowledge base on demand for the facts a
+  # Let CodeRabbit search the public knowledge tree on demand for the facts a
   # given change touches, rather than injecting all of it into every review.
+  #
+  # Unlike the globs above, this is agentic search over a repository the
+  # CodeRabbit installation can read in full, so the public/private boundary
+  # here rests on the instructions below being followed rather than on a path
+  # allowlist. Keep the restriction stated first and unambiguously.
   linked_repositories:
     - repository: "scylladb/vector-search-docs"
       instructions: >-
-        Curated knowledge base and source of truth for ScyllaDB vector search
-        and full-text search (FTS). Search `knowledge/` only: `concepts/`,
-        `features/`, `api/`, `decisions/` and `conventions/` hold canonical,
-        human-reviewed entries whose frontmatter records provenance
-        (`sources:`), the releases they apply to (`applies_to:`) and
-        confidence (`status:`). Prefer entries with `status: stable`; treat
-        `status: draft` or `status: review` as unverified and do not raise
-        review findings on their basis alone. Ignore `sources/` (vendored,
-        read-only ingests of external docs) and `generated/` (disposable LLM
-        drafts and slide decks) — both are large and non-authoritative.
-        Useful for checking whether a change contradicts documented API
-        behavior, configuration semantics or a recorded design decision.
+        STRICT SCOPE: read `knowledge/public/**` ONLY. Never read, quote,
+        summarize or otherwise surface `knowledge/private/**`; it holds facts
+        backed solely by internal sources, and findings from this repository
+        are published as comments on a PUBLIC repository. Also ignore
+        `sources/` (vendored, read-only ingests) and `generated/` (disposable
+        drafts and slide decks) — large and non-authoritative. If the public
+        tree does not answer a question, say so rather than consulting the
+        private tree.
+
+        Within that scope: this is the curated source of truth for ScyllaDB
+        vector search and full-text search (FTS). `knowledge/public/` holds
+        `concepts/`, `features/`, `api/`, `decisions/` and `conventions/`,
+        each entry human-reviewed with frontmatter recording provenance
+        (`sources:`), applicable releases (`applies_to:`) and confidence
+        (`status:`). Prefer `status: stable`; treat `status: draft` or
+        `status: review` as unverified and do not raise findings on their
+        basis alone. Useful for checking whether a change contradicts
+        documented API behavior, configuration semantics or a recorded
+        design decision.
 
   # Explicit: never auto-link further repositories. This repository is public
   # and most sibling ScyllaDB repositories are private; only the link declared

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+#
+# CodeRabbit review configuration.
+#
+# NOTE ON PRECEDENCE: once this file exists it becomes the highest-priority
+# configuration source and does NOT merge with the CodeRabbit Organization UI
+# settings. Any key not set here falls back to CodeRabbit's own defaults, not to
+# the org settings. Keys previously set in the org UI must therefore be restated
+# here to keep their effect.
+
+reviews:
+  # Previously set in the org UI; restated so this file does not silently
+  # widen review verbosity back to the `chill` default.
+  profile: quiet
+
+knowledge_base:
+  opt_out: false
+
+  # Treat the curated house rules and architecture decisions in the
+  # vector-search-docs knowledge base as review criteria. Cross-repository
+  # entries use `repo:path` and are read at that repository's default branch
+  # (master). These are additive: CodeRabbit's built-in patterns (CLAUDE.md,
+  # AGENTS.md, .github/instructions/*, ...) still apply.
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      # House rules this codebase enforces in review rather than in a document.
+      - "vector-search-docs:knowledge/conventions/*.md"
+      # Architecture decision records for vector search and FTS.
+      - "vector-search-docs:knowledge/decisions/*.md"
+
+  # Let CodeRabbit search the whole knowledge base on demand for the facts a
+  # given change touches, rather than injecting all of it into every review.
+  linked_repositories:
+    - repository: "scylladb/vector-search-docs"
+      instructions: >-
+        Curated knowledge base and source of truth for ScyllaDB vector search
+        and full-text search (FTS). Search `knowledge/` only: `concepts/`,
+        `features/`, `api/`, `decisions/` and `conventions/` hold canonical,
+        human-reviewed entries whose frontmatter records provenance
+        (`sources:`), the releases they apply to (`applies_to:`) and
+        confidence (`status:`). Prefer entries with `status: stable`; treat
+        `status: draft` or `status: review` as unverified and do not raise
+        review findings on their basis alone. Ignore `sources/` (vendored,
+        read-only ingests of external docs) and `generated/` (disposable LLM
+        drafts and slide decks) — both are large and non-authoritative.
+        Useful for checking whether a change contradicts documented API
+        behavior, configuration semantics or a recorded design decision.
+
+  # Explicit: never auto-link further repositories. This repository is public
+  # and most sibling ScyllaDB repositories are private; only the link declared
+  # above is intended. Manual links above are unaffected by this setting.
+  automatic_linking_mode: disabled


### PR DESCRIPTION
## Motivation

CodeRabbit already reviews this repository, but it has no knowledge of the curated vector search / FTS knowledge base kept in `scylladb/vector-search-docs`. It therefore cannot tell when a change contradicts documented API behavior, configuration semantics, or a recorded design decision — reviewers have to carry that context by hand, and it is exactly the context most easily missed.

This adds a `.coderabbit.yaml` that wires the two repositories together, scoped to the knowledge that is safe to quote in public.

## What changed

A single new root file, `.coderabbit.yaml`, using the two mechanisms CodeRabbit offers. They serve different purposes and, importantly, differ in how the public/private boundary is enforced:

**`knowledge_base.code_guidelines.filePatterns`** — cross-repository entries in `repo:path` form for `knowledge/public/conventions/*.md` (1 file) and `knowledge/public/decisions/*.md` (9 files). These are house rules and architecture decision records — review criteria proper — so they are worth applying to every review. Cross-repo guideline files are read at the source repository's default branch (`master`). Custom patterns are *additive*, so the built-in ones (`CLAUDE.md`, `AGENTS.md`, `.github/instructions/*`, …) keep working.

**`knowledge_base.linked_repositories`** — links the docs repository so CodeRabbit can search it on demand for the facts a given change touches, rather than injecting the whole base into every review. The `instructions` open with a strict scope restriction to `knowledge/public/**` and an explicit prohibition on `knowledge/private/**`, then steer it away from `sources/` and `generated/` and tell it to discount entries not marked `status: stable`.

`automatic_linking_mode` is set to `disabled` explicitly: this repository is public while most sibling repositories are private, and only the link declared here is intended.

## Sensitive-data exposure: what changed and what remains

CodeRabbit's review of the first revision raised this as a blocking finding (CWE-200) and proposed dropping the link entirely. The exposure was real: this repository is public, findings are published as comments anyone can read, and at that point the knowledge base was undifferentiated private material.

`vector-search-docs` has since classified the base. Every source in its manifest declares `visibility: public | private`; a fact confirmed by at least one public source is public, a fact backed only by internal sources is not, and **an entry is public only if every substantive fact in it is public** — one private-only fact forces the whole entry private. The classification is expressed as a path, not a frontmatter field, giving two trees with the same area hierarchy: `knowledge/public/**` (37 entries) and `knowledge/private/**` (34 entries). Their `validate.py` fails the build on an entry outside either tree, or a public entry citing no public source.

That changes the two halves of this config differently, and the distinction is worth being precise about:

- **The `code_guidelines` globs are a hard allowlist.** They name `knowledge/public/...` explicitly. The private tree is not reachable through this setting, by construction. This half is fully resolved.
- **`linked_repositories` is agentic search**, over a repository the CodeRabbit installation can read in full. The scope restriction lives in the `instructions` field, so the boundary here rests on the instruction being followed, not on a mechanism that can refuse. CodeRabbit publishes no guarantee that it will not read outside an instructed scope. The residual risk is small — the private tree is now separately labelled and explicitly named as off-limits, rather than being indistinguishable — but it is not zero, and the file comment says so plainly so a later reader does not mistake it for enforcement.

If that residual is not acceptable, the conservative option is to drop the `linked_repositories` block and keep only the `code_guidelines` globs: strictly weaker context, no instruction-following dependency. That is a judgement call for maintainers, so it is left explicit rather than decided here.

## Prerequisite, still outstanding

**The CodeRabbit App must be installed on `scylladb/vector-search-docs`**, with the installation plan permitting a linked repository. Both are being sorted out separately and neither is resolved yet, so this change is expected to be inert on merge until they are. Missing access is skipped *silently* — a warning in the review summary rather than an error — so nothing will look broken; it simply will not do anything. Worth re-checking once the installation lands.

Linked repositories are plan-gated: Free 0, Essentials 1, Team 5, Advanced 10, Enterprise 20. Run output reports `Plan: Pro Plus`, but also that this repository is reviewed under the free OSS tier. If the OSS tier is what applies, the linked repository may be capped at 0 and ignored; the `code_guidelines` half is not subject to that limit.

## Configuration precedence

Worth flagging because it is easy to miss: a repository `.coderabbit.yaml` is the highest-priority configuration source and **does not merge** with the Organization UI settings. Any key not set in this file falls back to CodeRabbit's own defaults, not to the org settings.

Runs before this change reported `Configuration used: Organization UI` with `Review profile: QUIET`, so `reviews.profile: quiet` is restated in the file to keep current behavior. If the org UI carries other non-default settings for this repository, they need to be restated here too (or configuration inheritance enabled in the CodeRabbit app) — only the profile was observable from PR run output.

## Testing

No code change, so no test impact — `.coderabbit.yaml` is consumed by CodeRabbit's service, not by the build.

Validated against CodeRabbit's published JSON schema (`schema.v2.json`): all keys and enum values are recognised, `reviews.profile: quiet` is a valid enum member, the `repository` value matches the required `owner/repo` pattern, `instructions` is within the 2000-character limit, and the entry count is within `maxItems`. Confirmed both cross-repo globs resolve at `vector-search-docs` `master` (1 and 9 files), so neither pattern is dead, and asserted that no configured path references `knowledge/private/`.

End-to-end behavior can only be confirmed once the app installation and plan are sorted: the walkthrough should then show the docs repository under **Review details → Additional context used**. Absence of findings there is not by itself a failure — it also means the change had no cross-repo relevance.

*(The `_TEMPLATE.md` wart noted in the first revision is gone: templates moved to `knowledge/_templates/`, outside both trees, in the same reorganization.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4jYzq8EPAG3XLF5pRp6zs