### PR TITLE
vector-store: bump diskann version to 0.57.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,8 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cbaae814e21834c53f28bf9fad0d29c3cd61f2c3bd38f2af496acb39625d25"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1837,8 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-inmem"
-version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6c17ef4e6628a4a09032f14ed3236039d494be7cf164f5d5e731b414501796"
 dependencies = [
  "bytemuck",
  "crossbeam-queue",
@@ -1854,8 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab785969c6dfb76f61ec107c1b0ba754556cec4a4f775d02c5d4bd4dd4e5385"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -1870,8 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4dd226bb7f1e0cd4e0cab323ea159b3d3973b72fa361aed999fdadb628bf4b"
 dependencies = [
  "cfg-if",
  "diskann-wide",
@@ -1880,8 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.55.0"
-source = "git+https://github.com/microsoft/DiskANN.git?rev=90f49467a7558bd53e01f61617c294611a96158d#90f49467a7558bd53e01f61617c294611a96158d"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0c7c27dd6d994860e09bb2873ab8d66a23279f8dbbd7f1f8d7f3c1d24e1548"
 dependencies = [
  "cfg-if",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ console-subscriber = "0.5.0"
 criterion = { version = "0.8.2", features = ["async_tokio"] }
 dashmap = "6.1.0"
 derive_more = { version = "2.0.1", features = ["full"] }
-diskann = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
-diskann-vector = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
-diskann-inmem = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
-diskann-utils = { git = "https://github.com/microsoft/DiskANN.git", rev = "90f49467a7558bd53e01f61617c294611a96158d" }
+diskann = "=0.57.0"
+diskann-vector = "=0.57.0"
+diskann-inmem = "=0.57.0"
+diskann-utils = "=0.57.0"
 dotenvy = "0.15.7"
 e2etest = "0.3.1"
 e2etest-dns = "0.1.0"

--- a/crates/vector-store/src/vs_index/diskann/mod.rs
+++ b/crates/vector-store/src/vs_index/diskann/mod.rs
@@ -480,10 +480,10 @@ async fn search<B: DiskannBackend>(
 
     let k = k.min(params.max_points.get());
     let l_value = params.l_default.get().max(k);
-    let knn = Knn::new(k, l_value, Some(params.beam_width.get()))
+    let knn = Knn::new(l_value, Some(params.beam_width.get()))
         .context("failed to build DiskANN search parameters")?;
 
-    let mut neighbors: Vec<Neighbor<PrimaryId>> = Vec::with_capacity(knn.k_value().get());
+    let mut neighbors: Vec<Neighbor<PrimaryId>> = Vec::with_capacity(k);
     let SearchStats { result_count, .. } = partition
         .index
         .search(
@@ -499,7 +499,7 @@ async fn search<B: DiskannBackend>(
     Ok(neighbors.into_iter().map(move |neighbor| {
         let raw_distance = match space_type {
             SpaceType::DotProduct => neighbor.distance() + 1.0,
-            _ => neighbor.distance(),
+            _ => *neighbor.distance(),
         };
         Distance::try_from((raw_distance, space_type, dimensions))
             .map(|distance| (*neighbor.id(), distance))

--- a/crates/vector-store/src/vs_index/diskann/scylla.rs
+++ b/crates/vector-store/src/vs_index/diskann/scylla.rs
@@ -1027,7 +1027,10 @@ impl<'a> glue::SearchPostProcess<ScyllaSearchAccessor<'a>, &'a [f32], PrimaryId>
                 continue;
             };
 
-            if output.push(external, candidate.distance()).is_full() {
+            if output
+                .push(Neighbor::new(external, *candidate.distance()))
+                .is_full()
+            {
                 break;
             }
         }


### PR DESCRIPTION
We are opposed to having crates be pinned to a concrete rev, so we might as well bump the version to 0.57.0 and pin it.

Changes relevant to our implementation:
- Knn::k_value removed (#1151 (https://github.com/microsoft/DiskANN/pull/1151)) — mod.rs:483,486. Behavior-neutral: k_value was never read.
- SearchOutputBuffer::push takes Neighbor, not (id, distance) (#1284 (https://github.com/microsoft/DiskANN/pull/1284)) — scylla.rs:1030. 
- Neighbor::distance() returns a &D instead of D
- In-Mem 2.0 (#1206 (https://github.com/microsoft/DiskANN/pull/1206)) — listed as a 0.56.0 highlight but already in our old pin.

Full release notes: 
- v0.57.0 release notes (https://github.com/microsoft/DiskANN/releases/tag/v0.57.0) 
- v0.56.0 release notes (https://github.com/microsoft/DiskANN/releases/tag/v0.56.0)

