### PR TITLE
ci: refactor workflows for testing before releasing

### DIFF
--- a/.github/workflows/build-validator.yml
+++ b/.github/workflows/build-validator.yml
@@ -1,0 +1,49 @@
+name: build-validator
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system for the build'
+        required: true
+        type: string
+      arch:
+        description: 'Architecture for the build'
+        required: true
+        type: string
+      ref:
+        description: 'Git reference to build from'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-validator:
+    runs-on: ${{ inputs.os }}
+    env:
+      TARGETARCH: ${{ inputs.arch }}
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+        ref: ${{ inputs.ref }}
+
+    - name: Print release toolchain rustc version
+      run: ./scripts/run-with-release-toolchain rustc --version
+
+    - name: Fetching dependencies
+      run: ./scripts/run-with-release-toolchain cargo fetch
+
+    - name: Build vector-search-validator
+      run: ./scripts/run-with-release-toolchain cargo build --release --bin vector-search-validator -p vector-search-validator
+
+    - name: Upload vector-search-validator as artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: vector-search-validator-${{inputs.arch}}
+        path: target/${{inputs.arch}}/release/vector-search-validator
+

--- a/.github/workflows/build-vector-store.yml
+++ b/.github/workflows/build-vector-store.yml
@@ -1,0 +1,49 @@
+name: build-vector-store
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system for the build'
+        required: true
+        type: string
+      arch:
+        description: 'Architecture for the build'
+        required: true
+        type: string
+      ref:
+        description: 'Git reference to build from'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-vector-store:
+    runs-on: ${{ inputs.os }}
+    env:
+      TARGETARCH: ${{ inputs.arch }}
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+        ref: ${{ inputs.ref }}
+
+    - name: Print release toolchain rustc version
+      run: ./scripts/run-with-release-toolchain rustc --version
+
+    - name: Fetching dependencies
+      run: ./scripts/run-with-release-toolchain cargo fetch
+
+    - name: Build vector-store
+      run: ./scripts/run-with-release-toolchain cargo build --release --bin vector-store -p vector-store
+
+    - name: Upload vector-store as artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: vector-store-${{inputs.arch}}
+        path: target/${{inputs.arch}}/release/vector-store
+

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -58,9 +58,14 @@ jobs:
       os: ubuntu-latest
       arch: amd64
 
-  daily-validator-tests:
+  daily-run-validator-tests:
     needs: ["daily-get-scylla-nightly-digest", "daily-build-vector-store", "daily-get-validator-test-list"]
-    runs-on: ${{ matrix.os }}
+    uses: $/.github/workflows/run-validator-tests.yml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      testcase: ${{ matrix.testcase }}
+      ref: ${{ github.sha }}
     strategy:
       fail-fast: false
       matrix:
@@ -71,42 +76,9 @@ jobs:
             arch: amd64
           - os: ubuntu-24.04-arm
             arch: arm64
-    steps:
-    - name: Download scylla-nightly digest artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: scylla-nightly-digest
-
-    - name: Download vector-store artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: vector-store-${{matrix.arch}}
-
-    - name: Download vector-search-validator artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: vector-search-validator-${{matrix.arch}}
-
-    - name: Download run-validator-with-scylla-docker artifact
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        sparse-checkout: |
-          scripts/run-validator-with-scylla-docker
-        sparse-checkout-cone-mode: false
-        ref: ${{ github.sha }}
-
-    - name: Chmod a+x downloaded artifacts
-      run: chmod a+x vector-store-${{matrix.arch}} vector-search-validator-${{matrix.arch}}
-
-    - name: Run the Validator tests for testcase ${{matrix.testcase}}
-      env:
-        testcase: ${{matrix.testcase}}
-        TARGETARCH: ${{matrix.arch}}
-      run: |
-        ./scripts/run-validator-with-scylla-docker scylladb/scylla-nightly@$(cat scylla-nightly-digest) vector-store-${TARGETARCH} vector-search-validator-${TARGETARCH} "\"${testcase}\"::" --verbose
 
   daily-save-scylla-nightly-digest:
-    needs: daily-validator-tests
+    needs: daily-run-validator-tests
     runs-on: ubuntu-latest
     steps:
     - name: Download scylla-nightly digest artifact

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,8 +19,12 @@ jobs:
     with:
       use-latest-scylla-nightly: true
 
-  daily-build:
-    runs-on: ${{ matrix.os }}
+  daily-build-validator:
+    uses: $/.github/workflows/build-validator.yml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      ref: ${{ github.sha }}
     strategy:
       fail-fast: false
       matrix:
@@ -31,121 +35,36 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: arm64
 
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0
-        fetch-tags: true
+  daily-build-vector-store:
+    uses: $/.github/workflows/build-vector-store.yml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      ref: ${{ github.sha }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
 
-    - name: Try to download vector-store artifact
-      id: download-vector-store
-      continue-on-error: true
-      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-      with:
-        workflow: daily.yml
-        name: daily-vector-store-${{matrix.arch}}-${{github.sha}}
-        workflow_conclusion: ""
-        search_artifacts: true
-
-    - name: Try to download vector-search-validator artifact
-      id: download-vector-search-validator
-      continue-on-error: true
-      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-      with:
-        workflow: daily.yml
-        name: daily-vector-search-validator-${{matrix.arch}}-${{github.sha}}
-        workflow_conclusion: ""
-        search_artifacts: true
-
-    - name: Chmod a+x vector-search-validator
-      if: steps.download-vector-search-validator.outcome == 'success'
-      run: chmod a+x vector-search-validator-${{matrix.arch}}
-
-    - name: Setup local .cargo directories
-      if: steps.download-vector-store.outcome == 'failure' || steps.download-vector-search-validator.outcome == 'failure'
-      run: mkdir -p $HOME/.cargo/git $HOME/.cargo/registry
-
-    - name: Print release toolchain rustc version
-      if: steps.download-vector-store.outcome == 'failure' || steps.download-vector-search-validator.outcome == 'failure'
-      env:
-        TARGETARCH: ${{matrix.arch}}
-      run: ./scripts/run-with-release-toolchain rustc --version
-
-    - name: Fetching dependencies
-      if: steps.download-vector-store.outcome == 'failure' || steps.download-vector-search-validator.outcome == 'failure'
-      env:
-        TARGETARCH: ${{matrix.arch}}
-      run: ./scripts/run-with-release-toolchain cargo fetch
-
-    - name: Build vector-store
-      if: steps.download-vector-store.outcome == 'failure'
-      env:
-        TARGETARCH: ${{matrix.arch}}
-      run: ./scripts/run-with-release-toolchain cargo build --release --bin vector-store
-
-    - name: Copy vector-store
-      if: steps.download-vector-store.outcome == 'failure'
-      run: cp target/${{matrix.arch}}/release/vector-store vector-store-${{matrix.arch}}
-
-    - name: Build vector-search-validator
-      if: steps.download-vector-search-validator.outcome == 'failure'
-      env:
-        TARGETARCH: ${{matrix.arch}}
-      run: ./scripts/run-with-release-toolchain cargo build --release --bin vector-search-validator -p vector-search-validator
-
-    - name: Copy vector-search-validator
-      if: steps.download-vector-search-validator.outcome == 'failure'
-      run: cp target/${{matrix.arch}}/release/vector-search-validator vector-search-validator-${{matrix.arch}}
-
-    - name: Upload vector-store as artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: daily-vector-store-${{matrix.arch}}-${{github.sha}}
-        path: vector-store-${{matrix.arch}}
-
-    - name: Upload vector-search-validator as artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: daily-vector-search-validator-${{matrix.arch}}-${{github.sha}}
-        path: vector-search-validator-${{matrix.arch}}
-
-    - name: Copy run-validator-with-scylla-docker script
-      run: cp scripts/run-validator-with-scylla-docker .
-
-    - name: Upload run-validator-with-scylla-docker as artifact
-      if: matrix.arch == 'amd64' # Only upload the script once since it's architecture agnostic
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: run-validator-with-scylla-docker
-        path: run-validator-with-scylla-docker
-
-  daily-get-testcases:
-    needs: daily-build
-    runs-on: ubuntu-latest
-    outputs:
-      testcases: ${{ steps.testcases.outputs.testcases }}
-
-    steps:
-    - name: Download vector-search-validator artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: daily-vector-search-validator-amd64-${{github.sha}}
-
-    - name: Chmod a+x vector-search-validator
-      run: chmod a+x vector-search-validator-amd64
-
-    - name: Set testcases output
-      id: testcases
-      run: |
-        echo "testcases=[$(./vector-search-validator-amd64 list | sed -E 's/(.*)::.*/\1/' | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)]" >> "$GITHUB_OUTPUT"
+  daily-get-validator-test-list:
+    needs: ["daily-build-validator"]
+    uses: $/.github/workflows/get-validator-test-list.yml
+    with:
+      os: ubuntu-latest
+      arch: amd64
 
   daily-validator-tests:
-    needs: ["daily-get-scylla-nightly-digest", "daily-get-testcases"]
+    needs: ["daily-get-scylla-nightly-digest", "daily-build-vector-store", "daily-get-validator-test-list"]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        testcase: ${{fromJSON(needs.daily-get-testcases.outputs.testcases)}}
+        testcase: ${{fromJSON(needs.daily-get-validator-test-list.outputs.testcases)}}
         os: [ubuntu-latest, ubuntu-24.04-arm]
         include:
           - os: ubuntu-latest
@@ -161,27 +80,30 @@ jobs:
     - name: Download vector-store artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: daily-vector-store-${{matrix.arch}}-${{github.sha}}
+        name: vector-store-${{matrix.arch}}
 
     - name: Download vector-search-validator artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: daily-vector-search-validator-${{matrix.arch}}-${{github.sha}}
+        name: vector-search-validator-${{matrix.arch}}
 
     - name: Download run-validator-with-scylla-docker artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
-        name: run-validator-with-scylla-docker
+        sparse-checkout: |
+          scripts/run-validator-with-scylla-docker
+        sparse-checkout-cone-mode: false
+        ref: ${{ github.sha }}
 
     - name: Chmod a+x downloaded artifacts
-      run: chmod a+x vector-store-${{matrix.arch}} vector-search-validator-${{matrix.arch}} run-validator-with-scylla-docker
+      run: chmod a+x vector-store-${{matrix.arch}} vector-search-validator-${{matrix.arch}}
 
     - name: Run the Validator tests for testcase ${{matrix.testcase}}
       env:
         testcase: ${{matrix.testcase}}
         TARGETARCH: ${{matrix.arch}}
       run: |
-        ./run-validator-with-scylla-docker scylladb/scylla-nightly@$(cat scylla-nightly-digest) vector-store-${TARGETARCH} vector-search-validator-${TARGETARCH} "\"${testcase}\"::" --verbose
+        ./scripts/run-validator-with-scylla-docker scylladb/scylla-nightly@$(cat scylla-nightly-digest) vector-store-${TARGETARCH} vector-search-validator-${TARGETARCH} "\"${testcase}\"::" --verbose
 
   daily-save-scylla-nightly-digest:
     needs: daily-validator-tests

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,19 +15,9 @@ env:
 
 jobs:
   daily-get-scylla-nightly-digest:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Get scylla-nightly digest for latest tag
-      run: wget -q -O - "https://hub.docker.com/v2/namespaces/scylladb/repositories/scylla-nightly/tags/latest" | jq -r .digest > scylla-nightly-digest
-
-    - name: Show scylla-nightly digest
-      run: cat scylla-nightly-digest
-
-    - name: Upload scylla-nightly digest as artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: daily-scylla-nightly-digest
-        path: scylla-nightly-digest
+    uses: $/.github/workflows/get-scylla-nightly-digest.yml
+    with:
+      use-latest-scylla-nightly: true
 
   daily-build:
     runs-on: ${{ matrix.os }}
@@ -166,7 +156,7 @@ jobs:
     - name: Download scylla-nightly digest artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: daily-scylla-nightly-digest
+        name: scylla-nightly-digest
 
     - name: Download vector-store artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -200,7 +190,7 @@ jobs:
     - name: Download scylla-nightly digest artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: daily-scylla-nightly-digest
+        name: scylla-nightly-digest
 
     - name: Show scylla-nightly digest
       run: cat scylla-nightly-digest
@@ -208,5 +198,5 @@ jobs:
     - name: Upload scylla-nightly digest artifact as artifact
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: scylla-nightly-digest
+        name: valid-scylla-nightly-digest
         path: scylla-nightly-digest

--- a/.github/workflows/get-scylla-nightly-digest.yml
+++ b/.github/workflows/get-scylla-nightly-digest.yml
@@ -1,0 +1,43 @@
+name: get-scylla-nightly-digest
+
+on:
+  workflow_call:
+    inputs:
+      use-latest-scylla-nightly:
+        description: 'Whether to use the latest scylla-nightly tag or the last working tag'
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  get-scylla-nightly-digest:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get scylla-nightly digest for latest tag
+      id: get-scylla-nightly-latest-digest
+      run: wget -q -O - "https://hub.docker.com/v2/namespaces/scylladb/repositories/scylla-nightly/tags/latest" | jq -r .digest > scylla-nightly-latest-digest
+
+    - name: Get scylla-nightly digest for the last working tag
+      if: ${{ !inputs.use-latest-scylla-nightly }}
+      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+      with:
+        workflow: daily.yml
+        name: valid-scylla-nightly-digest
+        search_artifacts: true
+        if_no_artifact_found: warn
+
+    - name: Set scylla-nightly digest
+      id: set-scylla-nightly-digest
+      run: |
+        if [ ! -f scylla-nightly-digest ]; then
+          mv scylla-nightly-latest-digest scylla-nightly-digest
+        fi
+        cat scylla-nightly-digest
+
+    - name: Upload scylla-nightly digest as artifact
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: scylla-nightly-digest
+        path: scylla-nightly-digest

--- a/.github/workflows/get-validator-test-list.yml
+++ b/.github/workflows/get-validator-test-list.yml
@@ -1,0 +1,42 @@
+name: get-validator-test-list
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system for the build'
+        required: true
+        type: string
+      arch:
+        description: 'Architecture for the build'
+        required: true
+        type: string
+    outputs:
+      testcases:
+        description: 'List of testcases'
+        value: ${{ jobs.get-validator-test-list.outputs.testcases }}
+
+permissions:
+  contents: read
+
+jobs:
+  get-validator-test-list:
+    runs-on: ${{ inputs.os }}
+    outputs:
+      testcases: ${{ steps.testcases.outputs.testcases }}
+
+    steps:
+    - name: Download vector-search-validator artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: vector-search-validator-${{inputs.arch}}
+
+    - name: Chmod a+x vector-search-validator
+      run: chmod a+x vector-search-validator
+
+    - name: Set testcases output
+      id: testcases
+      run: |
+        set -euo pipefail
+        testcases=$(./vector-search-validator list | sed -E 's/(.*)::.*/\1/' | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)
+        echo "testcases=[$testcases]" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,71 @@ env:
   VECTOR_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.VECTOR_VERSION }}
 
 jobs:
-  # Build vector-store once per architecture, natively (no QEMU emulation),
-  # and expose the results (binary tarball, docker image, SBOMs) as workflow
-  # artifacts for the downstream jobs.
-  build:
+  release-get-scylla-nightly-digest:
+    uses: $/.github/workflows/get-scylla-nightly-digest.yml
+    with:
+      use-latest-scylla-nightly: false
+
+  release-build-validator:
+    uses: $/.github/workflows/build-validator.yml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.VECTOR_VERSION }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+
+  release-build-vector-store:
+    uses: $/.github/workflows/build-vector-store.yml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.VECTOR_VERSION }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+
+  release-get-validator-test-list:
+    needs: ["release-build-validator"]
+    uses: $/.github/workflows/get-validator-test-list.yml
+    with:
+      os: ubuntu-latest
+      arch: amd64
+
+  release-run-validator-tests:
+    needs: ["release-get-scylla-nightly-digest", "release-build-vector-store", "release-get-validator-test-list"]
+    uses: $/.github/workflows/run-validator-tests.yml
+    with:
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      testcase: ${{ matrix.testcase }}
+      ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.VECTOR_VERSION }}
+    strategy:
+      fail-fast: false
+      matrix:
+        testcase: ${{fromJSON(needs.release-get-validator-test-list.outputs.testcases)}}
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+
+  release-build-docker-archive-sbom:
+    needs: ["release-run-validator-tests"]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -28,21 +89,42 @@ jobs:
             arch: amd64
           - os: ubuntu-24.04-arm
             arch: arm64
+    env:
+      TARGETARCH: ${{ matrix.arch }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ env.VECTOR_VERSION }}
           fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ env.VECTOR_VERSION }}
 
       - name: Install SBOM tooling (syft + cargo-cyclonedx) used by build-release
         run: |
           set -euo pipefail
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
-          cargo install cargo-cyclonedx --locked
+          # syft-v1.51.1
+          export DOWNLOAD_TAG_INSTALL_SCRIPT=false
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/91a0032987d91b7411b52f6f5c185c5e7f775495/install.sh | sh -s -- -b /usr/local/bin v1.51.1
+          cargo install cargo-cyclonedx --version 0.5.9 --locked
 
-      - name: Build image, tarball and SBOMs for ${{ matrix.arch }}
-        run: ./scripts/build-release ${{ matrix.arch }}
+      - name: Download vector-store artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vector-store-${{matrix.arch}}
+
+      - name: Copy downloaded vector-store into target directory
+        run: |
+          set -euo pipefail
+          chmod a+x vector-store
+          mkdir -p target/${{matrix.arch}}/release
+          cp vector-store target/${{matrix.arch}}/release
+
+      - name: Build docker for ${{ matrix.arch }}
+        run: ./scripts/build-dockers ${{ matrix.arch }}
+
+      - name: Build tarball and SBOMs for ${{ matrix.arch }}
+        run: ./scripts/generate-archive-sbom ${{ matrix.arch }}
 
       - name: Save the docker image
         run: docker save "scylladb/vector-store:${VECTOR_VERSION}-${{ matrix.arch }}" -o "vector-store-image-${VECTOR_VERSION}-${{ matrix.arch }}.tar"
@@ -71,7 +153,7 @@ jobs:
   # Push the per-arch images built by the build job (no rebuild) and combine
   # them into a multi-arch manifest.
   push-docker:
-    needs: [build]
+    needs: [release-build-docker-archive-sbom]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/run-validator-tests.yml
+++ b/.github/workflows/run-validator-tests.yml
@@ -1,0 +1,60 @@
+name: run-validator-tests
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system for the build'
+        required: true
+        type: string
+      arch:
+        description: 'Architecture for the build'
+        required: true
+        type: string
+      testcase:
+        description: 'Test case to run'
+        required: true
+        type: string
+      ref:
+        description: 'Git reference to build from'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  run-validator-tests:
+    runs-on: ${{ inputs.os }}
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        sparse-checkout: |
+          scripts/run-validator-with-scylla-docker
+        sparse-checkout-cone-mode: false
+        ref: ${{ inputs.ref }}
+
+    - name: Download scylla-nightly digest artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: scylla-nightly-digest
+
+    - name: Download vector-store artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: vector-store-${{inputs.arch}}
+
+    - name: Download vector-search-validator artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: vector-search-validator-${{inputs.arch}}
+
+    - name: Chmod a+x downloaded artifacts
+      run: chmod a+x vector-store vector-search-validator
+
+    - name: Run the Validator tests for testcase ${{inputs.testcase}}
+      env:
+        testcase: ${{inputs.testcase}}
+      run: |
+        ./scripts/run-validator-with-scylla-docker scylladb/scylla-nightly@$(cat scylla-nightly-digest) vector-store vector-search-validator "\"${testcase}\"::" --verbose

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -25,73 +25,34 @@ jobs:
     with:
       use-latest-scylla-nightly: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-latest-scylla-nightly') }}
 
-  validator-build:
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
-    env:
-      TARGETARCH: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
-    outputs:
-      testcases: ${{ steps.testcases.outputs.testcases }}
+  validator-build-validator:
+    uses: $/.github/workflows/build-validator.yml
+    with:
+      os: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+      arch: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
+      ref: ${{ github.sha }}
 
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      with:
-        fetch-depth: 0
-        fetch-tags: true
+  validator-build-vector-store:
+    uses: $/.github/workflows/build-vector-store.yml
+    with:
+      os: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+      arch: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
+      ref: ${{ github.sha }}
 
-    - name: Setup local .cargo directories
-      run: mkdir -p $HOME/.cargo/git $HOME/.cargo/registry
-
-    - name: Print release toolchain rustc version
-      run: ./scripts/run-with-release-toolchain rustc --version
-
-    - name: Fetching dependencies
-      run: ./scripts/run-with-release-toolchain cargo fetch
-
-    - name: Build vector-store
-      run: ./scripts/run-with-release-toolchain cargo build --release --bin vector-store
-
-    - name: Copy vector-store
-      run: cp target/${TARGETARCH}/release/vector-store vector-store
-
-    - name: Build vector-search-validator
-      run: ./scripts/run-with-release-toolchain cargo build --release --bin vector-search-validator -p vector-search-validator
-
-    - name: Copy vector-search-validator
-      run: cp target/${TARGETARCH}/release/vector-search-validator vector-search-validator
-
-    - name: Upload vector-store as artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: vector-store
-        path: vector-store
-
-    - name: Upload vector-search-validator as artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: vector-search-validator
-        path: vector-search-validator
-
-    - name: Copy run-validator-with-scylla-docker script
-      run: cp scripts/run-validator-with-scylla-docker .
-
-    - name: Upload run-validator-with-scylla-docker as artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: run-validator-with-scylla-docker
-        path: run-validator-with-scylla-docker
-
-    - name: Set testcases output
-      id: testcases
-      run: |
-        echo "testcases=[$(./vector-search-validator list | sed -E 's/(.*)::.*/\1/' | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)]" >> "$GITHUB_OUTPUT"
+  validator-get-validator-test-list:
+    needs: ["validator-build-validator"]
+    uses: $/.github/workflows/get-validator-test-list.yml
+    with:
+      os: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+      arch: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
 
   validator-tests:
-    needs: ["validator-get-scylla-nightly-digest", "validator-build"]
+    needs: ["validator-get-scylla-nightly-digest", "validator-build-vector-store", "validator-get-validator-test-list"]
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     strategy:
       fail-fast: false
       matrix:
-        testcase: ${{fromJSON(needs.validator-build.outputs.testcases)}}
+        testcase: ${{fromJSON(needs.validator-get-validator-test-list.outputs.testcases)}}
 
     steps:
     - name: Download scylla-nightly digest artifact
@@ -102,12 +63,12 @@ jobs:
     - name: Download vector-store artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: vector-store
+        name: vector-store-${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
 
     - name: Download vector-search-validator artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: vector-search-validator
+        name: vector-search-validator-${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
 
     - name: Download run-validator-with-scylla-docker artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -124,7 +85,7 @@ jobs:
         ./run-validator-with-scylla-docker scylladb/scylla-nightly@$(cat scylla-nightly-digest) vector-store vector-search-validator "\"${testcase}\"::" --verbose
 
   validator-workflow-status:
-    needs: ["validator-get-scylla-nightly-digest", "validator-build", "validator-tests"]
+    needs: ["validator-get-scylla-nightly-digest", "validator-build-validator", "validator-build-vector-store", "validator-get-validator-test-list", "validator-tests"]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -137,8 +98,18 @@ jobs:
           return_code=1
         fi
 
-        if [[ "${{ needs.validator-build.result }}" == "failure" ]]; then
-          echo "validator-build job failed"
+        if [[ "${{ needs.validator-build-validator.result }}" == "failure" ]]; then
+          echo "validator-build-validator job failed"
+          return_code=1
+        fi
+
+        if [[ "${{ needs.validator-build-vector-store.result }}" == "failure" ]]; then
+          echo "validator-build-vector-store job failed"
+          return_code=1
+        fi
+
+        if [[ "${{ needs.validator-get-validator-test-list.result }}" == "failure" ]]; then
+          echo "validator-get-validator-test-list job failed"
           return_code=1
         fi
 

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -46,46 +46,21 @@ jobs:
       os: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
       arch: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
 
-  validator-tests:
+  validator-run-validator-tests:
     needs: ["validator-get-scylla-nightly-digest", "validator-build-vector-store", "validator-get-validator-test-list"]
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    uses: $/.github/workflows/run-validator-tests.yml
+    with:
+      os: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+      arch: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
+      testcase: ${{ matrix.testcase }}
+      ref: ${{ github.sha }}
     strategy:
       fail-fast: false
       matrix:
         testcase: ${{fromJSON(needs.validator-get-validator-test-list.outputs.testcases)}}
 
-    steps:
-    - name: Download scylla-nightly digest artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: scylla-nightly-digest
-
-    - name: Download vector-store artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: vector-store-${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
-
-    - name: Download vector-search-validator artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: vector-search-validator-${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'amd64' || 'arm64' }}
-
-    - name: Download run-validator-with-scylla-docker artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: run-validator-with-scylla-docker
-
-    - name: Chmod a+x downloaded artifacts
-      run: chmod a+x vector-store vector-search-validator run-validator-with-scylla-docker
-
-    - name: Run the Validator tests for testcase ${{matrix.testcase}}
-      env:
-        testcase: ${{matrix.testcase}}
-      run: |
-        ./run-validator-with-scylla-docker scylladb/scylla-nightly@$(cat scylla-nightly-digest) vector-store vector-search-validator "\"${testcase}\"::" --verbose
-
   validator-workflow-status:
-    needs: ["validator-get-scylla-nightly-digest", "validator-build-validator", "validator-build-vector-store", "validator-get-validator-test-list", "validator-tests"]
+    needs: ["validator-get-scylla-nightly-digest", "validator-build-validator", "validator-build-vector-store", "validator-get-validator-test-list", "validator-run-validator-tests"]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -113,8 +88,8 @@ jobs:
           return_code=1
         fi
 
-        if [[ "${{ needs.validator-tests.result }}" == "failure" ]]; then
-          echo "validator-tests job failed"
+        if [[ "${{ needs.validator-run-validator-tests.result }}" == "failure" ]]; then
+          echo "validator-run-validator-tests job failed"
           return_code=1
         fi
 

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -20,30 +20,10 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
-  validator-scylla-nightly-digest:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Get scylla-nightly digest for latest tag
-      id: get-scylla-nightly-latest-digest
-      if: contains(github.event.pull_request.labels.*.name, 'ci-use-latest-scylla-nightly')
-      run: wget -q -O - "https://hub.docker.com/v2/namespaces/scylladb/repositories/scylla-nightly/tags/latest" | jq -r .digest > scylla-nightly-digest
-
-    - name: Get scylla-nightly digest for the last working tag
-      if: steps.get-scylla-nightly-latest-digest.outcome == 'skipped'
-      uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-      with:
-        workflow: daily.yml
-        name: scylla-nightly-digest
-        search_artifacts: true
-
-    - name: Show scylla-nightly digest
-      run: cat scylla-nightly-digest
-
-    - name: Upload scylla-nightly digest as artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: scylla-nightly-digest
-        path: scylla-nightly-digest
+  validator-get-scylla-nightly-digest:
+    uses: $/.github/workflows/get-scylla-nightly-digest.yml
+    with:
+      use-latest-scylla-nightly: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-latest-scylla-nightly') }}
 
   validator-build:
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
@@ -106,7 +86,7 @@ jobs:
         echo "testcases=[$(./vector-search-validator list | sed -E 's/(.*)::.*/\1/' | sort | uniq | xargs -n 1 -I '{}' echo \"{}\" | paste -sd,)]" >> "$GITHUB_OUTPUT"
 
   validator-tests:
-    needs: ["validator-scylla-nightly-digest", "validator-build"]
+    needs: ["validator-get-scylla-nightly-digest", "validator-build"]
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'ci-use-amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     strategy:
       fail-fast: false
@@ -144,7 +124,7 @@ jobs:
         ./run-validator-with-scylla-docker scylladb/scylla-nightly@$(cat scylla-nightly-digest) vector-store vector-search-validator "\"${testcase}\"::" --verbose
 
   validator-workflow-status:
-    needs: ["validator-scylla-nightly-digest", "validator-build", "validator-tests"]
+    needs: ["validator-get-scylla-nightly-digest", "validator-build", "validator-tests"]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -152,8 +132,8 @@ jobs:
       run: |
         return_code=0
 
-        if [[ "${{ needs.validator-scylla-nightly-digest.result }}" == "failure" ]]; then
-          echo "validator-scylla-nightly-digest job failed"
+        if [[ "${{ needs.validator-get-scylla-nightly-digest.result }}" == "failure" ]]; then
+          echo "validator-get-scylla-nightly-digest job failed"
           return_code=1
         fi
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,6 +19,18 @@ GitHub doesn't support creating annotated tags, so you must do them from local
 environment. You can add additional metadata to the tag, for example
 `X.Y.Z-dev` for development releases.
 
+In GitHub Actions there is a release workflow that builds the release artifacts
+and uploads them to GitHub and DockerHub. It is triggered when a GitHub Release
+is published, or manually via Run workflow with `VECTOR_VERSION`, and runs on
+both amd64 and arm64 runners. Before building artifacts it runs the full
+validator test suite.
+
+## Manual release
+
+In case you want to build the release manually, you can use the scripts in
+`scripts/` directory. The scripts are designed to be run from the root of the
+repository.
+
 Script `scripts/run-with-release-toolchain` can create a correct version for
 the `Cargo.toml` file based on annotated tags using `git describe --dirty`.
 

--- a/scripts/build-release
+++ b/scripts/build-release
@@ -30,35 +30,5 @@ for arch in $archs ; do
     TARGETARCH=$arch ./scripts/run-with-release-toolchain cargo build --release
 done
 
-for arch in $archs ; do
-    echo build the tar archive for $arch
-    vector_store_dir=vector-store-$vector_store_version-$arch
-    vector_store_tarball=$vector_store_dir.tar.gz
-    (cd target/$arch/release && tar -czf $vector_store_tarball --transform "s,^,$vector_store_dir/," vector-store)
-    ls -lh target/$arch/release/$vector_store_tarball
-done
-
-echo generate Cargo SBOM for version $vector_store_version
-cp Cargo.toml Cargo.toml.bak
-cp Cargo.lock Cargo.lock.bak
-trap 'mv Cargo.toml.bak Cargo.toml; mv Cargo.lock.bak Cargo.lock' EXIT
-sed -i "s/version = \"0.0.0-dev\"/version = \"$vector_store_version\"/" Cargo.toml
-cargo cyclonedx --manifest-path crates/vector-store/Cargo.toml --format json
-mv Cargo.toml.bak Cargo.toml
-mv Cargo.lock.bak Cargo.lock
-trap - EXIT
-cargo_sbom=crates/vector-store/vector-store.cdx.json
-[[ -f $cargo_sbom ]] || { echo "error: SBOM was not generated at $cargo_sbom"; exit 1; }
-mv $cargo_sbom vector-store-$vector_store_version.cdx.json
-echo "Cargo SBOM: vector-store-$vector_store_version.cdx.json"
-
 ./scripts/build-dockers $archs
-
-for arch in $archs ; do
-    echo generate Docker image SBOM for $arch using syft
-    docker_sbom=vector-store-docker-$vector_store_version-$arch.cdx.json
-    docker_tag=scylladb/vector-store:$vector_store_version-$arch
-    syft $docker_tag -o cyclonedx-json > $docker_sbom
-    [[ -s $docker_sbom ]] || { echo "error: Docker SBOM is empty at $docker_sbom"; exit 1; }
-    echo "Docker SBOM: $docker_sbom"
-done
+./scripts/generate-archive-sbom $archs

--- a/scripts/generate-archive-sbom
+++ b/scripts/generate-archive-sbom
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+repo=$(dirname "${BASH_SOURCE[0]}")
+repo=$(realpath $repo/..)
+
+cd $repo
+
+vector_store_version=$(./scripts/run-with-release-toolchain cargo info vector-store | grep ^version: | cut -d ' ' -f 2)
+
+archs="${*:-amd64 arm64}"
+
+for arch in $archs ; do
+    echo build the tar archive for $arch
+    vector_store_dir=vector-store-$vector_store_version-$arch
+    vector_store_tarball=$vector_store_dir.tar.gz
+    (cd target/$arch/release && tar -czf $vector_store_tarball --transform "s,^,$vector_store_dir/," vector-store)
+    ls -lh target/$arch/release/$vector_store_tarball
+done
+
+echo generate Cargo SBOM for version $vector_store_version
+cp Cargo.toml Cargo.toml.bak
+cp Cargo.lock Cargo.lock.bak
+trap 'mv Cargo.toml.bak Cargo.toml; mv Cargo.lock.bak Cargo.lock' EXIT
+sed -i "s/version = \"0.0.0-dev\"/version = \"$vector_store_version\"/" Cargo.toml
+cargo cyclonedx --manifest-path crates/vector-store/Cargo.toml --format json
+mv Cargo.toml.bak Cargo.toml
+mv Cargo.lock.bak Cargo.lock
+trap - EXIT
+cargo_sbom=crates/vector-store/vector-store.cdx.json
+[[ -f $cargo_sbom ]] || { echo "error: SBOM was not generated at $cargo_sbom"; exit 1; }
+mv $cargo_sbom vector-store-$vector_store_version.cdx.json
+echo "Cargo SBOM: vector-store-$vector_store_version.cdx.json"
+
+for arch in $archs ; do
+    echo generate Docker image SBOM for $arch using syft
+    docker_sbom=vector-store-docker-$vector_store_version-$arch.cdx.json
+    docker_tag=scylladb/vector-store:$vector_store_version-$arch
+    syft $docker_tag -o cyclonedx-json > $docker_sbom
+    [[ -s $docker_sbom ]] || { echo "error: Docker SBOM is empty at $docker_sbom"; exit 1; }
+    echo "Docker SBOM: $docker_sbom"
+done


### PR DESCRIPTION
This PR provides refactors to the GitHub Actions workflows to allow running validator tests before releasing version.

The first part moves common functionality from daily & validator workflows into separate ones. The second part refactors build-release script and release workflow by using prepared reusable workflows.

Fixes: VECTOR-790