### PR TITLE
vector-store: fix cql_cmp() missing Blob, Boolean, Uuid and Timeuuid arms

### DIFF
--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -7,10 +7,12 @@ use crate::TestActors;
 use crate::common::*;
 use httpapi::KeyspaceName;
 use scylla::client::session::Session;
+use scylla::value::CqlTimeuuid;
 use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::info;
+use uuid::Uuid;
 
 e2etest::group!(
     name = filtering,
@@ -744,6 +746,609 @@ async fn global_index_filter_by_filtering_columns(actors: Arc<TestActors>) {
         .map(|row| row.expect("failed to get row"))
         .collect();
     assert_eq!(results, HashSet::from([(2,), (6,)]));
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by equality on a BLOB filtering column.
+///
+/// Regression test for VECTOR-889: `cql_cmp()` had no comparison arm for
+/// `CqlValue::Blob`, so a `WHERE <blob column> = <literal>` restriction
+/// during ANN search always evaluated to "not equal" - silently matching
+/// zero rows instead of the expected ones. VECTOR-889 reported the same bug
+/// for Boolean, Uuid and Timeuuid columns too, and we have corresponding
+/// tests for these types as well, below.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_blob_column_eq(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f BLOB, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (0, vec![1u8, 2, 3], &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (1, vec![4u8, 5, 6], &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
+    }
+
+    info!("Querying index for f = 0x010203");
+    let results = get_pks(
+        format!(
+            "SELECT pk FROM {table} WHERE f = 0x010203 ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+        ),
+        &session,
+    )
+    .await;
+    assert_eq!(results, HashSet::from([0]));
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by an inequality (`>`) on a BLOB filtering
+/// column, cross-checked against Scylla's own (non-ANN) filtering, to
+/// verify we got the ordering right.
+///
+/// Blob ordering is unsigned byte-wise comparison, with a shorter blob
+/// that is a prefix of a longer one sorting first. The dataset has a
+/// three-way prefix family (b1 < b2 < b4, all starting [1,2]) alongside a
+/// value that differs in an earlier byte (b3), so a subtly wrong
+/// comparison (e.g. one that ignores length or compares lengths first)
+/// would misplace some of them. b2 vs b4 also gives a first, weaker,
+/// signed-byte check: their trailing tie-break byte is 0 vs 255. b5/b6
+/// add a stronger version of the same check at the primary differentiator
+/// instead of a tie-break: their first differing byte (0x7f vs 0x80)
+/// would flip order if compared as signed i8 instead of u8.
+///
+/// Rather than hardcoding the expected order, this loops over every value
+/// as the `>` threshold and, for each, derives the expected row set from
+/// Scylla evaluating the same restriction without `ORDER BY v ANN OF` -
+/// asserting the ANN-filtered query returns exactly that set. Looping the
+/// threshold over the whole dataset exercises every pairwise comparison
+/// among the values, not just one hand-picked split.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_blob_column_ordering_matches_scylla(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f BLOB, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    let values: [(i32, Vec<u8>); 6] = [
+        (0, vec![1, 2]),      // b1: prefix of b2
+        (1, vec![1, 2, 0]),   // b2: b1 + trailing byte -> greater than b1
+        (2, vec![1, 10]),     // b3: differs from b1/b2 at 2nd byte
+        (3, vec![1, 2, 255]), // b4: b1 + trailing byte, greater than b2
+        (4, vec![1, 127]),    // b5: 0x7f
+        (5, vec![1, 128]),    // b6: 0x80 - must sort after b5, not before
+    ];
+    for (pk, f) in &values {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+                (pk, f, &vec![*pk as f32, 0.0, 0.0]),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 6, "Expected 6 vectors to be indexed");
+    }
+
+    for (threshold_pk, threshold) in &values {
+        let literal = blob_literal(threshold);
+        info!("Comparing ANN-filtered and plain (non-ANN) results for f > {literal}");
+        let ann_results = get_pks(
+            format!(
+                "SELECT pk FROM {table} WHERE f > {literal} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+            ),
+            &session,
+        )
+        .await;
+        let plain_results = get_pks(
+            format!("SELECT pk FROM {table} WHERE f > {literal} ALLOW FILTERING"),
+            &session,
+        )
+        .await;
+
+        assert_eq!(
+            ann_results, plain_results,
+            "ANN-filtered results must match Scylla's own (non-ANN) filtering \
+             for f > {literal} (threshold pk={threshold_pk})"
+        );
+    }
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by equality on a BOOLEAN filtering column.
+///
+/// See ann_filter_by_blob_column_eq above: this is the Boolean case of the
+/// same VECTOR-889 bug.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_boolean_column_eq(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f BOOLEAN, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (0, true, &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (1, false, &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
+    }
+
+    info!("Querying index for f = true");
+    let results = get_pks(
+        format!(
+            "SELECT pk FROM {table} WHERE f = true ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+        ),
+        &session,
+    )
+    .await;
+    assert_eq!(results, HashSet::from([0]));
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by an inequality (`<`) on a BOOLEAN filtering
+/// column, cross-checked against Scylla's own (non-ANN) filtering.
+///
+/// There's only one possible relative order for two booleans, so unlike
+/// the other ordering tests this can't catch a subtly wrong comparison -
+/// but `cql_cmp()`'s `false < true` is still an assumption about Scylla's
+/// own `boolean_type` comparator, not a law of nature, and this confirms
+/// Scylla agrees rather than just asserting it in isolation.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_boolean_column_ordering_matches_scylla(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f BOOLEAN, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    let values: [(i32, bool); 2] = [(0, false), (1, true)];
+    for (pk, f) in &values {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+                (pk, f, &vec![*pk as f32, 0.0, 0.0]),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
+    }
+
+    for (threshold_pk, threshold) in &values {
+        info!("Comparing ANN-filtered and plain (non-ANN) results for f < {threshold}");
+        let ann_results = get_pks(
+            format!(
+                "SELECT pk FROM {table} WHERE f < {threshold} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+            ),
+            &session,
+        )
+        .await;
+        let plain_results = get_pks(
+            format!("SELECT pk FROM {table} WHERE f < {threshold} ALLOW FILTERING"),
+            &session,
+        )
+        .await;
+
+        assert_eq!(
+            ann_results, plain_results,
+            "ANN-filtered results must match Scylla's own (non-ANN) filtering \
+             for f < {threshold} (threshold pk={threshold_pk})"
+        );
+    }
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by equality on a UUID filtering column.
+///
+/// See ann_filter_by_blob_column_eq above: this is the Uuid case of the same
+/// VECTOR-889 bug.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_uuid_column_eq(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f UUID, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    let u0 = Uuid::parse_str("00000000-0000-4000-8000-000000000000").unwrap();
+    let u1 = Uuid::parse_str("7fffffff-ffff-4fff-7fff-ffffffffffff").unwrap();
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (0, u0, &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (1, u1, &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
+    }
+
+    info!("Querying index for f = {u0}");
+    let results = get_pks(
+        format!(
+            "SELECT pk FROM {table} WHERE f = {u0} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+        ),
+        &session,
+    )
+    .await;
+    assert_eq!(results, HashSet::from([0]));
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by an inequality (`<`) on a UUID filtering
+/// column, cross-checked against Scylla's own (non-ANN) filtering, to
+/// verify we got the ordering right.
+///
+/// Regression coverage for VECTOR-889's `uuid_cmp()`: UUIDs order by
+/// version nibble first, and version-1 (time-based) UUIDs then order by
+/// their reassembled timestamp rather than raw bytes. The dataset is
+/// crafted so that a naive 128-bit byte compare disagrees with that
+/// ordering:
+/// - `u_a` and `u_b` are both version 1, but `u_a` has a large `time_low`
+///   and small `time_hi` (giving it a small true timestamp), while `u_b`
+///   has a small `time_low` and large `time_hi` (giving it a large true
+///   timestamp) - so byte order and timestamp order disagree on them.
+/// - `u_v4` is version 4 with a `time_low` byte (0x80) that byte-sorts
+///   between `u_b` and `u_a`/`u_max`, but must sort after every version-1
+///   UUID regardless of its value.
+/// - `u_lo` shares `u_min`'s timestamp exactly (both v1, timestamp 0), so
+///   ScyllaDB's tie-break on bytes 8..16 as plain unsigned bytes decides:
+///   `u_lo`'s 0x7f < `u_min`'s 0x80. `CqlTimeuuid: Ord` (the different,
+///   sign-flipped tie-break ScyllaDB's *TIMEUUID*-column comparator uses)
+///   would order them the other way, so reusing it here would be a bug.
+///
+/// Rather than hardcoding the expected order, this loops over every value
+/// as the `<` threshold and, for each, derives the expected row set from
+/// Scylla evaluating the same restriction without `ORDER BY v ANN OF` -
+/// asserting the ANN-filtered query returns exactly that set. Looping the
+/// threshold over the whole dataset exercises every pairwise comparison
+/// among the values, not just one hand-picked split.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_uuid_column_ordering_matches_scylla(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f UUID, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    let u_min = Uuid::parse_str("00000000-0000-1000-8000-000000000000").unwrap(); // v1, timestamp = 0
+    let u_a = Uuid::parse_str("ffffffff-0000-1000-8000-000000000001").unwrap(); // v1, timestamp ~ 4.3e9
+    let u_b = Uuid::parse_str("00000000-0000-1fff-8000-000000000002").unwrap(); // v1, timestamp ~ 1.15e18
+    let u_max = Uuid::parse_str("ffffffff-ffff-1fff-bfff-ffffffffffff").unwrap(); // v1, max timestamp
+    let u_v4 = Uuid::parse_str("80000000-0000-4000-8000-000000000000").unwrap(); // v4
+    let u_lo = Uuid::parse_str("00000000-0000-1000-7f00-000000000003").unwrap(); // v1, same timestamp = 0 as u_min, but differs in the tie-break byte (0x7f vs 0x80)
+
+    let values: [(i32, Uuid); 6] = [
+        (0, u_min),
+        (1, u_a),
+        (2, u_b),
+        (3, u_max),
+        (4, u_v4),
+        (5, u_lo),
+    ];
+    for (pk, u) in &values {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+                (pk, u, &vec![*pk as f32, 0.0, 0.0]),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 6, "Expected 6 vectors to be indexed");
+    }
+
+    for (threshold_pk, threshold) in &values {
+        info!("Comparing ANN-filtered and plain (non-ANN) results for f < {threshold}");
+        let ann_results = get_pks(
+            format!(
+                "SELECT pk FROM {table} WHERE f < {threshold} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+            ),
+            &session,
+        )
+        .await;
+        let plain_results = get_pks(
+            format!("SELECT pk FROM {table} WHERE f < {threshold} ALLOW FILTERING"),
+            &session,
+        )
+        .await;
+
+        assert_eq!(
+            ann_results, plain_results,
+            "ANN-filtered results must match Scylla's own (non-ANN) filtering \
+             for f < {threshold} (threshold pk={threshold_pk})"
+        );
+    }
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by equality on a TIMEUUID filtering column.
+///
+/// See ann_filter_by_blob_column_eq above: this is the Timeuuid case of the
+/// same VECTOR-889 bug.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_timeuuid_column_eq(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f TIMEUUID, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    let t0: CqlTimeuuid = "00000000-0000-1000-8000-000000000000".parse().unwrap();
+    let t1: CqlTimeuuid = "ffffffff-ffff-1fff-bfff-ffffffffffff".parse().unwrap();
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (0, t0, &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+    session
+        .query_unpaged(
+            format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+            (1, t1, &vec![0.0f32, 0.0, 0.0]),
+        )
+        .await
+        .expect("failed to insert data");
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
+    }
+
+    info!("Querying index for f = {t0}");
+    let results = get_pks(
+        format!(
+            "SELECT pk FROM {table} WHERE f = {t0} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+        ),
+        &session,
+    )
+    .await;
+    assert_eq!(results, HashSet::from([0]));
+
+    session
+        .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
+        .await
+        .expect("failed to drop a keyspace");
+
+    info!("finished");
+}
+
+/// Test ANN search filtered by an inequality (`<`) on a TIMEUUID filtering
+/// column, cross-checked against Scylla's own (non-ANN) filtering, to
+/// verify we got the ordering right.
+///
+/// This dataset is crafted the same way as ann_filter_by_uuid_column_ordering_matches_scylla
+/// above: `t_a` has a large `time_low` and small `time_hi` (small true
+/// timestamp), `t_b` has a small `time_low` and large `time_hi` (large
+/// true timestamp) - so byte order and timestamp order disagree on them.
+///
+/// Rather than hardcoding the expected order, this loops over every value
+/// as the `<` threshold and, for each, derives the expected row set from
+/// Scylla evaluating the same restriction without `ORDER BY v ANN OF` -
+/// asserting the ANN-filtered query returns exactly that set. Looping the
+/// threshold over the whole dataset exercises every pairwise comparison
+/// among the values, not just one hand-picked split.
+#[e2etest::test(group = filtering)]
+async fn ann_filter_by_timeuuid_column_ordering_matches_scylla(actors: Arc<TestActors>) {
+    info!("started");
+
+    let (session, clients) = prepare_connection(&actors).await;
+
+    let keyspace = create_keyspace(&session).await;
+    let table = create_table(
+        &session,
+        "pk INT, f TIMEUUID, v VECTOR<FLOAT, 3>, PRIMARY KEY (pk)",
+        None,
+    )
+    .await;
+
+    let t_min: CqlTimeuuid = "00000000-0000-1000-8000-000000000000".parse().unwrap(); // timestamp = 0
+    let t_a: CqlTimeuuid = "ffffffff-0000-1000-8000-000000000001".parse().unwrap(); // timestamp ~ 4.3e9
+    let t_b: CqlTimeuuid = "00000000-0000-1fff-8000-000000000002".parse().unwrap(); // timestamp ~ 1.15e18
+    let t_max: CqlTimeuuid = "ffffffff-ffff-1fff-bfff-ffffffffffff".parse().unwrap(); // max timestamp
+
+    let values: [(i32, CqlTimeuuid); 4] = [(0, t_min), (1, t_a), (2, t_b), (3, t_max)];
+    for (pk, t) in &values {
+        session
+            .query_unpaged(
+                format!("INSERT INTO {table} (pk, f, v) VALUES (?, ?, ?)"),
+                (pk, t, &vec![*pk as f32, 0.0, 0.0]),
+            )
+            .await
+            .expect("failed to insert data");
+    }
+
+    let index =
+        create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
+            .await;
+
+    for client in &clients {
+        let index_status = wait_for_index(client, &index).await;
+        assert_eq!(index_status.count, 4, "Expected 4 vectors to be indexed");
+    }
+
+    for (threshold_pk, threshold) in &values {
+        info!("Comparing ANN-filtered and plain (non-ANN) results for f < {threshold}");
+        let ann_results = get_pks(
+            format!(
+                "SELECT pk FROM {table} WHERE f < {threshold} ORDER BY v ANN OF [0.0, 0.0, 0.0] LIMIT 10 ALLOW FILTERING"
+            ),
+            &session,
+        )
+        .await;
+        let plain_results = get_pks(
+            format!("SELECT pk FROM {table} WHERE f < {threshold} ALLOW FILTERING"),
+            &session,
+        )
+        .await;
+
+        assert_eq!(
+            ann_results, plain_results,
+            "ANN-filtered results must match Scylla's own (non-ANN) filtering \
+             for f < {threshold} (threshold pk={threshold_pk})"
+        );
+    }
 
     session
         .query_unpaged(format!("DROP KEYSPACE {keyspace}"), ())
@@ -1528,6 +2133,24 @@ async fn ann_filter_by_non_pk_column_rejected_with_allow_filtering(actors: Arc<T
         .expect("failed to drop a keyspace");
 
     info!("finished");
+}
+
+/// Format bytes as a CQL blob literal, e.g. `0x0102ff`.
+fn blob_literal(bytes: &[u8]) -> String {
+    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    format!("0x{hex}")
+}
+
+/// Run a query expected to select a `pk` column and collect the results
+/// into a set, for comparing an ANN-filtered query against the same
+/// restriction evaluated by Scylla without `ORDER BY v ANN OF`.
+async fn get_pks(query: String, session: &Session) -> HashSet<i32> {
+    get_query_results(query, session)
+        .await
+        .rows::<(i32,)>()
+        .expect("failed to get rows")
+        .map(|row| row.expect("failed to get row").0)
+        .collect()
 }
 
 async fn insert_ck_only_test_rows(session: &Session, table: &TableName) {

--- a/crates/validator/src/filtering.rs
+++ b/crates/validator/src/filtering.rs
@@ -69,10 +69,7 @@ async fn ann_filter_by_partition_key_eq(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 20, "Expected 20 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 20).await;
 
     let result = wait_for_value(
         || async {
@@ -140,10 +137,7 @@ async fn ann_filter_by_partition_key_in(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 20, "Expected 20 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 20).await;
 
     let result = wait_for_value(
         || async {
@@ -207,10 +201,7 @@ async fn ann_filter_by_clustering_key_lt(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 10, "Expected 10 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 10).await;
 
     let result = wait_for_value(
         || async {
@@ -274,10 +265,7 @@ async fn ann_filter_by_clustering_key_gt(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 10, "Expected 10 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 10).await;
 
     let result = wait_for_value(
         || async {
@@ -345,14 +333,7 @@ async fn ann_filter_by_inet_clustering_key_gt(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(
-            index_status.count,
-            addrs.len(),
-            "Expected every address to be indexed"
-        );
-    }
+    wait_for_index_count(&clients, &index, addrs.len()).await;
 
     // ScyllaDB owns the ordering, so take the expected rows from a plain query.
     let expected: HashSet<IpAddr> = get_query_results(
@@ -431,10 +412,7 @@ async fn ann_filter_by_clustering_key_range(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 10, "Expected 10 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 10).await;
 
     let result = wait_for_value(
         || async {
@@ -504,10 +482,7 @@ async fn ann_filter_by_pk_and_ck(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 20, "Expected 20 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 20).await;
 
     let result = wait_for_value(
         || async {
@@ -573,10 +548,7 @@ async fn ann_filter_returns_no_results_when_nothing_matches(actors: Arc<TestActo
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 10, "Expected 10 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 10).await;
 
     // Wait until the index is operational for filtered queries
     wait_for(
@@ -642,10 +614,7 @@ async fn ann_filter_by_vector_column_fails(actors: Arc<TestActors>) {
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 5, "Expected 5 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 5).await;
 
     session
         .query_unpaged(
@@ -703,13 +672,7 @@ async fn global_index_filter_by_filtering_columns(actors: Arc<TestActors>) {
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(
-            index_status.count, 10,
-            "Expected 10 vectors to be indexed in the index"
-        );
-    }
+    wait_for_index_count(&clients, &index, 10).await;
 
     info!("Querying index for f = 0");
     let results: HashSet<_> = get_query_results(
@@ -796,10 +759,7 @@ async fn ann_filter_by_blob_column_eq(actors: Arc<TestActors>) {
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 2).await;
 
     info!("Querying index for f = 0x010203");
     let results = get_pks(
@@ -876,10 +836,7 @@ async fn ann_filter_by_blob_column_ordering_matches_scylla(actors: Arc<TestActor
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 6, "Expected 6 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 6).await;
 
     for (threshold_pk, threshold) in &values {
         let literal = blob_literal(threshold);
@@ -949,10 +906,7 @@ async fn ann_filter_by_boolean_column_eq(actors: Arc<TestActors>) {
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 2).await;
 
     info!("Querying index for f = true");
     let results = get_pks(
@@ -1009,10 +963,7 @@ async fn ann_filter_by_boolean_column_ordering_matches_scylla(actors: Arc<TestAc
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 2).await;
 
     for (threshold_pk, threshold) in &values {
         info!("Comparing ANN-filtered and plain (non-ANN) results for f < {threshold}");
@@ -1083,10 +1034,7 @@ async fn ann_filter_by_uuid_column_eq(actors: Arc<TestActors>) {
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 2).await;
 
     info!("Querying index for f = {u0}");
     let results = get_pks(
@@ -1177,10 +1125,7 @@ async fn ann_filter_by_uuid_column_ordering_matches_scylla(actors: Arc<TestActor
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 6, "Expected 6 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 6).await;
 
     for (threshold_pk, threshold) in &values {
         info!("Comparing ANN-filtered and plain (non-ANN) results for f < {threshold}");
@@ -1251,10 +1196,7 @@ async fn ann_filter_by_timeuuid_column_eq(actors: Arc<TestActors>) {
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 2, "Expected 2 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 2).await;
 
     info!("Querying index for f = {t0}");
     let results = get_pks(
@@ -1323,10 +1265,7 @@ async fn ann_filter_by_timeuuid_column_ordering_matches_scylla(actors: Arc<TestA
         create_index(CreateIndexQuery::new(&session, &clients, &table, "v").filter_columns(["f"]))
             .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 4, "Expected 4 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 4).await;
 
     for (threshold_pk, threshold) in &values {
         info!("Comparing ANN-filtered and plain (non-ANN) results for f < {threshold}");
@@ -1401,13 +1340,7 @@ async fn local_index_filter_by_filtering_columns(actors: Arc<TestActors>) {
     )
     .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(
-            index_status.count, 100,
-            "Expected 100 vectors to be indexed in the index"
-        );
-    }
+    wait_for_index_count(&clients, &index, 100).await;
 
     info!("Querying index for pk = 3 AND f = 1");
     let results: HashSet<_> = get_query_results(
@@ -1483,10 +1416,7 @@ async fn global_index_filter_by_filtering_column_shared_with_primary_key(actors:
     )
     .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 1, "Expected 1 vector to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 1).await;
 
     let results = get_query_results(
         format!(
@@ -1549,10 +1479,7 @@ async fn local_index_filter_by_partition_key_eq(actors: Arc<TestActors>) {
     )
     .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 20, "Expected 20 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 20).await;
 
     let result = wait_for_value(
         || async {
@@ -1623,10 +1550,7 @@ async fn local_index_filter_by_clustering_key_range(actors: Arc<TestActors>) {
     )
     .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 10, "Expected 10 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 10).await;
 
     let result = wait_for_value(
         || async {
@@ -1691,10 +1615,7 @@ async fn local_index_filter_returns_no_results_when_nothing_matches(actors: Arc<
     )
     .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 10, "Expected 10 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 10).await;
 
     wait_for(
         || async {
@@ -1779,13 +1700,7 @@ async fn local_index_filter_by_partition_key_or_filtering(actors: Arc<TestActors
         )
         .await;
 
-        for client in &clients {
-            let index_status = wait_for_index(client, &index).await;
-            assert_eq!(
-                index_status.count, DATASET_SIZE,
-                "Expected {DATASET_SIZE} vectors to be indexed in the index"
-            );
-        }
+        wait_for_index_count(&clients, &index, DATASET_SIZE).await;
 
         info!("Querying index for {pc} = 1");
         let rows = get_query_results(
@@ -1877,10 +1792,7 @@ async fn global_ann_query_on_local_only_index_fails(actors: Arc<TestActors>) {
     )
     .await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 20, "Expected 20 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 20).await;
 
     let err = session
         .query_unpaged(
@@ -2060,10 +1972,7 @@ async fn ann_filter_by_clustering_key_only_requires_allow_filtering(actors: Arc<
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
 
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 3, "Expected 3 vectors to be indexed");
-    }
+    wait_for_index_count(&clients, &index, 3).await;
 
     info!("Verify ANN query with only ck filtering is rejected without ALLOW FILTERING");
     session
@@ -2245,10 +2154,7 @@ async fn prepare_non_pk_column_filter_test(
     .await;
 
     let index = create_index(CreateIndexQuery::new(&session, &clients, &table, "v")).await;
-    for client in &clients {
-        let index_status = wait_for_index(client, &index).await;
-        assert_eq!(index_status.count, 0, "Index should start empty");
-    }
+    wait_for_index_count(&clients, &index, 0).await;
 
     info!("Create index on non-PK column c");
     session

--- a/crates/vector-store/src/cql_types.rs
+++ b/crates/vector-store/src/cql_types.rs
@@ -28,6 +28,7 @@ use time::Time;
 use time::format_description::well_known::Iso8601;
 use time::format_description::well_known::iso8601::Config;
 use time::format_description::well_known::iso8601::TimePrecision;
+use uuid::Uuid;
 
 pub(crate) const SUPPORTED: &[NativeType] = &[
     NativeType::Ascii,
@@ -274,8 +275,58 @@ pub(crate) fn from_json(value: Value, cql_type: &NativeType) -> anyhow::Result<C
     }
 }
 
+/// Orders two regular (non-time) UUIDs the way ScyllaDB's `uuid_type_impl`
+/// comparator does: by version nibble first; version-1 (time-based) UUIDs
+/// then compare by reassembled timestamp and, on a timestamp tie, by
+/// bytes 8..16 as plain unsigned bytes (`utils::uuid_tri_compare_timeuuid`
+/// in UUID.hh); everything else compares by unsigned bytes.
+///
+/// The timestamp tie-break is deliberately NOT `CqlTimeuuid: Ord` /
+/// `a.cmp(b)` on the raw bytes: those match `utils::timeuuid_tri_compare`,
+/// which is the *TIMEUUID-column* comparator - it XORs bytes 8..16 with
+/// 0x80 (a signed-byte compare, kept for legacy Cassandra sstable
+/// ordering) before comparing. That disagrees with the plain-UUID-column
+/// comparator above whenever two version-1 UUIDs share a timestamp and
+/// their tie-break bytes straddle the 0x7f/0x80 boundary - confirmed
+/// against a live scylladb/scylla:2026.4.0 (see the pinned unit test
+/// below and the boundary case in ann_filter_by_uuid_column_ordering_matches_scylla).
+///
+/// Plain `uuid::Uuid: Ord` is a raw 128-bit byte compare and would
+/// disagree with ScyllaDB too.
+fn uuid_cmp(a: &Uuid, b: &Uuid) -> Ordering {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    let va = (a[6] >> 4) & 0x0f;
+    let vb = (b[6] >> 4) & 0x0f;
+    if va != vb {
+        return va.cmp(&vb);
+    }
+    if va == 1 {
+        // && vb == 1
+        return uuid_timeuuid_msb(a)
+            .cmp(&uuid_timeuuid_msb(b))
+            .then_with(|| a[8..].cmp(&b[8..]));
+    }
+    a.cmp(b)
+}
+
+/// Reassembles the 60-bit timeuuid timestamp (time_hi | time_mid |
+/// time_low) into a directly comparable `u64`, matching ScyllaDB's
+/// `timeuuid_read_msb` (UUID.hh) exactly.
+fn uuid_timeuuid_msb(bytes: &[u8; 16]) -> u64 {
+    u64::from(bytes[6] & 0x0f) << 56
+        | u64::from(bytes[7]) << 48
+        | u64::from(bytes[4]) << 40
+        | u64::from(bytes[5]) << 32
+        | u64::from(bytes[0]) << 24
+        | u64::from(bytes[1]) << 16
+        | u64::from(bytes[2]) << 8
+        | u64::from(bytes[3])
+}
+
 /// Compare two CqlValues, returning an Ordering if they are comparable. `None` means "does
-/// not match" to callers, not an error, so a missing arm silently matches no rows.
+/// not match" to callers, not an error, so a missing arm silently matches no rows. Supports
+/// Numeric, Text, Date, Time, Timestamp, Inet, Blob, Boolean, Uuid, and Timeuuid types.
 pub(crate) fn cmp(lhs: &CqlValue, rhs: &CqlValue) -> Option<Ordering> {
     match (lhs, rhs) {
         // Numeric types
@@ -316,6 +367,15 @@ pub(crate) fn cmp(lhs: &CqlValue, rhs: &CqlValue) -> Option<Ordering> {
         (CqlValue::Timestamp(a), CqlValue::Timestamp(b)) => Some(a.0.cmp(&b.0)),
         // Inet type
         (CqlValue::Inet(a), CqlValue::Inet(b)) => Some(inet_cmp(a, b)),
+        // Blob: byte-wise unsigned comparison, matching Cassandra's BytesType.
+        (CqlValue::Blob(a), CqlValue::Blob(b)) => Some(a.cmp(b)),
+        // Boolean: false < true, matching a single 0/1 byte comparison.
+        (CqlValue::Boolean(a), CqlValue::Boolean(b)) => Some(a.cmp(b)),
+        // Timeuuid: the driver's CqlTimeuuid: Ord already implements
+        // ScyllaDB's timeuuid ordering exactly (see uuid_cmp's doc comment).
+        (CqlValue::Timeuuid(a), CqlValue::Timeuuid(b)) => Some(a.cmp(b)),
+        // Uuid: version-aware comparison, see uuid_cmp().
+        (CqlValue::Uuid(a), CqlValue::Uuid(b)) => Some(uuid_cmp(a, b)),
         // Unsupported or mismatched types
         _ => None,
     }
@@ -386,13 +446,6 @@ mod tests {
         }
     }
 
-    pub(crate) const CMP_UNSUPPORTED: &[NativeType] = &[
-        NativeType::Blob,
-        NativeType::Boolean,
-        NativeType::Timeuuid,
-        NativeType::Uuid,
-    ];
-
     #[test]
     fn every_supported_type_is_handled() {
         for typ in SUPPORTED {
@@ -406,19 +459,11 @@ mod tests {
             let back = from_json(json.clone(), typ)
                 .unwrap_or_else(|err| panic!("{typ:?}: from_json({json}): {err}"));
             assert_eq!(back, value, "{typ:?}: JSON round trip");
-            if CMP_UNSUPPORTED.contains(typ) {
-                assert_eq!(
-                    cmp(&value, &value),
-                    None,
-                    "{typ:?}: comparable - drop it from CMP_UNSUPPORTED"
-                );
-            } else {
-                assert_eq!(
-                    cmp(&value, &value),
-                    Some(Ordering::Equal),
-                    "{typ:?}: a value must compare equal to itself"
-                );
-            }
+            assert_eq!(
+                cmp(&value, &value),
+                Some(Ordering::Equal),
+                "{typ:?}: a value must compare equal to itself"
+            );
         }
     }
 
@@ -1040,16 +1085,129 @@ mod tests {
 
     #[test]
     fn cmp_unsupported_types_return_none() {
+        // Duration and other complex/collection types still have no cmp arm.
+        use scylla::value::CqlDuration;
+        let duration = CqlDuration {
+            months: 0,
+            days: 0,
+            nanoseconds: 0,
+        };
+        assert_eq!(
+            cmp(&CqlValue::Duration(duration), &CqlValue::Duration(duration)),
+            None
+        );
+    }
+
+    // Regression tests for VECTOR-889: cmp() had no arm for Blob, Boolean,
+    // Uuid or Timeuuid, so an ANN filter restriction on a column of any of
+    // these types silently matched zero rows - even a value compared against
+    // itself.
+    #[test]
+    fn cmp_blob() {
         assert_eq!(
             cmp(
                 &CqlValue::Blob(vec![1, 2, 3]),
                 &CqlValue::Blob(vec![1, 2, 3])
             ),
-            None
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            cmp(&CqlValue::Blob(vec![1, 2]), &CqlValue::Blob(vec![1, 2, 3])),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            cmp(&CqlValue::Blob(vec![1, 3]), &CqlValue::Blob(vec![1, 2, 3])),
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn cmp_boolean() {
+        assert_eq!(
+            cmp(&CqlValue::Boolean(true), &CqlValue::Boolean(true)),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            cmp(&CqlValue::Boolean(false), &CqlValue::Boolean(true)),
+            Some(Ordering::Less)
         );
         assert_eq!(
             cmp(&CqlValue::Boolean(true), &CqlValue::Boolean(false)),
-            None
+            Some(Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn cmp_timeuuid() {
+        let make = |bytes: [u8; 16]| CqlValue::Timeuuid(CqlTimeuuid::from_bytes(bytes));
+        let t = [
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x11, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+            0xff, 0x00,
+        ];
+        assert_eq!(cmp(&make(t), &make(t)), Some(Ordering::Equal));
+        // Earlier timestamp (lower first byte of the time-low field) orders first.
+        let mut earlier = t;
+        earlier[0] = 0x01;
+        assert_eq!(cmp(&make(earlier), &make(t)), Some(Ordering::Less));
+        assert_eq!(cmp(&make(t), &make(earlier)), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn cmp_uuid_equality() {
+        let u = Uuid::parse_str("841685b2-8803-11f0-8de9-0242ac120002").unwrap();
+        assert_eq!(
+            cmp(&CqlValue::Uuid(u), &CqlValue::Uuid(u)),
+            Some(Ordering::Equal)
+        );
+    }
+
+    // Pins the authoritative clustering order for a mixed-version set of
+    // UUIDs, verified against a live scylladb/scylla:2026.2.2 (see
+    // VECTOR-889): version orders first, and version-1 (time-based) UUIDs
+    // order by timestamp rather than by raw bytes.
+    #[test]
+    fn cmp_uuid_mixed_versions_matches_scylladb_order() {
+        let ordered_uuids = [
+            "00000000-0000-1000-8000-000000000000", // v1
+            "841685b2-8803-11f0-8de9-0242ac120002", // v1
+            "ffffffff-ffff-1fff-bfff-ffffffffffff", // v1
+            "00000000-0000-3000-8000-000000000000", // v3
+            "00000000-0000-4000-8000-000000000000", // v4
+            "7fffffff-ffff-4fff-7fff-ffffffffffff", // v4
+            "ffffffff-ffff-4fff-bfff-ffffffffffff", // v4
+            "00000000-0000-5000-8000-000000000000", // v5
+        ]
+        .map(|s| Uuid::parse_str(s).unwrap());
+
+        for pair in ordered_uuids.windows(2) {
+            let (a, b) = (pair[0], pair[1]);
+            assert_eq!(
+                cmp(&CqlValue::Uuid(a), &CqlValue::Uuid(b)),
+                Some(Ordering::Less),
+                "expected {a} < {b}"
+            );
+        }
+    }
+
+    /// Regression test: two version-1 UUIDs with the *same* reassembled
+    /// timestamp, but tie-break bytes (8..16) straddling the 0x7f/0x80
+    /// boundary. `uuid_type_impl`'s `UUID`-column comparator
+    /// (`uuid_tri_compare_timeuuid`) breaks the tie by plain unsigned
+    /// bytes, so `0x7f... < 0x80...` - confirmed against a live
+    /// scylladb/scylla 2026.4.0 with a UUID-clustering-key table. This is
+    /// the opposite of what `CqlTimeuuid: Ord` (the *TIMEUUID*-column
+    /// comparator, `utils::timeuuid_tri_compare`, which XORs those same
+    /// bytes with 0x80 - a signed compare) would give, confirmed against
+    /// the same live cluster with a TIMEUUID-clustering-key table instead.
+    /// `cmp_uuid_mixed_versions_matches_scylladb_order` above never
+    /// exercises this because none of its UUIDs share a timestamp.
+    #[test]
+    fn cmp_uuid_same_timestamp_lsb_tie_break_is_unsigned() {
+        let lo = Uuid::parse_str("00000000-0000-1000-7f00-000000000000").unwrap();
+        let hi = Uuid::parse_str("00000000-0000-1000-8000-000000000000").unwrap();
+        assert_eq!(
+            cmp(&CqlValue::Uuid(lo), &CqlValue::Uuid(hi)),
+            Some(Ordering::Less)
         );
     }
 


### PR DESCRIPTION
cql_cmp() (in table/mod.rs), used by is_valid_for() to evaluate ANN filter restrictions, had no comparison arm for these four types. Its callers treat a None result as "row does not match", not as an error, so an Eq (or Lt/Lte/Gt/Gte/In) restriction on a blob, boolean, uuid or timeuuid column always silently matched zero rows - with no error and no log line.

This bug is easily reproducable in CQL - e.g., a table with a blob filtered in a vector index - and we include in this patch CQL validator tests that demonstrate this. It was also hit while adding Alternator SearchSchema support for the "B" (binary) attribute type, which reaches the same code path in the vector store.

Fix:
* Blob: byte-wise comparison, matching Cassandra's BytesType.
* Boolean: false < true.
* Timeuuid: the driver's CqlTimeuuid: Ord already implements ScyllaDB's timeuuid ordering exactly.
* Uuid: needs its own uuid_cmp() helper - ScyllaDB's uuid_type_impl orders by version nibble first, and version-1 (time-based) UUIDs by timestamp; a plain 128-bit byte compare disagrees with ScyllaDB. 

We also add regression tests: unit tests in table/mod.rs for all four types, validator (end-to-end) tests in filtering.rs that reproduce the bug with pure CQL ANN queries filtered by each type, and additional validator (end-to-end) tests that check that the comparison order of ANN filtering in Scylla is exactly the same as the comparison order in traditional CQL filtering - by comparing ANN queries to regular queries without ANN.

Fixes VECTOR-889.