### PR TITLE
validator: fix waiting for restore number of connection

### DIFF
--- a/crates/validator/src/reconnect.rs
+++ b/crates/validator/src/reconnect.rs
@@ -406,19 +406,20 @@ async fn restarting_all_nodes_doesnt_break_fullscan(actors: Arc<TestActors>) {
     )
     .await;
 
+    let total_connections = *client
+        .internals_session_counters()
+        .await
+        .unwrap()
+        .get("total-connections")
+        .unwrap();
+    info!("Base number of total connections: {total_connections}");
+
     info!("Restart each node one by one");
     for proxy_addr in get_default_scylla_proxy_node_configs(&actors)
         .await
         .into_iter()
         .map(|config| config.proxy_addr)
     {
-        let total_connections = *client
-            .internals_session_counters()
-            .await
-            .unwrap()
-            .get("total-connections")
-            .unwrap();
-
         info!("Disconnect scylla-proxy {proxy_addr}");
         actors.firewall.drop_traffic(vec![proxy_addr]).await;
 
@@ -428,17 +429,13 @@ async fn restarting_all_nodes_doesnt_break_fullscan(actors: Arc<TestActors>) {
                 info!("session counters: {:?}", counters);
                 *counters.unwrap().get("total-connections").unwrap() < total_connections
             },
-            format!("connections to {proxy_addr} must be closed"),
+            format!(
+                "connections to {proxy_addr} must be closed, \
+                number of connections should be less than {total_connections}"
+            ),
             KEEPALIVE_TIMEOUT,
         )
         .await;
-
-        let total_connections = *client
-            .internals_session_counters()
-            .await
-            .unwrap()
-            .get("total-connections")
-            .unwrap();
 
         info!("Reconnect scylla-proxy");
         actors.firewall.turn_off_rules().await;
@@ -447,9 +444,12 @@ async fn restarting_all_nodes_doesnt_break_fullscan(actors: Arc<TestActors>) {
             || async {
                 let counters = client.internals_session_counters().await;
                 info!("session counters: {:?}", counters);
-                *counters.unwrap().get("total-connections").unwrap() > total_connections
+                *counters.unwrap().get("total-connections").unwrap() == total_connections
             },
-            format!("connections to {proxy_addr} must be opened"),
+            format!(
+                "connections to {proxy_addr} must be opened, \
+                number of connections should be {total_connections}"
+            ),
             KEEPALIVE_TIMEOUT,
         )
         .await;


### PR DESCRIPTION
The validator test reconnect::restarting_all_nodes_doesnt_break_fullscan is flaky in CI.  The problematic area is discovering when connection to the missing node is missing. We use for this the scylla driver metric total-connection - number of the all connection to all scylla nodes. This number is in our situation two per node, so base number is 6 in case of three nodes. The issue is with reliable calculations when we disconnect or reconnect node. Temporary number of connections grew to 8 - it seems we didn't add enough time to remove stalled connections.

This commit retrieve the base total-connection and after the down-up procedure with the node the test is waiting for the exact number of this base total-connection - in this situation we know that the connectivity back to normal.

Fixes: VECTOR-877