### PR TITLE
vector-store: release full-scan range permit before waiting for row acknowledgements

### DIFF
--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -71,6 +71,8 @@ use tracing::info;
 use tracing::trace;
 use tracing::warn;
 
+mod full_scan;
+
 type GetTableColumnsR = Arc<HashMap<ColumnName, NativeType>>;
 type RangeScanResult =
     anyhow::Result<Pin<Box<dyn Stream<Item = DbIndexedRow> + std::marker::Send>>, anyhow::Error>;
@@ -455,52 +457,16 @@ impl Statements {
         tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
         completed_scan_length: Arc<AtomicU64>,
     ) {
-        let semaphore_capacity = self.nr_parallel_queries().get();
-        let semaphore = Arc::new(Semaphore::new(semaphore_capacity));
-
-        for (begin, end) in self.fullscan_ranges() {
-            let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
-
-            let range_scan = self.preform_range_scan(begin, end).await;
-            if let Ok(embeddings) = range_scan {
-                let tx = tx.clone();
-                let scan_length = completed_scan_length.clone();
-                tokio::spawn(async move {
-                    let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
-                    embeddings
-                        .for_each(move |embedding| {
-                            let tx = tx.clone();
-                            let tx_in_progress = tx_in_progress.clone();
-                            async move {
-                                _ = tx
-                                    .send((embedding, AsyncInProgress::Fullscan(tx_in_progress)))
-                                    .await;
-                            }
-                        })
-                        .await;
-
-                    // wait until all in-progress markers are dropped
-                    while rx_in_progress.recv().await.is_some() {
-                        rx_in_progress.len();
-                    }
-
-                    //Safety: end > begin, and the range fits into u64
-                    scan_length.fetch_add(
-                        end.value().abs_diff(begin.value() - 1),
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
-                    drop(permit);
-                });
-            } else {
-                drop(permit);
-            }
-        }
-
-        // Acquire all permits to wait until all spawned tasks have finished and released their permits.
-        let _permits = semaphore
-            .acquire_many(semaphore_capacity as u32)
-            .await
-            .unwrap();
+        full_scan::scan_ranges(
+            self.fullscan_ranges(),
+            self.nr_parallel_queries(),
+            |(begin, end)| self.preform_range_scan(begin, end),
+            //Safety: end > begin, and the range fits into u64
+            |&(begin, end)| end.value().abs_diff(begin.value() - 1),
+            tx,
+            completed_scan_length,
+        )
+        .await
     }
 
     fn nr_shards_in_cluster(&self) -> NonZeroUsize {

--- a/crates/vector-store/src/db_index/full_scan.rs
+++ b/crates/vector-store/src/db_index/full_scan.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+use crate::AsyncInProgress;
+use crate::DbIndexedRow;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use tokio::sync::Semaphore;
+use tokio::sync::mpsc;
+
+pub(crate) type RangeRows = BoxStream<'static, DbIndexedRow>;
+
+/// Streams the rows of every range into `tx`, limiting the number of concurrently scanned ranges
+/// to `concurrency`. Each row is tagged with an `AsyncInProgress::Fullscan` guard; a range
+/// contributes `range_length(&range)` to `completed_scan_length` once the pipeline has dropped all
+/// of its guards. The future resolves only after every range has been acknowledged this way.
+pub(crate) async fn scan_ranges<R, Fut>(
+    ranges: impl IntoIterator<Item = R>,
+    concurrency: NonZeroUsize,
+    open: impl Fn(R) -> Fut,
+    range_length: impl Fn(&R) -> u64,
+    tx: mpsc::Sender<(DbIndexedRow, AsyncInProgress)>,
+    completed_scan_length: Arc<AtomicU64>,
+) where
+    Fut: Future<Output = anyhow::Result<RangeRows>>,
+{
+    let semaphore_capacity = concurrency.get();
+    let semaphore = Arc::new(Semaphore::new(semaphore_capacity));
+
+    for range in ranges {
+        let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
+
+        let length = range_length(&range);
+        let range_scan = open(range).await;
+        if let Ok(embeddings) = range_scan {
+            let tx = tx.clone();
+            let scan_length = completed_scan_length.clone();
+            tokio::spawn(async move {
+                let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+                embeddings
+                    .for_each(move |embedding| {
+                        let tx = tx.clone();
+                        let tx_in_progress = tx_in_progress.clone();
+                        async move {
+                            _ = tx
+                                .send((embedding, AsyncInProgress::Fullscan(tx_in_progress)))
+                                .await;
+                        }
+                    })
+                    .await;
+
+                // wait until all in-progress markers are dropped
+                while rx_in_progress.recv().await.is_some() {
+                    rx_in_progress.len();
+                }
+
+                scan_length.fetch_add(length, Ordering::Relaxed);
+                drop(permit);
+            });
+        } else {
+            drop(permit);
+        }
+    }
+
+    // Acquire all permits to wait until all spawned tasks have finished and released their permits.
+    let _permits = semaphore
+        .acquire_many(semaphore_capacity as u32)
+        .await
+        .unwrap();
+}

--- a/crates/vector-store/src/db_index/full_scan.rs
+++ b/crates/vector-store/src/db_index/full_scan.rs
@@ -14,13 +14,19 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tracing::error;
 
 pub(crate) type RangeRows = BoxStream<'static, DbIndexedRow>;
 
-/// Streams the rows of every range into `tx`, limiting the number of concurrently scanned ranges
-/// to `concurrency`. Each row is tagged with an `AsyncInProgress::Fullscan` guard; a range
-/// contributes `range_length(&range)` to `completed_scan_length` once the pipeline has dropped all
-/// of its guards. The future resolves only after every range has been acknowledged this way.
+/// Streams the rows of every range into `tx`, keeping at most `concurrency` range streams open
+/// at once. Each row is tagged with an `AsyncInProgress::Fullscan` guard; a range contributes
+/// `range_length(&range)` to `completed_scan_length` once the pipeline has dropped all of its
+/// guards. The future resolves only after every range has been acknowledged this way. Dropping
+/// the future aborts the in-flight range tasks.
+///
+/// A range whose `open` fails is skipped: `open` is expected to have logged the failure, and the
+/// length of the range is not accounted, so the progress stays below `Progress::Done`.
 pub(crate) async fn scan_ranges<R, Fut>(
     ranges: impl IntoIterator<Item = R>,
     concurrency: NonZeroUsize,
@@ -31,47 +37,208 @@ pub(crate) async fn scan_ranges<R, Fut>(
 ) where
     Fut: Future<Output = anyhow::Result<RangeRows>>,
 {
-    let semaphore_capacity = concurrency.get();
-    let semaphore = Arc::new(Semaphore::new(semaphore_capacity));
+    let semaphore = Arc::new(Semaphore::new(concurrency.get()));
+    let mut in_flight = JoinSet::new();
 
     for range in ranges {
-        let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
-
+        let permit = Arc::clone(&semaphore)
+            .acquire_owned()
+            .await
+            .expect("full scan semaphore is never closed");
         let length = range_length(&range);
-        let range_scan = open(range).await;
-        if let Ok(embeddings) = range_scan {
-            let tx = tx.clone();
-            let scan_length = completed_scan_length.clone();
-            tokio::spawn(async move {
-                let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
-                embeddings
-                    .for_each(move |embedding| {
-                        let tx = tx.clone();
-                        let tx_in_progress = tx_in_progress.clone();
-                        async move {
-                            _ = tx
-                                .send((embedding, AsyncInProgress::Fullscan(tx_in_progress)))
-                                .await;
-                        }
-                    })
-                    .await;
-
-                // wait until all in-progress markers are dropped
-                while rx_in_progress.recv().await.is_some() {
-                    rx_in_progress.len();
+        let Ok(rows) = open(range).await else {
+            continue;
+        };
+        let tx = tx.clone();
+        let completed_scan_length = Arc::clone(&completed_scan_length);
+        in_flight.spawn(async move {
+            let (tx_in_progress, mut rx_in_progress) = mpsc::channel(1);
+            rows.for_each(move |row| {
+                let tx = tx.clone();
+                let tx_in_progress = tx_in_progress.clone();
+                async move {
+                    _ = tx
+                        .send((row, AsyncInProgress::Fullscan(tx_in_progress)))
+                        .await;
                 }
+            })
+            .await;
 
-                scan_length.fetch_add(length, Ordering::Relaxed);
-                drop(permit);
-            });
-        } else {
+            // wait until all in-progress markers are dropped
+            while rx_in_progress.recv().await.is_some() {}
+
+            completed_scan_length.fetch_add(length, Ordering::Relaxed);
             drop(permit);
+        });
+    }
+
+    while let Some(result) = in_flight.join_next().await {
+        if let Err(err) = result {
+            error!("full scan range task failed: {err}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DbIndexedOperation;
+    use crate::PrimaryKey;
+    use crate::Timestamp;
+    use anyhow::anyhow;
+    use futures::future;
+    use futures::stream;
+    use rstest::rstest;
+    use scylla::value::CqlValue;
+    use std::sync::atomic::AtomicUsize;
+    use std::time::Duration;
+    use tokio::sync::watch;
+    use tokio::task;
+
+    type Rx = mpsc::Receiver<(DbIndexedRow, AsyncInProgress)>;
+
+    fn row(i: usize) -> DbIndexedRow {
+        DbIndexedRow {
+            primary_key: PrimaryKey::from(vec![CqlValue::Int(i as i32)]),
+            operation: DbIndexedOperation::Delete(Timestamp::from_millis(0)),
         }
     }
 
-    // Acquire all permits to wait until all spawned tasks have finished and released their permits.
-    let _permits = semaphore
-        .acquire_many(semaphore_capacity as u32)
-        .await
-        .unwrap();
+    fn single_row_range(i: usize) -> anyhow::Result<RangeRows> {
+        Ok(stream::iter([row(i)]).boxed())
+    }
+
+    fn concurrency(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).unwrap()
+    }
+
+    fn spawn_consumer_acking_immediately(mut rx: Rx) -> task::JoinHandle<usize> {
+        tokio::spawn(async move {
+            let mut received = 0;
+            while let Some((_row, guard)) = rx.recv().await {
+                drop(guard);
+                received += 1;
+            }
+            received
+        })
+    }
+
+    async fn wait_until(condition: impl Fn() -> bool) {
+        while !condition() {
+            task::yield_now().await;
+        }
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn progress_reaches_sum_of_range_lengths_once_rows_are_acknowledged() {
+        const RANGES: usize = 5;
+        let (tx, rx) = mpsc::channel(1);
+        let completed = Arc::new(AtomicU64::new(0));
+        let consumer = spawn_consumer_acking_immediately(rx);
+
+        scan_ranges(
+            1..=RANGES,
+            concurrency(2),
+            |i| future::ready(single_row_range(i)),
+            |i| *i as u64 * 10,
+            tx,
+            Arc::clone(&completed),
+        )
+        .await;
+
+        assert_eq!(consumer.await.unwrap(), RANGES);
+        assert_eq!(completed.load(Ordering::Relaxed), 10 + 20 + 30 + 40 + 50);
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn range_failing_to_open_is_skipped_without_progress() {
+        let (tx, rx) = mpsc::channel(1);
+        let completed = Arc::new(AtomicU64::new(0));
+        let consumer = spawn_consumer_acking_immediately(rx);
+
+        scan_ranges(
+            0..3,
+            concurrency(1),
+            |i| {
+                future::ready(if i == 1 {
+                    Err(anyhow!("range unavailable"))
+                } else {
+                    single_row_range(i)
+                })
+            },
+            |_| 1,
+            tx,
+            Arc::clone(&completed),
+        )
+        .await;
+
+        assert_eq!(consumer.await.unwrap(), 2);
+        assert_eq!(completed.load(Ordering::Relaxed), 2);
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn never_opens_more_range_streams_than_concurrency() {
+        const RANGES: usize = 6;
+        const CONCURRENCY: usize = 2;
+        let (tx, rx) = mpsc::channel(1);
+        let completed = Arc::new(AtomicU64::new(0));
+        let (gate_tx, gate_rx) = watch::channel(false);
+        let opened_total = Arc::new(AtomicUsize::new(0));
+        let open_now = Arc::new(AtomicUsize::new(0));
+        let max_open = Arc::new(AtomicUsize::new(0));
+        let consumer = spawn_consumer_acking_immediately(rx);
+
+        let scan = {
+            let opened_total = Arc::clone(&opened_total);
+            let open_now = Arc::clone(&open_now);
+            let max_open = Arc::clone(&max_open);
+            let completed = Arc::clone(&completed);
+            tokio::spawn(async move {
+                scan_ranges(
+                    0..RANGES,
+                    concurrency(CONCURRENCY),
+                    |i| {
+                        opened_total.fetch_add(1, Ordering::Relaxed);
+                        let now_open = open_now.fetch_add(1, Ordering::Relaxed) + 1;
+                        max_open.fetch_max(now_open, Ordering::Relaxed);
+                        let mut gate_rx = gate_rx.clone();
+                        let open_now = Arc::clone(&open_now);
+                        future::ready(Ok(stream::iter([row(i)])
+                            .chain(
+                                stream::once(async move {
+                                    _ = gate_rx.wait_for(|open| *open).await;
+                                    open_now.fetch_sub(1, Ordering::Relaxed);
+                                })
+                                .filter_map(|()| async { None }),
+                            )
+                            .boxed()))
+                    },
+                    |_| 1,
+                    tx,
+                    completed,
+                )
+                .await
+            })
+        };
+
+        wait_until(|| opened_total.load(Ordering::Relaxed) == CONCURRENCY).await;
+        for _ in 0..10 {
+            task::yield_now().await;
+        }
+        assert_eq!(opened_total.load(Ordering::Relaxed), CONCURRENCY);
+
+        gate_tx.send(true).unwrap();
+        scan.await.unwrap();
+
+        assert_eq!(consumer.await.unwrap(), RANGES);
+        assert_eq!(opened_total.load(Ordering::Relaxed), RANGES);
+        assert_eq!(max_open.load(Ordering::Relaxed), CONCURRENCY);
+        assert_eq!(completed.load(Ordering::Relaxed), RANGES as u64);
+    }
 }

--- a/crates/vector-store/src/db_index/full_scan.rs
+++ b/crates/vector-store/src/db_index/full_scan.rs
@@ -64,11 +64,15 @@ pub(crate) async fn scan_ranges<R, Fut>(
             })
             .await;
 
+            // The range query is exhausted, so let the next range start now. Waiting for the
+            // pipeline to acknowledge the rows must not hold the slot: the FTS index acknowledges
+            // only on commit, and a range rarely has enough rows to trigger one by itself.
+            drop(permit);
+
             // wait until all in-progress markers are dropped
             while rx_in_progress.recv().await.is_some() {}
 
             completed_scan_length.fetch_add(length, Ordering::Relaxed);
-            drop(permit);
         });
     }
 
@@ -127,6 +131,43 @@ mod tests {
         while !condition() {
             task::yield_now().await;
         }
+    }
+
+    /// Mimics an index which acknowledges rows only when it commits, and whose commit needs more
+    /// rows than the currently open ranges can deliver, e.g. tantivy committing on a timer or on a
+    /// 10k-document threshold. Scheduling the next ranges must not depend on that acknowledgement.
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn opens_next_ranges_while_rows_of_open_ranges_are_unacknowledged() {
+        const RANGES: usize = 8;
+        let (tx, mut rx) = mpsc::channel(1);
+        let completed = Arc::new(AtomicU64::new(0));
+        let consumer = {
+            let completed = Arc::clone(&completed);
+            tokio::spawn(async move {
+                let mut guards = Vec::new();
+                while guards.len() < RANGES {
+                    let (_row, guard) = rx.recv().await.unwrap();
+                    guards.push(guard);
+                }
+                assert_eq!(completed.load(Ordering::Relaxed), 0);
+                drop(guards);
+            })
+        };
+
+        scan_ranges(
+            0..RANGES,
+            concurrency(2),
+            |i| future::ready(single_row_range(i)),
+            |_| 1,
+            tx,
+            Arc::clone(&completed),
+        )
+        .await;
+
+        consumer.await.unwrap();
+        assert_eq!(completed.load(Ordering::Relaxed), RANGES as u64);
     }
 
     #[rstest]


### PR DESCRIPTION
## Motivation

[VECTOR-862](https://scylladb.atlassian.net/browse/VECTOR-862): performance tests show that small FTS indexes build slowly.

The full scan opens at most `shards * 3` token range queries at a time. Until now a range kept its slot not only while its rows were being read, but also until the pipeline had acknowledged every row by dropping its `AsyncInProgress::Fullscan` guard. For vector indexes that is harmless, because usearch drops the guard as soon as the vector is inserted. The FTS index keeps the guards until the tantivy writer commits, and it commits only at 10k pending documents or every 3s (#521). A single range of a small or medium table never reaches 10k documents, so every non-empty range pinned its slot for a whole commit interval and the scan advanced in waves of `shards * 3` ranges per 3 seconds: `ceil(non_empty_ranges / (shards * 3)) * 3s`. On a 2-shard node with ~257 vnode ranges that is ~43 waves, about two minutes for a table with a few thousand rows.

## Change

The permit is released as soon as the range query stream is exhausted; waiting for the acknowledgements and updating the scan progress happens in the background. The bound on concurrently open queries is unchanged, the bounded pipeline channel still provides backpressure, and `initial_scan()` still resolves only after every range has been acknowledged, so `FullScanFinished` (hence `SERVING`) continues to imply that all rows are searchable. The FTS index now pays at most one commit interval after the last row.

The first patch extracts the range scheduler into `db_index/full_scan.rs` so it can be unit-tested with fake streams (the integration harness mocks the whole db actor and never reached it). The second patch is the one-line permit move plus a regression test that deadlocks with the old ordering.

## Measurements

Validator harness, 3 ScyllaDB nodes (`--smp=2`, scylla-nightly), 3 vector-store nodes, FTS index on a `pk INT PRIMARY KEY, content TEXT` table. The default validator cluster gives every node a single token (4 ranges, 18 parallel slots), so the waves never show up there; for the measurement the nodes were started with `--num-tokens=256`, i.e. 769 token ranges for 18 slots. Times are "CREATE INDEX to SERVING on all nodes" as measured by a temporary validator test (not part of this PR); the full-scan duration is taken from the vector-store log.

| Documents | Token ranges | master | this PR |
|---|---|---|---|
| 2 000 | 769 | not SERVING after 60 s (scan still running) | 5.2 s (scan 3.0 s, one commit interval) |
| 10 000 | 769 | scan 61 s, not SERVING after 60 s | 2.9 s (scan 0.2 s, 10k threshold commit) |
| 2 000 | 4 | 6.1 s | 5.2 s |
| 10 000 | 4 | 2.8 s | 2.8 s |

The remaining ~3 s for the 2 000-document case is the FTS commit interval after the last row; it no longer multiplies with the number of ranges.

## Alternatives considered

- **Notify tantivy when the full scan finished and commit then.** Not workable: the scan can only finish after the guards are dropped, and the guards are dropped by the commit, so the notification would always arrive after the commit it should trigger.
- **Per-range "range drained, commit now" message through the row pipeline.** Works, but needs a new pipeline item type across `db`, `db_cdc`, `db_index`, `monitor_items`, `fts_index` and the test mocks, produces one commit per range, and still leaves the scan wave-coupled to the FTS commit.
- **Commit-on-idle in the tantivy actor** (commit shortly after the last full-scan document arrives). Useful follow-up to trim the remaining <= 3s tail; alone it would still keep the wave structure.
- **Shorter or configurable commit interval.** A global knob that also affects CDC steady state and does not remove the coupling.
- **Dropping the guards when the document is added (like usearch).** Breaks the `SERVING` implies searchable contract restored in #521.
- **Tablet-aware full scan (VECTOR-863).** Complementary: fewer ranges, but the coupling would remain.

Fixes: VECTOR-862


[VECTOR-862]: https://scylladb.atlassian.net/browse/VECTOR-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ