### PR TITLE
ci: trigger siren add-vectorstore-ver workflow after cloud images are built

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -195,6 +195,107 @@ jobs:
           asset_name: vector-store-cloud-images-${{ env.VECTOR_VERSION }}.json
           asset_content_type: application/json
 
+  # Hand the freshly built cloud images over to siren: extract the image IDs
+  # from the packer manifest and send the repository_dispatch that starts
+  # https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml,
+  # which opens a versions.yaml PR in scylladb/siren. A separate job consuming
+  # the manifest artifact (the push-docker pattern) keeps the dispatch
+  # re-runnable without rebuilding the images.
+  trigger-siren:
+    needs: [build-cloud-images]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check the version is a GA release
+        id: ga
+        run: |
+          set -euo pipefail
+          # siren validates the version against ^X.Y.Z$ and unconditionally
+          # moves its defaults.vectorstore to it, so pre-release and dev tags
+          # (1.6.1-rc0, X.Y.Z-dev) must not be dispatched. The release trigger
+          # already filters prereleases out, but workflow_dispatch takes an
+          # arbitrary VECTOR_VERSION — skip (not fail) the job on those.
+          if [[ "${VECTOR_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ; then
+            echo "ga=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ga=false" >> "$GITHUB_OUTPUT"
+            echo "Version \`${VECTOR_VERSION}\` is not a GA X.Y.Z release — skipping the siren dispatch" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Download the packer manifest artifact
+        if: steps.ga.outputs.ga == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vector-store-cloud-images-${{ env.VECTOR_VERSION }}
+
+      - name: Extract the image IDs from the packer manifest
+        if: steps.ga.outputs.ga == 'true'
+        id: images
+        run: |
+          set -euo pipefail
+          # All three sequential packer builds append to the one .builds[]
+          # array, and a re-run appends rather than replaces — take the last
+          # matching entry. The AWS builds are told apart by the arch recorded
+          # in custom_data by the manifest post-processor; their artifact_id
+          # is a comma-separated region:ami list and siren expects the bare
+          # us-east-1 AMI (it prefixes the value with us-east-1/ itself).
+          # The GCP image needs no such disambiguation: only one architecture
+          # (amd64) is built there, so builder_type alone identifies it.
+          aws_ami() {
+            jq -r --arg arch "$1" \
+              '[.builds[] | select(.builder_type=="amazon-ebs" and .custom_data.arch==$arch)] | last | .artifact_id // empty' \
+              packer-manifest.json \
+              | tr ',' '\n' | { grep '^us-east-1:' || true ; } | cut -d: -f2
+          }
+          aws_amd64_ami=$(aws_ami amd64)
+          aws_arm64_ami=$(aws_ami arm64)
+          gcp_amd64_image=$(jq -r \
+            '[.builds[] | select(.builder_type=="googlecompute")] | last | .artifact_id // empty' \
+            packer-manifest.json)
+          for var in aws_amd64_ami aws_arm64_ami gcp_amd64_image ; do
+            if [[ -z "${!var}" ]] ; then
+              echo "::error::failed to extract ${var} from packer-manifest.json"
+              exit 1
+            fi
+            echo "${var}=${!var}" >> "$GITHUB_OUTPUT"
+          done
+
+      - name: Trigger the siren add-vectorstore-ver workflow
+        if: steps.ga.outputs.ga == 'true'
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.SIREN_REPO_TOKEN }}
+          repository: scylladb/siren
+          event-type: vectorstore-release
+          client-payload: |
+            {
+              "version": "${{ env.VECTOR_VERSION }}",
+              "aws_amd64_ami": "${{ steps.images.outputs.aws_amd64_ami }}",
+              "gcp_amd64_image": "${{ steps.images.outputs.gcp_amd64_image }}",
+              "aws_arm64_ami": "${{ steps.images.outputs.aws_arm64_ami }}"
+            }
+
+      - name: Log the siren workflow link
+        if: steps.ga.outputs.ga == 'true'
+        env:
+          AWS_AMD64_AMI: ${{ steps.images.outputs.aws_amd64_ami }}
+          AWS_ARM64_AMI: ${{ steps.images.outputs.aws_arm64_ami }}
+          GCP_AMD64_IMAGE: ${{ steps.images.outputs.gcp_amd64_image }}
+        run: |
+          set -euo pipefail
+          # repository_dispatch returns 204 with no run id, so the run status
+          # cannot be reported here — link to the siren workflow page instead.
+          {
+            echo "Dispatched \`vectorstore-release\` for \`${VECTOR_VERSION}\` to scylladb/siren:"
+            echo ""
+            echo "- \`aws_amd64_ami\`: \`${AWS_AMD64_AMI}\`"
+            echo "- \`aws_arm64_ami\`: \`${AWS_ARM64_AMI}\`"
+            echo "- \`gcp_amd64_image\`: \`${GCP_AMD64_IMAGE}\`"
+            echo ""
+            echo "Check <https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml> for the resulting run and versions.yaml PR."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   announce:
     needs: [push-docker, build-cloud-images]
     runs-on: ubuntu-latest

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -87,6 +87,45 @@ This will upload all tar.gz archives and SBOM files to the GitHub release
 matching the current version tag. It requires the `gh` CLI to be installed and
 authenticated.
 
+## Registering the release in siren
+
+The release workflow registers a GA release with siren automatically: after
+`build-cloud-images` uploads the packer manifest, the `trigger-siren` job
+extracts the `us-east-1` amd64/arm64 AMI IDs and the GCP image name from it
+and sends a `vectorstore-release` `repository_dispatch` to scylladb/siren.
+That starts siren's
+[add-vectorstore-ver](https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml)
+workflow, which opens a `feat(vectorstore): add version X.Y.Z [automation]`
+PR against siren's `info/version/versions.yaml`. No manual step is needed for
+a GA release.
+
+Two caveats:
+
+- Only GA `X.Y.Z` versions are dispatched. Pre-release and dev tags
+  (`1.6.1-rc0`, `X.Y.Z-dev`) skip the dispatch, because siren validates the
+  version against `^X.Y.Z$` and unconditionally moves its
+  `defaults.vectorstore` to the dispatched version. For the same reason,
+  releasing a patch on an *older* series still moves `defaults.vectorstore`
+  back to it — review the siren PR before merging in that case.
+- `repository_dispatch` returns no run id, so the job cannot report the siren
+  run status. It logs the dispatched image IDs and a link to the siren
+  workflow page in its job summary — verify there that the run succeeded and
+  the PR appeared.
+
+If the dispatch fails, or the siren run does, the cloud images do not need to
+be rebuilt: re-run just the `trigger-siren` job, which re-reads the packer
+manifest artifact of the same workflow run. To trigger siren fully by hand
+instead, start
+[add-vectorstore-ver](https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml)
+via `workflow_dispatch`, copying the version, the bare `us-east-1` amd64 and
+arm64 AMI IDs, and the GCP image name from the packer manifest. For a release
+started by publishing a GitHub release, the manifest is attached to the
+release as the `vector-store-cloud-images-X.Y.Z.json` asset; a release
+started via `workflow_dispatch` uploads no release asset, so download the
+`vector-store-cloud-images-X.Y.Z` workflow artifact from the run page
+instead. In the manifest the AWS `artifact_id` is a comma-separated
+`region:ami` list — use the AMI from the `us-east-1` entry.
+
 ### Prerequisites
 
 - Docker; qemu support is needed only when building a non-native

--- a/packer/vector-store-template.json
+++ b/packer/vector-store-template.json
@@ -119,7 +119,10 @@
     {
       "type": "manifest",
       "output": "packer-manifest.json",
-      "strip_path": true
+      "strip_path": true,
+      "custom_data": {
+        "arch": "{{ user `arch` }}"
+      }
     }
   ],
   "variables": {


### PR DESCRIPTION
### Motivation

The last step of a Vector Store release is still manual: after the `build-cloud-images` job uploads `packer-manifest.json`, someone has to open siren's [add-vectorstore-ver](https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml) workflow, copy the AMI IDs and the GCP image name out of the manifest, and start it via `workflow_dispatch`. The siren workflow already supports being triggered remotely (`repository_dispatch` with `types: [vectorstore-release]`), and the `SIREN_REPO_TOKEN` secret is now provisioned (VECTOR-854), so the release workflow can send that dispatch itself.

### What this does

**`packer: tag manifest entries with the target architecture`** — both AWS AMIs come from the same `amazon-ebs` builder block (architecture is only a user variable), so their manifest entries were indistinguishable except by build ordering. The manifest post-processor now records `custom_data.arch`, letting consumers select AMIs by architecture instead of position.

**`ci: trigger siren add-vectorstore-ver workflow after cloud images`** — adds a `trigger-siren` job with `needs: [build-cloud-images]` that:

- downloads the packer manifest artifact and extracts the bare `us-east-1` amd64/arm64 AMI IDs and the GCP image name, selecting AWS entries by `custom_data.arch` and taking the **last** matching entry (re-running a build appends to `.builds[]` rather than replacing);
- sends the `vectorstore-release` `repository_dispatch` to scylladb/siren via `peter-evans/repository-dispatch` (pinned by SHA) using `SIREN_REPO_TOKEN`;
- **skips** (not fails) when `VECTOR_VERSION` is not a GA `X.Y.Z` version — siren validates against `^X.Y.Z$` and unconditionally moves `defaults.vectorstore`, and while the `release: [released]` trigger already filters prereleases, `workflow_dispatch` takes an arbitrary version;
- fails loudly if any image ID cannot be extracted or the dispatch itself fails, and logs the dispatched IDs plus a link to the siren workflow page in the job summary (`repository_dispatch` returns 204 with no run id, so the siren run status cannot be reported directly).

Being a separate job consuming the artifact (the `push-docker` pattern), the dispatch can be re-run without rebuilding the AMIs.

`docs/releasing.md` documents the automated step, the GA-only guard, the out-of-order-release caveat (a patch release on an older series still moves siren's `defaults.vectorstore` back — review the siren PR before merging in that case), and the manual `workflow_dispatch` fallback.

### Test plan

- [x] Workflow YAML and packer template JSON parse cleanly
- [x] jq extraction verified against a simulated manifest: re-run append picks the last entry, AMIs selected by arch (not position), bare `us-east-1` AMI extracted from the `region:ami` list, missing arch fails the job with a clear error
- [ ] Dry-run: dispatch a `workflow_dispatch` release run with a non-GA version (e.g. `X.Y.Z-dev`) and confirm `trigger-siren` skips cleanly
- [ ] First GA release: confirm the `feat(vectorstore): add version X.Y.Z [automation]` PR appears in scylladb/siren with the correct image IDs

Fixes: VECTOR-853
Refs: VECTOR-854
