### PR TITLE
vector-store: reduce allocations on fetched Vector rows

### DIFF
--- a/crates/vector-store/src/db_cdc/consumer.rs
+++ b/crates/vector-store/src/db_cdc/consumer.rs
@@ -17,6 +17,7 @@ use crate::PrimaryKey;
 use crate::Timestamp;
 use crate::db_index;
 use crate::db_index_backend;
+use crate::db_value::DbRow;
 use anyhow::Context;
 use anyhow::anyhow;
 use anyhow::bail;
@@ -26,7 +27,6 @@ use scylla::cluster::metadata::ColumnType;
 use scylla::cluster::metadata::NativeType;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
-use scylla::value::Row;
 use scylla_cdc::consumer::CDCRow;
 use scylla_cdc::consumer::Consumer;
 use scylla_cdc::consumer::ConsumerFactory;
@@ -82,7 +82,7 @@ impl CdcConsumerData {
             timestamp,
         );
 
-        let Some(row) = rows_result.maybe_first_row::<Row>()? else {
+        let Some(row) = rows_result.maybe_first_row::<DbRow>()? else {
             // If no row is found for the primary key, it is deleted
             _ = self
                 .tx

--- a/crates/vector-store/src/db_index.rs
+++ b/crates/vector-store/src/db_index.rs
@@ -25,6 +25,8 @@ use crate::Vector;
 use crate::db_cdc;
 use crate::db_cdc::CdcReaderConfig;
 use crate::db_index_backend;
+use crate::db_value::DbRow;
+use crate::db_value::DbValue;
 use crate::internals::Internals;
 use crate::invariant_key::InvariantKey;
 use crate::node_state::Event;
@@ -47,7 +49,6 @@ use scylla::errors::PagerExecutionError;
 use scylla::routing::Token;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlValue;
-use scylla::value::Row;
 use scylla_cdc::CqlIdentifier;
 use std::collections::HashMap;
 use std::iter;
@@ -521,11 +522,8 @@ impl Statements {
             .execute_unpaged(&self.st_fetch_vector, &key)
             .await?
             .into_rows_result()?;
-        let Some(row) = rows_result.maybe_first_row::<Row>()? else {
-            // The row is gone from the base table.
-            return Ok(None);
-        };
-        parse_vector_row(row.columns)
+        let row = rows_result.maybe_first_row::<(Option<Vector>,)>()?;
+        Ok(row.and_then(|(vector,)| vector))
     }
 
     async fn preform_range_scan(&self, begin: Token, end: Token) -> RangeScanResult {
@@ -717,7 +715,7 @@ impl Statements {
         Ok(session
             .execute_iter(self.st_range_scan.clone(), (begin.value(), end.value()))
             .await?
-            .rows_stream::<Row>()?
+            .rows_stream::<DbRow>()?
             .map_err(anyhow::Error::from)
             .map_ok(move |mut row| {
                 if row.columns.len() != columns_len_expected {
@@ -825,7 +823,7 @@ pub(crate) fn alternator_decode_types<'a>(
 }
 
 pub(crate) fn parse_values(
-    columns: impl IntoIterator<Item = Option<CqlValue>>,
+    columns: impl IntoIterator<Item = Option<DbValue>>,
     default_timestamp: Option<Timestamp>,
     target_columns_len: NonZeroUsize,
     kind: &IndexKind,
@@ -856,7 +854,7 @@ pub(crate) fn parse_values(
                     .cloned()
                     .flatten();
                 let value = value
-                    .map(|value| match (value, native_type) {
+                    .map(|value| match (filtering_value(value)?, native_type) {
                         (CqlValue::Blob(bytes), Some(native_type)) => {
                             crate::alternator::parse_alternator_scalar(&bytes, &native_type)
                         }
@@ -872,7 +870,7 @@ pub(crate) fn parse_values(
                     "parse_values: unable to get timestamp value from chunk"
                 ))?
                 .map(|timestamp| {
-                    if let CqlValue::BigInt(timestamp) = timestamp {
+                    if let DbValue::Value(CqlValue::BigInt(timestamp)) = timestamp {
                         Ok(Timestamp::from_micros(timestamp as u64))
                     } else {
                         bail!("parse_values: bad type of a writetime")
@@ -894,48 +892,50 @@ pub(crate) fn parse_values(
     Ok(NonemptyBox::try_from(values).unwrap())
 }
 
-fn parse_primary_key(columns: impl IntoIterator<Item = Option<CqlValue>>) -> Option<PrimaryKey> {
+fn parse_primary_key(columns: impl IntoIterator<Item = Option<DbValue>>) -> Option<PrimaryKey> {
     columns
         .into_iter()
-        .inspect(|value| {
-            if value.is_none() {
+        .map(|value| match value {
+            Some(DbValue::Value(value)) => Some(value),
+            // A primary key column is never of a vector type.
+            Some(DbValue::Vector(_)) => {
+                debug!("parse_primary_key: unexpected vector primary key column");
+                None
+            }
+            None => {
                 debug!("parse_primary_key: missing a primary key column");
-            };
+                None
+            }
         })
         .collect::<Option<_>>()
 }
 
-fn parse_indexed_value(value: CqlValue, kind: &IndexKind) -> anyhow::Result<DbIndexedValue> {
+fn filtering_value(value: DbValue) -> anyhow::Result<CqlValue> {
+    match value {
+        DbValue::Value(value) => Ok(value),
+        DbValue::Vector(_) => {
+            bail!("parse_values: unexpected vector value of a filtering column")
+        }
+    }
+}
+
+fn parse_indexed_value(value: DbValue, kind: &IndexKind) -> anyhow::Result<DbIndexedValue> {
     match kind {
-        IndexKind::Vs(_) => Vector::try_from(value)
-            .map_err(|err| anyhow!("parse_indexed_value: {err}"))
-            .map(DbIndexedValue::Vector),
+        IndexKind::Vs(_) => match value {
+            DbValue::Vector(vector) => Ok(DbIndexedValue::Vector(vector)),
+            DbValue::Value(value) => Vector::try_from(value)
+                .map_err(|err| anyhow!("parse_indexed_value: {err}"))
+                .map(DbIndexedValue::Vector),
+        },
         IndexKind::Fts(_) => match value {
-            CqlValue::Text(s) => Ok(DbIndexedValue::Document(s)),
-            CqlValue::Ascii(s) => Ok(DbIndexedValue::Document(s)),
+            DbValue::Value(CqlValue::Text(s) | CqlValue::Ascii(s)) => {
+                Ok(DbIndexedValue::Document(s))
+            }
             other => {
                 bail!("parse_indexed_value: expected text column, got {:?}", other);
             }
         },
     }
-}
-
-/// Parse a row of `[value]`, as selected by
-/// [`db_index_backend::fetch_vector_query`].
-fn parse_vector_row(columns: Vec<Option<CqlValue>>) -> anyhow::Result<Option<Vector>> {
-    const EXPECTED_COLUMNS: usize = 1;
-    if columns.len() != EXPECTED_COLUMNS {
-        bail!(
-            "parse_vector_row: expected {EXPECTED_COLUMNS} columns, got {}",
-            columns.len()
-        );
-    }
-    columns
-        .into_iter()
-        .next()
-        .unwrap()
-        .map(|value| Vector::try_from(value).map_err(|err| anyhow!("parse_vector_row: {err}")))
-        .transpose()
 }
 
 fn concurrency_limit() -> usize {
@@ -995,13 +995,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_indexed_value_vector_from_cql_vector() {
-        let cql = CqlValue::Vector(vec![
-            CqlValue::Float(1.0),
-            CqlValue::Float(2.0),
-            CqlValue::Float(3.0),
-        ]);
-        let result = parse_indexed_value(cql, &vs_kind());
+    fn parse_indexed_value_vector_from_vector_column() {
+        let column = DbValue::Vector(Vector::from(vec![1.0, 2.0, 3.0]));
+        let result = parse_indexed_value(column, &vs_kind());
         assert_eq!(
             result.unwrap(),
             DbIndexedValue::Vector(Vector::from(vec![1.0, 2.0, 3.0]))
@@ -1009,16 +1005,39 @@ mod tests {
     }
 
     #[test]
+    fn parse_indexed_value_vector_from_alternator_blob() {
+        // Tag 5 = ALTERNATOR_TYPE_FLOAT32VECTOR, followed by big-endian
+        // floats: an Alternator embedding is still decoded from a blob.
+        let mut tagged_vector = vec![5u8];
+        tagged_vector.extend_from_slice(&1.0f32.to_be_bytes());
+        tagged_vector.extend_from_slice(&2.0f32.to_be_bytes());
+
+        let column = DbValue::Value(CqlValue::Blob(tagged_vector));
+        let result = parse_indexed_value(column, &vs_kind());
+        assert_eq!(
+            result.unwrap(),
+            DbIndexedValue::Vector(Vector::from(vec![1.0, 2.0]))
+        );
+    }
+
+    #[test]
     fn parse_indexed_value_vector_rejects_invalid_type() {
-        let cql = CqlValue::Text("not a vector".to_string());
-        let result = parse_indexed_value(cql, &vs_kind());
+        let column = DbValue::Value(CqlValue::Text("not a vector".to_string()));
+        let result = parse_indexed_value(column, &vs_kind());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_indexed_value_fts_rejects_a_vector_column() {
+        let column = DbValue::Vector(Vector::from(vec![1.0]));
+        let result = parse_indexed_value(column, &fts_kind());
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_indexed_value_fts_from_text() {
-        let cql = CqlValue::Text("hello world".to_string());
-        let result = parse_indexed_value(cql, &fts_kind());
+        let column = DbValue::Value(CqlValue::Text("hello world".to_string()));
+        let result = parse_indexed_value(column, &fts_kind());
         assert_eq!(
             result.unwrap(),
             DbIndexedValue::Document("hello world".to_string())
@@ -1027,8 +1046,8 @@ mod tests {
 
     #[test]
     fn parse_indexed_value_fts_from_ascii() {
-        let cql = CqlValue::Ascii("ascii doc".to_string());
-        let result = parse_indexed_value(cql, &fts_kind());
+        let column = DbValue::Value(CqlValue::Ascii("ascii doc".to_string()));
+        let result = parse_indexed_value(column, &fts_kind());
         assert_eq!(
             result.unwrap(),
             DbIndexedValue::Document("ascii doc".to_string())
@@ -1037,51 +1056,17 @@ mod tests {
 
     #[test]
     fn parse_indexed_value_fts_rejects_invalid_type() {
-        let cql = CqlValue::Int(42);
-        let result = parse_indexed_value(cql, &fts_kind());
+        let column = DbValue::Value(CqlValue::Int(42));
+        let result = parse_indexed_value(column, &fts_kind());
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_vector_row_returns_the_vector() {
-        let columns = vec![Some(CqlValue::Vector(vec![
-            CqlValue::Float(1.0),
-            CqlValue::Float(2.0),
-        ]))];
-        let result = parse_vector_row(columns);
-        assert_eq!(result.unwrap(), Some(Vector::from(vec![1.0, 2.0])));
-    }
-
-    #[test]
-    fn parse_vector_row_null_value_is_none() {
-        let columns = vec![None];
-        let result = parse_vector_row(columns);
-        assert_eq!(result.unwrap(), None);
-    }
-
-    #[test]
-    fn parse_vector_row_rejects_a_wrong_column_count() {
-        let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::BigInt(12345)),
-        ];
-        assert!(parse_vector_row(columns).is_err());
-
-        assert!(parse_vector_row(vec![]).is_err());
-    }
-
-    #[test]
-    fn parse_vector_row_rejects_a_non_vector_value() {
-        let columns = vec![Some(CqlValue::Text("not a vector".to_string()))];
-        assert!(parse_vector_row(columns).is_err());
     }
 
     #[test]
     fn parse_values_with_missing_timestamp() {
         let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::BigInt(1234567890)),
-            Some(CqlValue::Int(1)),
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            Some(DbValue::Value(CqlValue::Int(1))),
             None, // missing timestamp
         ];
 
@@ -1129,8 +1114,8 @@ mod tests {
     #[test]
     fn parse_values_with_wrong_timestamp() {
         let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::Int(1234567890)),
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::Int(1234567890))),
         ];
         let result = parse_values(
             columns.clone(),
@@ -1149,7 +1134,10 @@ mod tests {
 
     #[test]
     fn parse_values_with_wrong_value() {
-        let columns = vec![Some(CqlValue::Int(1)), Some(CqlValue::BigInt(1234567890))];
+        let columns = vec![
+            Some(DbValue::Value(CqlValue::Int(1))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+        ];
         let result = parse_values(
             columns.clone(),
             None,
@@ -1167,10 +1155,11 @@ mod tests {
 
     #[test]
     fn parse_values_with_wrong_columns_len() {
+        // A dangling filtering column, with no writetime to pair it with.
         let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::BigInt(1234567890)),
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            Some(DbValue::Value(CqlValue::Int(42))),
         ];
         let result = parse_values(
             columns.clone(),
@@ -1190,10 +1179,10 @@ mod tests {
     #[test]
     fn parse_values_with_wrong_target_len() {
         let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::BigInt(1234567890)),
-            Some(CqlValue::Vector(vec![CqlValue::Float(2.0)])),
-            Some(CqlValue::BigInt(1234567891)),
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            Some(DbValue::Vector(Vector::from(vec![2.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567891))),
         ];
         let result = parse_values(
             columns.clone(),
@@ -1211,16 +1200,37 @@ mod tests {
     }
 
     #[test]
+    fn parse_values_rejects_a_vector_filtering_column() {
+        let columns = vec![
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            Some(DbValue::Vector(Vector::from(vec![2.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+        ];
+        let result = parse_values(
+            columns,
+            None,
+            NonZeroUsize::new(1).unwrap(),
+            &vs_kind(),
+            &[],
+        );
+        assert_matches!(
+            result.unwrap_err().to_string(),
+            err if err.contains("unexpected vector value of a filtering column")
+        );
+    }
+
+    #[test]
     fn parse_values_decodes_alternator_filtering_column() {
         // Tag 0 = ALTERNATOR_TYPE_S (string), per vector.rs.
         let mut tagged_name = vec![0u8];
         tagged_name.extend_from_slice(b"red");
 
         let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::BigInt(1234567890)),
-            Some(CqlValue::Blob(tagged_name)),
-            Some(CqlValue::BigInt(1234567890)),
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            Some(DbValue::Value(CqlValue::Blob(tagged_name))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
         ];
         let result = parse_values(
             columns,
@@ -1244,10 +1254,10 @@ mod tests {
         // because it's a real CQL column, not a virtual Alternator
         // attribute - its raw value must pass through unchanged.
         let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::BigInt(1234567890)),
-            Some(CqlValue::Int(42)),
-            Some(CqlValue::BigInt(1234567890)),
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            Some(DbValue::Value(CqlValue::Int(42))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
         ];
         let result = parse_values(
             columns,
@@ -1270,10 +1280,10 @@ mod tests {
         // "S" (Text) - parse_alternator_scalar() must reject this rather
         // than silently misinterpreting the payload.
         let columns = vec![
-            Some(CqlValue::Vector(vec![CqlValue::Float(1.0)])),
-            Some(CqlValue::BigInt(1234567890)),
-            Some(CqlValue::Blob(vec![1u8, 0xDE, 0xAD])),
-            Some(CqlValue::BigInt(1234567890)),
+            Some(DbValue::Vector(Vector::from(vec![1.0]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            Some(DbValue::Value(CqlValue::Blob(vec![1u8, 0xDE, 0xAD]))),
+            Some(DbValue::Value(CqlValue::BigInt(1234567890))),
         ];
         let result = parse_values(
             columns,

--- a/crates/vector-store/src/db_value.rs
+++ b/crates/vector-store/src/db_value.rs
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+//! Row and value types for reads of an indexed base table.
+//!
+//! The rows read by a full scan ([`crate::db_index`]) and by a CDC upsert's
+//! point read ([`crate::db_cdc`]) have a column layout that is only known at
+//! runtime, which is why they used to be read as [`CqlValue`]s. That is
+//! needlessly expensive for the embedding column: a `vector<float, N>`
+//! becomes a `Vec<CqlValue>`, one 72-byte enum per 4-byte element, which is
+//! then walked a second time to unwrap the floats.
+//!
+//! [`DbRow`] keeps the dynamic layout, but dispatches per value on the
+//! column's CQL type, so the embedding is deserialized straight into a
+//! [`Vector`] while every other value keeps its [`CqlValue`]
+//! representation.
+
+use crate::Vector;
+use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
+use scylla::deserialize::DeserializationError;
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::TypeCheckError;
+use scylla::deserialize::row::ColumnIterator;
+use scylla::deserialize::row::DeserializeRow;
+use scylla::deserialize::value::DeserializeValue;
+use scylla::frame::response::result::ColumnSpec;
+use scylla::value::CqlValue;
+
+/// A single value of a [`DbRow`].
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum DbValue {
+    /// A value of a native CQL `vector<float, N>` column.
+    Vector(Vector),
+    /// Any other value, in the dynamic representation its runtime-only CQL
+    /// type requires. For an Alternator table this includes the embedding
+    /// column, which arrives as a tagged `CqlValue::Blob`.
+    Value(CqlValue),
+}
+
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for DbValue {
+    fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
+        match typ {
+            // Only a vector<float, N> is an embedding. A vector of any other
+            // element type is an ordinary column and keeps its CqlValue
+            // representation, instead of failing the type check of the whole
+            // row.
+            ColumnType::Vector { typ: element, .. }
+                if matches!(**element, ColumnType::Native(NativeType::Float)) =>
+            {
+                <Vector>::type_check(typ)
+            }
+            _ => <CqlValue>::type_check(typ),
+        }
+    }
+
+    fn deserialize(
+        typ: &'metadata ColumnType<'metadata>,
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
+        match typ {
+            ColumnType::Vector { typ: element, .. }
+                if matches!(**element, ColumnType::Native(NativeType::Float)) =>
+            {
+                <Vector>::deserialize(typ, v).map(Self::Vector)
+            }
+            _ => <CqlValue>::deserialize(typ, v).map(Self::Value),
+        }
+    }
+}
+
+/// A row of an indexed base table: all selected columns, in the order the
+/// query selected them, with a `None` for a null column.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct DbRow {
+    pub(crate) columns: Vec<Option<DbValue>>,
+}
+
+/// Deserializes the row eagerly, column by column.
+impl<'frame, 'metadata> DeserializeRow<'frame, 'metadata> for DbRow {
+    fn type_check(specs: &[ColumnSpec]) -> Result<(), TypeCheckError> {
+        specs
+            .iter()
+            .try_for_each(|spec| <Option<DbValue>>::type_check(spec.typ()))
+    }
+
+    fn deserialize(row: ColumnIterator<'frame, 'metadata>) -> Result<Self, DeserializationError> {
+        let mut columns = Vec::with_capacity(row.columns_remaining());
+        for column in row {
+            let column = column?;
+            columns.push(<Option<DbValue>>::deserialize(
+                column.spec.typ(),
+                column.slice,
+            )?);
+        }
+        Ok(Self { columns })
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scylla::frame::response::result::TableSpec;
+
+    fn float_vector_type(dimensions: u16) -> ColumnType<'static> {
+        ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Float)),
+            dimensions,
+        }
+    }
+
+    fn spec(name: &str, typ: ColumnType<'static>) -> ColumnSpec<'static> {
+        ColumnSpec::owned(
+            name.to_string(),
+            typ,
+            TableSpec::owned("ks".into(), "tbl".into()),
+        )
+    }
+
+    fn deserialize_row(columns: &[(ColumnSpec<'static>, Option<Vec<u8>>)]) -> DbRow {
+        let specs = columns
+            .iter()
+            .map(|(spec, _)| spec.clone())
+            .collect::<Vec<_>>();
+        <DbRow>::type_check(&specs).unwrap();
+
+        // The frame of a row is the concatenation of its [len][value] cells,
+        // with a length of -1 for a null column.
+        let mut frame = Vec::new();
+        for (_, value) in columns {
+            match value {
+                Some(value) => {
+                    frame.extend_from_slice(&(value.len() as i32).to_be_bytes());
+                    frame.extend_from_slice(value);
+                }
+                None => frame.extend_from_slice(&(-1i32).to_be_bytes()),
+            }
+        }
+        let frame = FrameSlice::new_borrowed(&frame);
+        <DbRow>::deserialize(ColumnIterator::new(&specs, frame)).unwrap()
+    }
+
+    fn float_cells(floats: &[f32]) -> Vec<u8> {
+        floats.iter().flat_map(|f| f.to_be_bytes()).collect()
+    }
+
+    #[test]
+    fn vector_column_deserializes_into_a_vector() {
+        let row = deserialize_row(&[(
+            spec("embedding", float_vector_type(3)),
+            Some(float_cells(&[1.0, 2.5, 3.0])),
+        )]);
+        assert_eq!(
+            row.columns,
+            vec![Some(DbValue::Vector(Vector::from(vec![1.0, 2.5, 3.0])))]
+        );
+    }
+
+    #[test]
+    fn other_columns_stay_cql_values() {
+        let row = deserialize_row(&[
+            (
+                spec("color", ColumnType::Native(NativeType::Text)),
+                Some(b"red".to_vec()),
+            ),
+            (
+                spec("writetime(color)", ColumnType::Native(NativeType::BigInt)),
+                Some(1234567890i64.to_be_bytes().to_vec()),
+            ),
+        ]);
+        assert_eq!(
+            row.columns,
+            vec![
+                Some(DbValue::Value(CqlValue::Text("red".to_string()))),
+                Some(DbValue::Value(CqlValue::BigInt(1234567890))),
+            ]
+        );
+    }
+
+    #[test]
+    fn alternator_blob_column_stays_a_cql_value() {
+        let row = deserialize_row(&[(
+            spec(":attrs['embedding']", ColumnType::Native(NativeType::Blob)),
+            Some(vec![0x05, 0x3f, 0x80, 0x00, 0x00]),
+        )]);
+        assert_eq!(
+            row.columns,
+            vec![Some(DbValue::Value(CqlValue::Blob(vec![
+                0x05, 0x3f, 0x80, 0x00, 0x00
+            ])))]
+        );
+    }
+
+    #[test]
+    fn null_columns_deserialize_into_none() {
+        let row = deserialize_row(&[
+            (spec("embedding", float_vector_type(3)), None),
+            (spec("color", ColumnType::Native(NativeType::Text)), None),
+        ]);
+        assert_eq!(row.columns, vec![None, None]);
+    }
+
+    #[test]
+    fn a_mixed_row_keeps_the_column_order() {
+        let row = deserialize_row(&[
+            (
+                spec("pk", ColumnType::Native(NativeType::BigInt)),
+                Some(7i64.to_be_bytes().to_vec()),
+            ),
+            (
+                spec("embedding", float_vector_type(2)),
+                Some(float_cells(&[1.0, 2.0])),
+            ),
+            (
+                spec("color", ColumnType::Native(NativeType::Text)),
+                Some(b"red".to_vec()),
+            ),
+        ]);
+        assert_eq!(
+            row.columns,
+            vec![
+                Some(DbValue::Value(CqlValue::BigInt(7))),
+                Some(DbValue::Vector(Vector::from(vec![1.0, 2.0]))),
+                Some(DbValue::Value(CqlValue::Text("red".to_string()))),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_non_float_vector_column_stays_a_cql_value() {
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Int)),
+            dimensions: 2,
+        };
+        let cells = [1i32, 2].iter().flat_map(|i| i.to_be_bytes()).collect();
+        let row = deserialize_row(&[(spec("ints", typ), Some(cells))]);
+        assert_eq!(
+            row.columns,
+            vec![Some(DbValue::Value(CqlValue::Vector(vec![
+                CqlValue::Int(1),
+                CqlValue::Int(2),
+            ])))]
+        );
+    }
+}

--- a/crates/vector-store/src/lib.rs
+++ b/crates/vector-store/src/lib.rs
@@ -11,6 +11,7 @@ pub mod db;
 mod db_cdc;
 pub mod db_index;
 mod db_index_backend;
+mod db_value;
 mod distance;
 mod engine;
 mod file_monitor;

--- a/crates/vector-store/src/vector.rs
+++ b/crates/vector-store/src/vector.rs
@@ -7,6 +7,12 @@ use crate::Dimensions;
 use crate::alternator;
 use anyhow::anyhow;
 use anyhow::bail;
+use scylla::cluster::metadata::ColumnType;
+use scylla::cluster::metadata::NativeType;
+use scylla::deserialize::DeserializationError;
+use scylla::deserialize::FrameSlice;
+use scylla::deserialize::TypeCheckError;
+use scylla::deserialize::value::DeserializeValue;
 use scylla::value::CqlValue;
 use std::num::NonZeroUsize;
 
@@ -60,6 +66,48 @@ impl TryFrom<CqlValue> for Vector {
     }
 }
 
+/// A failure of [`Vector`] decoding, reported through the driver's error
+/// types, which require [`std::error::Error`].
+#[derive(Debug, thiserror::Error)]
+enum EmbeddingColumnError {
+    #[error("unsupported CQL type for an embedding column: {0:?}")]
+    UnsupportedType(ColumnType<'static>),
+    #[error("invalid Alternator embedding: {0:#}")]
+    Alternator(anyhow::Error),
+}
+
+/// Deserializes a [`Vector`] straight out of the frame, accepting both
+/// representations an embedding column can have: a native
+/// `vector<float, N>`, deserialized by the driver's [`Vec<f32>`]
+/// deserializer, and a blob, which is an Alternator embedding.
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for Vector {
+    fn type_check(typ: &ColumnType) -> Result<(), TypeCheckError> {
+        match typ {
+            ColumnType::Vector { .. } => <Vec<f32>>::type_check(typ),
+            ColumnType::Native(NativeType::Blob) => Ok(()),
+            other => Err(TypeCheckError::new(EmbeddingColumnError::UnsupportedType(
+                other.clone().into_owned(),
+            ))),
+        }
+    }
+
+    fn deserialize(
+        typ: &'metadata ColumnType<'metadata>,
+        v: Option<FrameSlice<'frame>>,
+    ) -> Result<Self, DeserializationError> {
+        match typ {
+            ColumnType::Vector { .. } => <Vec<f32>>::deserialize(typ, v).map(Self::from),
+            // Type-checked above
+            _ => {
+                let bytes = <&'frame [u8]>::deserialize(typ, v)?;
+                alternator::parse_alternator_vector(bytes)
+                    .map(Self::from)
+                    .map_err(|err| DeserializationError::new(EmbeddingColumnError::Alternator(err)))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -82,6 +130,53 @@ mod tests {
             v.extend_from_slice(&f.to_be_bytes());
         }
         v
+    }
+
+    fn deserialize_cql_vector(floats: &[f32]) -> anyhow::Result<Vector> {
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Float)),
+            dimensions: floats.len() as u16,
+        };
+        let bytes: Vec<u8> = floats.iter().flat_map(|f| f.to_be_bytes()).collect();
+        deserialize_column(&typ, &bytes)
+    }
+
+    fn deserialize_blob(bytes: &[u8]) -> anyhow::Result<Vector> {
+        deserialize_column(&ColumnType::Native(NativeType::Blob), bytes)
+    }
+
+    fn deserialize_column(typ: &ColumnType<'static>, bytes: &[u8]) -> anyhow::Result<Vector> {
+        <Vector>::type_check(typ).map_err(|err| anyhow!("{err}"))?;
+        <Vector>::deserialize(typ, Some(FrameSlice::new_borrowed(bytes)))
+            .map_err(|err| anyhow!("{err}"))
+    }
+
+    #[test]
+    fn deserialize_from_cql_vector() {
+        let result = deserialize_cql_vector(&[1.0, 2.5, 3.0]).unwrap();
+        assert_eq!(result, Vector::from(vec![1.0, 2.5, 3.0]));
+    }
+
+    #[test]
+    fn deserialize_from_dynamodb_json_blob() {
+        let json = r#"{"L": [{"N": "123.4"}, {"N": "234.5"}, {"N": "345.6"}]}"#;
+        let result = deserialize_blob(&alternator_list_blob(json)).unwrap();
+        assert_eq!(result, Vector::from(vec![123.4, 234.5, 345.6]));
+    }
+
+    #[test]
+    fn deserialize_from_alternator_vector_blob() {
+        let result = deserialize_blob(&alternator_vector_blob(&[1.0, 2.5, 3.0])).unwrap();
+        assert_eq!(result, Vector::from(vec![1.0, 2.5, 3.0]));
+    }
+
+    #[test]
+    fn deserialize_rejects_a_wrong_vector_element_type() {
+        let typ = ColumnType::Vector {
+            typ: Box::new(ColumnType::Native(NativeType::Int)),
+            dimensions: 1,
+        };
+        assert!(<Vector>::type_check(&typ).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Reading an embedding through CqlValue materializes one 72-byte enum per
4-byte float, then walks it again to build the Vec<f32>. This PR removes this for both 
fetching vectors during the DiskANN graph traversal and during full-scan and CDC.
Other CQL types are still decoded the same way as before, including Alternator embeddings
which arrive as blobs.

Fixes: VECTOR-934