### PR TITLE
httpapi: report the index status as part of the index info

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -427,7 +427,7 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Returns the same information about a single index as `/api/v1/indexes/{keyspace}/{index}` returns.",
+        "description": "Returns the same information about a single index as `/api/v1/indexes/{keyspace}/{index}`. Deprecated. Use that endpoint instead.",
         "operationId": "get_index_status",
         "parameters": [
           {
@@ -496,7 +496,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/api/v1/info": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "LicenseRef-ScyllaDB-Source-Available-1.1"
     },
-    "version": "3.0.0"
+    "version": "3.1.0"
   },
   "paths": {
     "/api/v1/indexes": {
@@ -14,7 +14,7 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Returns the list of indexes managed by the Vector Store indexing service. The list includes both vector and fulltext indexes in any state (initializing, available/built, destroying). Due to synchronization delays, it may temporarily differ from the list of indexes inside ScyllaDB.",
+        "description": "Returns the list of indexes managed by the Vector Store indexing service, each with its current operational status, the total number of items indexed and the progress of the initial table scan that backfills it. The list includes both vector and fulltext indexes in any state (initializing, available/built, destroying). Due to synchronization delays, it may temporarily differ from the list of indexes inside ScyllaDB. An index whose item count cannot be obtained, e.g. because it is being removed while the request is served, is omitted from the list.",
         "operationId": "get_indexes",
         "responses": {
           "200": {
@@ -29,6 +29,8 @@
                 },
                 "example": [
                   {
+                    "build_progress": 100.0,
+                    "count": 12345,
                     "index": "my_vector_index",
                     "keyspace": "my_keyspace",
                     "options": {
@@ -39,16 +41,20 @@
                       "search_beam_width": 64,
                       "similarity_function": "COSINE",
                       "type": "vector"
-                    }
+                    },
+                    "status": "SERVING"
                   },
                   {
+                    "build_progress": 37.5,
+                    "count": 42,
                     "index": "my_fulltext_index",
                     "keyspace": "my_keyspace",
                     "options": {
                       "analyzer": "standard",
                       "positions": true,
                       "type": "fulltext"
-                    }
+                    },
+                    "status": "BOOTSTRAPPING"
                   }
                 ]
               }
@@ -62,7 +68,7 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Retrieves information about a specific index, including its search type and the options it was created with. This is the same information reported per-entry by the `/api/v1/indexes` listing, scoped to a single index.",
+        "description": "Retrieves information about a specific index: its search type, the options it was created with, its current operational status, the total number of items indexed and the progress of the initial table scan that backfills it. Each entry of the `/api/v1/indexes` listing carries the same information.",
         "operationId": "get_index_info",
         "parameters": [
           {
@@ -86,13 +92,15 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful operation. Returns the index's type and creation options.",
+            "description": "Successful operation. Returns the index's type, creation options, and the status it currently reports.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/IndexInfo"
                 },
                 "example": {
+                  "build_progress": 100.0,
+                  "count": 12345,
                   "index": "my_vector_index",
                   "keyspace": "my_keyspace",
                   "options": {
@@ -103,13 +111,24 @@
                     "search_beam_width": 64,
                     "similarity_function": "COSINE",
                     "type": "vector"
-                  }
+                  },
+                  "status": "SERVING"
                 }
               }
             }
           },
           "404": {
             "description": "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorMessage"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error while checking index state or counting indexed items. Possible causes: internal error, or issues accessing the database.",
             "content": {
               "application/json": {
                 "schema": {
@@ -558,13 +577,27 @@
       },
       "IndexInfo": {
         "type": "object",
-        "description": "Information about an index, such as keyspace, name, and creation options.",
+        "description": "Information about an index: its keyspace, name, creation options, and the status it currently reports.",
         "required": [
           "keyspace",
           "index",
-          "options"
+          "options",
+          "status",
+          "count",
+          "build_progress"
         ],
         "properties": {
+          "build_progress": {
+            "type": "number",
+            "format": "double",
+            "description": "Progress of the initial full table scan that backfills the index,\nexpressed as a percentage in the range `0.0..=100.0`. This reflects\nonly how far the full scan has advanced; it is not a source of truth\nfor the index state. The `status` field is authoritative: an index\nreporting `SERVING` is serving regardless of `build_progress`, which\nmay not reach `100.0` (e.g. if some scan ranges failed).",
+            "maximum": 100,
+            "minimum": 0
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 0
+          },
           "index": {
             "$ref": "#/components/schemas/IndexName"
           },
@@ -573,6 +606,9 @@
           },
           "options": {
             "$ref": "#/components/schemas/IndexOptions"
+          },
+          "status": {
+            "$ref": "#/components/schemas/IndexStatus"
           }
         }
       },

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -427,7 +427,7 @@
         "tags": [
           "scylla-vector-store-index"
         ],
-        "description": "Retrieves the current operational status and item count for a specific index. The response includes the index's state and the total number of items currently indexed (excluding tombstoned or deleted entries). This endpoint enables clients to monitor index readiness and data availability for search operations.",
+        "description": "Returns the same information about a single index as `/api/v1/indexes/{keyspace}/{index}` returns.",
         "operationId": "get_index_status",
         "parameters": [
           {
@@ -451,15 +451,26 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful operation. Returns the current operational status of the specified index, including its state and the total number of items currently indexed.",
+            "description": "Successful operation. Returns the index's type, creation options, and the status it currently reports.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IndexStatusResponse"
+                  "$ref": "#/components/schemas/IndexInfo"
                 },
                 "example": {
                   "build_progress": 100.0,
                   "count": 12345,
+                  "index": "my_vector_index",
+                  "keyspace": "my_keyspace",
+                  "options": {
+                    "construction_beam_width": 128,
+                    "dimensions": 384,
+                    "maximum_node_connections": 16,
+                    "quantization": "F32",
+                    "search_beam_width": 64,
+                    "similarity_function": "COSINE",
+                    "type": "vector"
+                  },
                   "status": "SERVING"
                 }
               }
@@ -716,29 +727,6 @@
           "The index is performing the initial full scan of the underlying table to populate the index.",
           "The index has completed the initial table scan. It is now monitoring the database for changes."
         ]
-      },
-      "IndexStatusResponse": {
-        "type": "object",
-        "required": [
-          "status",
-          "count"
-        ],
-        "properties": {
-          "build_progress": {
-            "type": "number",
-            "format": "double",
-            "description": "Progress of the initial full table scan that backfills the index,\nexpressed as a percentage in the range `0.0..=100.0`. This reflects\nonly how far the full scan has advanced; it is not a source of truth\nfor the index state. The `status` field is authoritative: an index\nreporting `SERVING` is serving regardless of `build_progress`, which\nmay not reach `100.0` (e.g. if some scan ranges failed). Defaults to\n`100.0` when omitted, so a new client talking to an older server that\ndoes not report the field falls back to relying solely on `status`.",
-            "maximum": 100,
-            "minimum": 0
-          },
-          "count": {
-            "type": "integer",
-            "minimum": 0
-          },
-          "status": {
-            "$ref": "#/components/schemas/IndexStatus"
-          }
-        }
       },
       "InfoResponse": {
         "type": "object",

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -82,11 +82,21 @@ impl Serialize for Distance {
 }
 
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
-/// Information about an index, such as keyspace, name, and creation options.
+/// Information about an index: its keyspace, name, creation options, and the status it currently reports.
 pub struct IndexInfo {
     pub keyspace: KeyspaceName,
     pub index: IndexName,
     pub options: IndexOptions,
+    pub status: IndexStatus,
+    pub count: usize,
+    /// Progress of the initial full table scan that backfills the index,
+    /// expressed as a percentage in the range `0.0..=100.0`. This reflects
+    /// only how far the full scan has advanced; it is not a source of truth
+    /// for the index state. The `status` field is authoritative: an index
+    /// reporting `SERVING` is serving regardless of `build_progress`, which
+    /// may not reach `100.0` (e.g. if some scan ranges failed).
+    #[schema(minimum = 0, maximum = 100)]
+    pub build_progress: f64,
 }
 
 impl IndexInfo {
@@ -102,6 +112,9 @@ impl IndexInfo {
                 similarity_function: SimilarityFunction::Euclidean,
                 quantization: DataType::F32,
             }),
+            status: IndexStatus::Initializing,
+            count: 0,
+            build_progress: 0.0,
         }
     }
 }

--- a/crates/httpapi/src/lib.rs
+++ b/crates/httpapi/src/lib.rs
@@ -202,27 +202,6 @@ pub enum IndexOptions {
     Fulltext(FulltextIndexOptions),
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
-pub struct IndexStatusResponse {
-    pub status: IndexStatus,
-    pub count: usize,
-    /// Progress of the initial full table scan that backfills the index,
-    /// expressed as a percentage in the range `0.0..=100.0`. This reflects
-    /// only how far the full scan has advanced; it is not a source of truth
-    /// for the index state. The `status` field is authoritative: an index
-    /// reporting `SERVING` is serving regardless of `build_progress`, which
-    /// may not reach `100.0` (e.g. if some scan ranges failed). Defaults to
-    /// `100.0` when omitted, so a new client talking to an older server that
-    /// does not report the field falls back to relying solely on `status`.
-    #[serde(default = "default_build_progress")]
-    #[schema(minimum = 0, maximum = 100)]
-    pub build_progress: f64,
-}
-
-fn default_build_progress() -> f64 {
-    100.0
-}
-
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize, utoipa::ToSchema)]
 #[serde(tag = "reason", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum IndexNotReadyReason {

--- a/crates/httpclient/src/lib.rs
+++ b/crates/httpclient/src/lib.rs
@@ -7,7 +7,6 @@ use httpapi::ColumnName;
 use httpapi::Distance;
 use httpapi::IndexInfo;
 use httpapi::IndexName;
-use httpapi::IndexStatusResponse;
 use httpapi::InfoResponse;
 use httpapi::KeyspaceName;
 use httpapi::Limit;
@@ -188,7 +187,7 @@ impl HttpClient {
         &self,
         keyspace_name: &KeyspaceName,
         index_name: &IndexName,
-    ) -> anyhow::Result<IndexStatusResponse> {
+    ) -> anyhow::Result<IndexInfo> {
         let response = self
             .client
             .get(format!(
@@ -199,7 +198,7 @@ impl HttpClient {
             .await?;
 
         if response.status().is_success() {
-            Ok(response.json::<IndexStatusResponse>().await?)
+            Ok(response.json::<IndexInfo>().await?)
         } else {
             let status = response.status();
             let error_text = response.text().await?;

--- a/crates/validator/src/common.rs
+++ b/crates/validator/src/common.rs
@@ -16,7 +16,6 @@ use e2etest_vector_store_cluster::VectorStoreNodeConfig;
 use httpapi::IndexInfo;
 use httpapi::IndexName;
 use httpapi::IndexStatus;
-use httpapi::IndexStatusResponse;
 use httpapi::KeyspaceName;
 use httpclient::HttpClient;
 use itertools::Itertools;
@@ -643,7 +642,7 @@ where
 }
 
 #[framed]
-pub async fn wait_for_index(client: &HttpClient, index: &IndexInfo) -> IndexStatusResponse {
+pub async fn wait_for_index(client: &HttpClient, index: &IndexInfo) -> IndexInfo {
     wait_for_value(
         || async {
             match client.index_status(&index.keyspace, &index.index).await {

--- a/crates/vector-store/benches/pipeline.rs
+++ b/crates/vector-store/benches/pipeline.rs
@@ -17,8 +17,8 @@ use db_basic::Table;
 use futures::FutureExt;
 use futures::StreamExt;
 use futures::stream;
+use httpapi::IndexInfo;
 use httpapi::IndexStatus;
-use httpapi::IndexStatusResponse;
 use itertools::Itertools;
 use scylla::cluster::metadata::NativeType;
 use scylla::value::CqlValue;
@@ -246,7 +246,7 @@ async fn wait_until_index_is_ready(
     loop {
         let response = client.index_status(keyspace_name, index_name).await;
         if response.status_code() == StatusCode::OK
-            && response.json::<IndexStatusResponse>().status == IndexStatus::Serving
+            && response.json::<IndexInfo>().status == IndexStatus::Serving
         {
             break;
         }

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -156,6 +156,7 @@ pub fn api() -> utoipa::openapi::OpenApi {
     new_open_api_router().1
 }
 
+#[allow(deprecated)]
 fn new_open_api_router() -> (Router<RoutesInnerState>, utoipa::openapi::OpenApi) {
     OpenApiRouter::with_openapi(ApiDoc::openapi())
         .merge(
@@ -404,7 +405,8 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
     get,
     path = "/api/v1/indexes/{keyspace}/{index}/status",
     tag = "scylla-vector-store-index",
-    description = "Returns the same information about a single index as `/api/v1/indexes/{keyspace}/{index}` returns.",
+    description = "Returns the same information about a single index as `/api/v1/indexes/{keyspace}/{index}`. \
+    Deprecated. Use that endpoint instead.",
     params(
         ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the index."),
         ("index" = httpapi::IndexName, Path, description = "The name of the ScyllaDB index within the specified keyspace to check status of.")
@@ -446,6 +448,7 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
         )
     )
 )]
+#[deprecated(note = "use get_index_info at /api/v1/indexes/{keyspace}/{index}")]
 async fn get_index_status(
     state: State<RoutesInnerState>,
     path: Path<(httpapi::KeyspaceName, httpapi::IndexName)>,

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -50,6 +50,7 @@ use axum::response::Response;
 use axum::routing::get;
 use axum::routing::put;
 use axum_server_dual_protocol::Protocol;
+use futures::future;
 use httpapi::DataType;
 use httpapi::FulltextIndexOptions;
 use httpapi::IndexInfo;
@@ -85,7 +86,7 @@ use utoipa_swagger_ui::SwaggerUi;
             name = "LicenseRef-ScyllaDB-Source-Available-1.1"
         ),
         // version should be updated manually when there are changes in API
-        version = "3.0.0"
+        version = "3.1.0"
     ),
     tags(
         (
@@ -274,9 +275,11 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
     get,
     path = "/api/v1/indexes",
     tag = "scylla-vector-store-index",
-    description = "Returns the list of indexes managed by the Vector Store indexing service. \
+    description = "Returns the list of indexes managed by the Vector Store indexing service, each with its current operational status, \
+    the total number of items indexed and the progress of the initial table scan that backfills it. \
     The list includes both vector and fulltext indexes in any state (initializing, available/built, destroying). \
-    Due to synchronization delays, it may temporarily differ from the list of indexes inside ScyllaDB.",
+    Due to synchronization delays, it may temporarily differ from the list of indexes inside ScyllaDB. \
+    An index whose item count cannot be obtained, e.g. because it is being removed while the request is served, is omitted from the list.",
     responses(
         (
             status = 200,
@@ -295,7 +298,10 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
                         "search_beam_width": 64,
                         "similarity_function": "COSINE",
                         "quantization": "F32"
-                    }
+                    },
+                    "status": "SERVING",
+                    "count": 12345,
+                    "build_progress": 100.0
                 },
                 {
                     "keyspace": "my_keyspace",
@@ -304,7 +310,10 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
                         "type": "fulltext",
                         "analyzer": "standard",
                         "positions": true
-                    }
+                    },
+                    "status": "BOOTSTRAPPING",
+                    "count": 42,
+                    "build_progress": 37.5
                 }
             ])
         )
@@ -312,21 +321,53 @@ impl From<crate::SimilarityScore> for httpapi::SimilarityScore {
 )]
 
 async fn get_indexes(State(state): State<RoutesInnerState>) -> Response {
-    let indexes_guard = state.indexes.read().unwrap();
+    let entries: Vec<_> = {
+        let indexes = state.indexes.read().unwrap();
+        indexes
+            .iter_vs()
+            .map(|(key, entry)| {
+                (
+                    key.clone(),
+                    IndexOptions::Vector(entry.options().into()),
+                    IndexSender::Vs(entry.index().clone()),
+                    entry.status(),
+                    entry.progress(),
+                )
+            })
+            .chain(indexes.iter_fts().map(|(key, entry)| {
+                (
+                    key.clone(),
+                    IndexOptions::Fulltext(entry.options().into()),
+                    IndexSender::Fts(entry.index().clone()),
+                    entry.status(),
+                    entry.progress(),
+                )
+            }))
+            .collect()
+    };
 
-    let indexes: Vec<_> = indexes_guard
-        .iter_vs()
-        .map(|(key, entry)| IndexInfo {
-            keyspace: key.keyspace().into(),
-            index: key.index().into(),
-            options: IndexOptions::Vector(entry.options().into()),
-        })
-        .chain(indexes_guard.iter_fts().map(|(key, entry)| IndexInfo {
-            keyspace: key.keyspace().into(),
-            index: key.index().into(),
-            options: IndexOptions::Fulltext(entry.options().into()),
-        }))
-        .collect();
+    let indexes: Vec<_> = future::join_all(entries.into_iter().map(
+        |(key, options, index, status, progress)| async move {
+            match index.count(key.clone()).await {
+                Ok(count) => Some(IndexInfo {
+                    keyspace: key.keyspace().into(),
+                    index: key.index().into(),
+                    options,
+                    status: status.into(),
+                    count,
+                    build_progress: progress_to_percentage(progress),
+                }),
+                Err(err) => {
+                    debug!("get_indexes: index.count request error for {key}: {err}");
+                    None
+                }
+            }
+        },
+    ))
+    .await
+    .into_iter()
+    .flatten()
+    .collect();
 
     (StatusCode::OK, response::Json(indexes)).into_response()
 }
@@ -448,9 +489,9 @@ async fn get_index_status(
     get,
     path = "/api/v1/indexes/{keyspace}/{index}",
     tag = "scylla-vector-store-index",
-    description = "Retrieves information about a specific index, including its search type and the options \
-    it was created with. This is the same information reported per-entry by the `/api/v1/indexes` listing, \
-    scoped to a single index.",
+    description = "Retrieves information about a specific index: its search type, the options it was created with, \
+    its current operational status, the total number of items indexed and the progress of the initial table scan \
+    that backfills it. Each entry of the `/api/v1/indexes` listing carries the same information.",
     params(
         ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the index."),
         ("index" = httpapi::IndexName, Path, description = "The name of the ScyllaDB index within the specified keyspace.")
@@ -458,7 +499,7 @@ async fn get_index_status(
     responses(
         (
             status = 200,
-            description = "Successful operation. Returns the index's type and creation options.",
+            description = "Successful operation. Returns the index's type, creation options, and the status it currently reports.",
             body = IndexInfo,
             content_type = "application/json",
             example = json!({
@@ -472,12 +513,21 @@ async fn get_index_status(
                     "search_beam_width": 64,
                     "similarity_function": "COSINE",
                     "quantization": "F32"
-                }
+                },
+                "status": "SERVING",
+                "count": 12345,
+                "build_progress": 100.0
             })
         ),
         (
             status = 404,
             description = "Index not found. Possible causes: index does not exist, or is not discovered yet.",
+            content_type = "application/json",
+            body = ErrorMessage
+        ),
+        (
+            status = 500,
+            description = "Error while checking index state or counting indexed items. Possible causes: internal error, or issues accessing the database.",
             content_type = "application/json",
             body = ErrorMessage
         )
@@ -491,26 +541,48 @@ async fn get_index_info(
     let index_name: crate::IndexName = index_name.into();
     let index_key = IndexKey::new(&keyspace_name, &index_name);
 
-    let indexes = state.indexes.read().unwrap();
-    let info = if let Some(entry) = indexes.get_vs(&index_key) {
-        IndexInfo {
-            keyspace: keyspace_name.into(),
-            index: index_name.into(),
-            options: IndexOptions::Vector(entry.options().into()),
+    let (options, index, status, progress) = {
+        let indexes = state.indexes.read().unwrap();
+        if let Some(entry) = indexes.get_vs(&index_key) {
+            (
+                IndexOptions::Vector(entry.options().into()),
+                IndexSender::Vs(entry.index().clone()),
+                entry.status(),
+                entry.progress(),
+            )
+        } else if let Some(entry) = indexes.get_fts(&index_key) {
+            (
+                IndexOptions::Fulltext(entry.options().into()),
+                IndexSender::Fts(entry.index().clone()),
+                entry.status(),
+                entry.progress(),
+            )
+        } else {
+            let msg = format!("missing index: {keyspace_name}.{index_name}");
+            debug!("get_index_info: {msg}");
+            return (StatusCode::NOT_FOUND, msg).into_response();
         }
-    } else if let Some(entry) = indexes.get_fts(&index_key) {
-        IndexInfo {
-            keyspace: keyspace_name.into(),
-            index: index_name.into(),
-            options: IndexOptions::Fulltext(entry.options().into()),
-        }
-    } else {
-        let msg = format!("missing index: {keyspace_name}.{index_name}");
-        debug!("get_index_info: {msg}");
-        return (StatusCode::NOT_FOUND, msg).into_response();
     };
 
-    (StatusCode::OK, response::Json(info)).into_response()
+    match index.count(index_key).await {
+        Err(err) => {
+            let msg = format!("index.count request error: {err}");
+            debug!("get_index_info: {msg}");
+            (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+        }
+        Ok(count) => (
+            StatusCode::OK,
+            response::Json(IndexInfo {
+                keyspace: keyspace_name.into(),
+                index: index_name.into(),
+                options,
+                status: status.into(),
+                count,
+                build_progress: progress_to_percentage(progress),
+            }),
+        )
+            .into_response(),
+    }
 }
 
 async fn refresh_index_metrics(

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -335,6 +335,20 @@ async fn get_indexes(State(state): State<RoutesInnerState>) -> Response {
 #[derive(utoipa::ToSchema)]
 struct ErrorMessage(#[allow(dead_code)] String);
 
+enum IndexSender {
+    Vs(Sender<VsIndexSearch>),
+    Fts(Sender<FtsIndex>),
+}
+
+impl IndexSender {
+    async fn count(&self, index_key: IndexKey) -> anyhow::Result<usize> {
+        match self {
+            IndexSender::Vs(index) => index.count(index_key).await,
+            IndexSender::Fts(index) => index.count(index_key).await,
+        }
+    }
+}
+
 impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
     fn from(status: crate::node_state::IndexStatus) -> Self {
         match status {
@@ -391,11 +405,6 @@ async fn get_index_status(
     let index_name: crate::IndexName = index_name.into();
     let index_key = IndexKey::new(&keyspace_name, &index_name);
 
-    enum IndexSender {
-        Vs(Sender<VsIndexSearch>),
-        Fts(Sender<FtsIndex>),
-    }
-
     let (index, status, progress) = {
         let indexes = state.indexes.read().unwrap();
         if let Some(entry) = indexes.get_vs(&index_key) {
@@ -417,11 +426,7 @@ async fn get_index_status(
         }
     };
 
-    let count_result = match index {
-        IndexSender::Vs(s) => s.count(index_key).await,
-        IndexSender::Fts(s) => s.count(index_key).await,
-    };
-    match count_result {
+    match index.count(index_key).await {
         Err(err) => {
             let msg = format!("index.count request error: {err}");
             debug!("get_index_status: {msg}");

--- a/crates/vector-store/src/httproutes.rs
+++ b/crates/vector-store/src/httproutes.rs
@@ -404,9 +404,7 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
     get,
     path = "/api/v1/indexes/{keyspace}/{index}/status",
     tag = "scylla-vector-store-index",
-    description = "Retrieves the current operational status and item count for a specific index. \
-    The response includes the index's state and the total number of items currently indexed (excluding tombstoned or deleted entries). \
-    This endpoint enables clients to monitor index readiness and data availability for search operations.",
+    description = "Returns the same information about a single index as `/api/v1/indexes/{keyspace}/{index}` returns.",
     params(
         ("keyspace" = httpapi::KeyspaceName, Path, description = "The name of the ScyllaDB keyspace containing the index."),
         ("index" = httpapi::IndexName, Path, description = "The name of the ScyllaDB index within the specified keyspace to check status of.")
@@ -414,11 +412,21 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
     responses(
         (
             status = 200,
-            description = "Successful operation. Returns the current operational status of the specified index, including its state \
-            and the total number of items currently indexed.",
-            body = httpapi::IndexStatusResponse,
+            description = "Successful operation. Returns the index's type, creation options, and the status it currently reports.",
+            body = IndexInfo,
             content_type = "application/json",
             example = json!({
+                "keyspace": "my_keyspace",
+                "index": "my_vector_index",
+                "options": {
+                    "type": "vector",
+                    "dimensions": 384,
+                    "maximum_node_connections": 16,
+                    "construction_beam_width": 128,
+                    "search_beam_width": 64,
+                    "similarity_function": "COSINE",
+                    "quantization": "F32"
+                },
                 "status": "SERVING",
                 "count": 12345,
                 "build_progress": 100.0
@@ -439,50 +447,10 @@ impl From<crate::node_state::IndexStatus> for httpapi::IndexStatus {
     )
 )]
 async fn get_index_status(
-    State(state): State<RoutesInnerState>,
-    Path((keyspace_name, index_name)): Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
+    state: State<RoutesInnerState>,
+    path: Path<(httpapi::KeyspaceName, httpapi::IndexName)>,
 ) -> Response {
-    let keyspace_name: crate::KeyspaceName = keyspace_name.into();
-    let index_name: crate::IndexName = index_name.into();
-    let index_key = IndexKey::new(&keyspace_name, &index_name);
-
-    let (index, status, progress) = {
-        let indexes = state.indexes.read().unwrap();
-        if let Some(entry) = indexes.get_vs(&index_key) {
-            (
-                IndexSender::Vs(entry.index().clone()),
-                entry.status(),
-                entry.progress(),
-            )
-        } else if let Some(entry) = indexes.get_fts(&index_key) {
-            (
-                IndexSender::Fts(entry.index().clone()),
-                entry.status(),
-                entry.progress(),
-            )
-        } else {
-            let msg = format!("missing index: {keyspace_name}.{index_name}");
-            debug!("get_index_status: {msg}");
-            return (StatusCode::NOT_FOUND, msg).into_response();
-        }
-    };
-
-    match index.count(index_key).await {
-        Err(err) => {
-            let msg = format!("index.count request error: {err}");
-            debug!("get_index_status: {msg}");
-            (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
-        }
-        Ok(count) => (
-            StatusCode::OK,
-            response::Json(httpapi::IndexStatusResponse {
-                status: status.into(),
-                count,
-                build_progress: progress_to_percentage(progress),
-            }),
-        )
-            .into_response(),
-    }
+    get_index_info(state, path).await
 }
 
 #[utoipa::path(

--- a/crates/vector-store/tests/integration/index_info.rs
+++ b/crates/vector-store/tests/integration/index_info.rs
@@ -3,17 +3,21 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 use crate::common::add_table;
+use crate::common::blocking_scan_fn;
 use crate::common::make_fts_index;
 use crate::common::make_fts_index_with_options;
 use crate::common::make_index_with_kind;
+use crate::common::make_vs_index;
 use crate::common::ordered_timeuuid;
 use crate::common::setup;
 use crate::common::single_row_scan;
 use crate::db_basic;
 use crate::wait_for;
+use crate::wait_for_value;
 use httpapi::DataType;
 use httpapi::FulltextIndexOptions;
 use httpapi::IndexOptions;
+use httpapi::IndexStatus;
 use httpapi::SimilarityFunction;
 use httpapi::VectorIndexOptions;
 use rstest::rstest;
@@ -27,6 +31,8 @@ use vector_store::DbIndexPartitioning;
 use vector_store::IndexKind;
 use vector_store::IndexOptionsFts;
 use vector_store::IndexOptionsVs;
+use vector_store::Percentage;
+use vector_store::Progress;
 use vector_store::Timestamp;
 
 #[rstest]
@@ -266,4 +272,142 @@ async fn indexes_lists_all_indexes_with_options() {
             expected_options.get(entry.index.as_ref()).unwrap()
         );
     }
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn indexes_listing_reports_status_and_progress_when_serving() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    let index = make_vs_index(
+        "ready",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(
+        index.clone(),
+        Some(single_row_scan([CqlValue::Int(1)])),
+        None,
+    )
+    .unwrap();
+
+    let entries = wait_for_value(
+        async || {
+            let entries = client.indexes().await;
+            entries
+                .first()
+                .is_some_and(|entry| entry.status == IndexStatus::Serving && entry.count == 1)
+                .then_some(entries)
+        },
+        "the listed index to be serving with a single item indexed",
+    )
+    .await;
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].index.as_ref(), index.index_name.as_ref());
+    assert_eq!(entries[0].build_progress, 100.0);
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn indexes_listing_reports_progress_of_bootstrapping_index() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [("pk".into(), NativeType::Int)],
+        ["embedding".into()],
+    );
+
+    // Pin the reported full-scan progress to a partial value, then add an index
+    // whose scan never completes, keeping it bootstrapping at that progress.
+    db.set_next_full_scan_progress(Progress::InProgress(Percentage::try_from(37.0).unwrap()));
+
+    let index = make_vs_index(
+        "building",
+        &["pk"],
+        1,
+        "embedding",
+        DbIndexPartitioning::Global,
+        &[],
+        ordered_timeuuid(1),
+    );
+    db.add_index(index.clone(), Some(blocking_scan_fn()), None)
+        .unwrap();
+
+    wait_for(
+        || async {
+            client.indexes().await.first().is_some_and(|entry| {
+                entry.status == IndexStatus::Bootstrapping && entry.build_progress == 37.0
+            })
+        },
+        "the listed index to be bootstrapping with build_progress == 37%",
+    )
+    .await;
+}
+
+#[rstest]
+#[timeout(Duration::from_secs(10))]
+#[tokio::test]
+async fn indexes_listing_reports_status_of_a_fulltext_index() {
+    crate::enable_tracing();
+    let (client, db, _keep) = setup().await;
+
+    add_table(
+        &db,
+        ["pk".into()],
+        1,
+        [
+            ("pk".into(), NativeType::Int),
+            ("content".into(), NativeType::Text),
+        ],
+        [],
+    );
+
+    let index = make_fts_index("fulltext", &["pk"], 1, "content", ordered_timeuuid(1));
+    db.add_index(
+        index.clone(),
+        Some(db_basic::scan_fn_documents([(
+            [CqlValue::Int(1)].into(),
+            Some("hello world".to_string()),
+            Timestamp::from_millis(10),
+        )])),
+        None,
+    )
+    .unwrap();
+
+    let entries = wait_for_value(
+        async || {
+            let entries = client.indexes().await;
+            entries
+                .first()
+                .is_some_and(|entry| entry.status == IndexStatus::Serving && entry.count == 1)
+                .then_some(entries)
+        },
+        "the listed full-text index to be serving with a single document indexed",
+    )
+    .await;
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].index.as_ref(), index.index_name.as_ref());
+    assert!(matches!(entries[0].options, IndexOptions::Fulltext(_)));
+    assert_eq!(entries[0].build_progress, 100.0);
 }

--- a/crates/vector-store/tests/integration/opensearch.rs
+++ b/crates/vector-store/tests/integration/opensearch.rs
@@ -130,7 +130,8 @@ async fn simple_create_search_delete_index() {
 
     let indexes = client.indexes().await;
     assert_eq!(indexes.len(), 1);
-    assert_eq!(indexes[0], httpapi::IndexInfo::new("vector", "ann"));
+    assert_eq!(indexes[0].keyspace.as_ref(), "vector");
+    assert_eq!(indexes[0].index.as_ref(), "ann");
 
     let (primary_keys, distances, similarity_scores) = client
         .ann(

--- a/crates/vector-store/tests/integration/vs_index.rs
+++ b/crates/vector-store/tests/integration/vs_index.rs
@@ -301,7 +301,8 @@ async fn simple_create_search_delete_index(#[case] config: Config) {
 
     let indexes = client.indexes().await;
     assert_eq!(indexes.len(), 1);
-    assert_eq!(indexes[0], httpapi::IndexInfo::new("vector", "ann"));
+    assert_eq!(indexes[0].keyspace.as_ref(), "vector");
+    assert_eq!(indexes[0].index.as_ref(), "ann");
 
     let (primary_keys, distances, similarity_scores) = client
         .ann(
@@ -423,8 +424,9 @@ async fn failed_db_index_create(#[case] config: Config) {
 
     let indexes = client.indexes().await;
     assert_eq!(indexes.len(), 2);
-    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann")));
-    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann2")));
+    let names: Vec<_> = indexes.iter().map(|info| info.index.as_ref()).collect();
+    assert!(names.contains(&"ann"));
+    assert!(names.contains(&"ann2"));
 
     db.add_index(
         IndexMetadata {
@@ -444,9 +446,10 @@ async fn failed_db_index_create(#[case] config: Config) {
 
     let indexes = client.indexes().await;
     assert_eq!(indexes.len(), 3);
-    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann")));
-    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann2")));
-    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann3")));
+    let names: Vec<_> = indexes.iter().map(|info| info.index.as_ref()).collect();
+    assert!(names.contains(&"ann"));
+    assert!(names.contains(&"ann2"));
+    assert!(names.contains(&"ann3"));
 
     db.del_index(&index.keyspace_name, &"ann2".into()).unwrap();
 
@@ -458,8 +461,9 @@ async fn failed_db_index_create(#[case] config: Config) {
 
     let indexes = client.indexes().await;
     assert_eq!(indexes.len(), 2);
-    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann")));
-    assert!(indexes.contains(&httpapi::IndexInfo::new("vector", "ann3")));
+    let names: Vec<_> = indexes.iter().map(|info| info.index.as_ref()).collect();
+    assert!(names.contains(&"ann"));
+    assert!(names.contains(&"ann3"));
 }
 
 #[rstest]


### PR DESCRIPTION
Rendering the Vector Store index build status of a whole cluster took M x N requests. Listing the indexes of a node needs an `/indexes` call, then every index needs an `/indexes/{keyspace}/{index}/status` call. Such polling grows with the size of the cluster.

The status now belongs to the description of an index: `IndexInfo` carries `status`, `count` and `build_progress` next to the creation options, and every endpoint serving an index answers with it. `/indexes` lists one such object per index, so a node takes one request:

```json
{
  "keyspace": "my_keyspace",
  "index": "my_vector_index",
  "options": { "type": "vector", "dimensions": 384, "...": "..." },
  "status": "SERVING",
  "count": 12345,
  "build_progress": 100.0
}
```

`/indexes/{keyspace}/{index}` answers with the same object for one index, and so does `/indexes/{keyspace}/{index}/status`, which leaves `IndexStatusResponse` with nothing to describe. That path is marked deprecated in the OpenAPI document and stays served for the clients reading the status from it; its body only gains fields, so those clients keep working.

The counts are gathered concurrently, once the `Indexes` read lock has been released. The listing skips an index whose count cannot be obtained, for example while the index is being removed. A lookup of a single index counts the items as well, and answers 500 when the count fails.

Worth a reviewer's attention: `/indexes` and `/indexes/{keyspace}/{index}` used to be pure in-memory reads, and each of them now issues one count per index it reports. On the OpenSearch provider that count is a remote `_count` request.

The API version goes to 3.1.0 and `openapi.json` is regenerated. Integration tests cover a serving index, one whose initial scan still runs, and a full-text index.

Fixes: VECTOR-887
