### PR TITLE
vector-store: fix concurrent reading schema version and index list

### DIFF
--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -53,6 +53,7 @@ use scylla::client::session_builder::SessionBuilder;
 use scylla::cluster::metadata::ColumnType;
 use scylla::cluster::metadata::NativeType;
 use scylla::cluster::metadata::Table;
+use scylla::statement::Consistency;
 use scylla::statement::prepared::PreparedStatement;
 use secrecy::ExposeSecret;
 use std::collections::BTreeMap;
@@ -61,6 +62,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tap::Pipe;
+use tap::Tap;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
@@ -94,6 +96,7 @@ type GetVsIndexParamsR = anyhow::Result<
 >;
 type GetFtsIndexParamsR = anyhow::Result<Option<IndexOptionsFts>>;
 type IsValidIndexR = bool;
+type IsValidSchemaR = bool;
 
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -140,16 +143,21 @@ pub enum Db {
         tx: oneshot::Sender<GetFtsIndexParamsR>,
     },
 
-    // Schema changes are concurrent processes without an atomic view from the client/driver side.
-    // A process of retrieving an index metadata from the vector-store could be faster than similar
-    // process in a driver itself. The vector-store reads some schema metadata from system tables
-    // directly, because they are not available from a rust driver, and it reads some other schema
-    // metadata from the rust driver, so there must be an agreement between data read directly from
-    // a db and a driver. This message checks if index metadata are correct and if there is an
-    // agreement on a db schema in the rust driver.
+    // The vector-store reads some schema metadata from system tables directly, because they are
+    // not available from a rust driver, and it reads some other schema metadata from the rust
+    // driver, so there must be an agreement between data read directly from a db and a driver.
+    // This message checks if index metadata are aligned between a vector-store and a rust driver.
     IsValidIndex {
         metadata: IndexMetadata,
         tx: oneshot::Sender<IsValidIndexR>,
+    },
+
+    // Schema changes are concurrently processed and a vector-store uses system tables which are
+    // in LocalStrategy, so we need to check if the latest schema_version didn't change and
+    // is agreed between all nodes in a cluster.
+    IsValidSchema {
+        schema_version: Uuid,
+        tx: oneshot::Sender<IsValidSchemaR>,
     },
 }
 
@@ -190,6 +198,8 @@ pub(crate) trait DbExt {
     ) -> GetFtsIndexParamsR;
 
     async fn is_valid_index(&self, metadata: IndexMetadata) -> IsValidIndexR;
+
+    async fn is_valid_schema(&self, schema_version: Uuid) -> IsValidSchemaR;
 }
 
 impl DbExt for mpsc::Sender<Db> {
@@ -288,6 +298,15 @@ impl DbExt for mpsc::Sender<Db> {
             .expect("DbExt::is_valid_index: internal actor should receive request");
         rx.await
             .expect("DbExt::is_valid_index: internal actor should send response")
+    }
+
+    async fn is_valid_schema(&self, schema_version: Uuid) -> IsValidSchemaR {
+        let (tx, rx) = oneshot::channel();
+        self.send(Db::IsValidSchema { schema_version, tx })
+            .await
+            .expect("DbExt::is_valid_schema: internal actor should receive request");
+        rx.await
+            .expect("DbExt::is_valid_schema: internal actor should send response")
     }
 }
 
@@ -428,6 +447,9 @@ fn respond_with_error(msg: Db, error: anyhow::Error) {
         Db::IsValidIndex { tx, .. } => {
             let _ = tx.send(false);
         }
+        Db::IsValidSchema { tx, .. } => {
+            let _ = tx.send(false);
+        }
     }
 }
 
@@ -505,6 +527,10 @@ async fn process(
         Db::IsValidIndex { metadata, tx } => tx
             .send(statements.is_valid_index(metadata).await)
             .unwrap_or_else(|_| trace!("process: Db::IsValidIndex: unable to send response")),
+
+        Db::IsValidSchema { schema_version, tx } => tx
+            .send(statements.is_valid_schema(schema_version).await)
+            .unwrap_or_else(|_| trace!("process: Db::IsValidSchema: unable to send response")),
     }
 }
 
@@ -741,7 +767,14 @@ impl Statements {
             st_latest_schema_version: session
                 .prepare(Self::ST_LATEST_SCHEMA_VERSION)
                 .await
-                .context("ST_LATEST_SCHEMA_VERSION")?,
+                .context("ST_LATEST_SCHEMA_VERSION")?
+                .tap_mut(|stmt| {
+                    // Use ONE consistency for schema version queries - this is a local query
+                    // that reads from system.local, so ONE is appropriate. During reading
+                    // indexes list we will check the schema agreement.
+                    stmt.set_consistency(Consistency::One);
+                    stmt.set_is_idempotent(true);
+                }),
 
             st_get_indexes: session
                 .prepare(Self::ST_GET_INDEXES)
@@ -785,11 +818,9 @@ impl Statements {
     }
 
     const ST_LATEST_SCHEMA_VERSION: &str = "
-        SELECT state_id
-        FROM system.group0_history
-        WHERE key = 'history'
-        ORDER BY state_id DESC
-        LIMIT 1
+        SELECT schema_version
+        FROM system.local
+        WHERE key='local'
         ";
 
     async fn latest_schema_version(&self) -> LatestSchemaVersionR {
@@ -1045,10 +1076,6 @@ impl Statements {
             debug!("is_valid_index: no active session for {}", metadata.key());
             return false;
         };
-        let Ok(version_begin) = session.await_schema_agreement().await else {
-            debug!("is_valid_index: schema not agreed for {}", metadata.key());
-            return false;
-        };
         let cluster_state = session.get_cluster_state();
 
         // check a keyspace
@@ -1081,15 +1108,19 @@ impl Statements {
             return false;
         }
 
-        // check if schema version changed
-        let Ok(Some(version_end)) = session.check_schema_agreement().await else {
-            debug!(
-                "is_valid_index: schema not agreed for {} finally",
-                metadata.key()
-            );
+        true
+    }
+
+    async fn is_valid_schema(&self, schema_version: Uuid) -> IsValidSchemaR {
+        let Some(session) = self.session_rx.borrow().clone() else {
+            debug!("is_valid_schema: no active session");
             return false;
         };
-        version_begin == version_end
+        let Ok(Some(agreed_version)) = session.check_schema_agreement().await else {
+            debug!("is_valid_schema: schema not agreed");
+            return false;
+        };
+        agreed_version == schema_version
     }
 }
 
@@ -1367,6 +1398,12 @@ pub(crate) mod tests {
             metadata: IndexMetadata,
             tx: oneshot::Sender<IsValidIndexR>,
         ) -> impl Future<Output = ()> + Send + 'static;
+
+        fn is_valid_schema(
+            &self,
+            schema_version: Uuid,
+            tx: oneshot::Sender<IsValidSchemaR>,
+        ) -> impl Future<Output = ()> + Send + 'static;
     }
 
     pub(crate) fn new(sim: impl SimDb + Send + 'static) -> mpsc::Sender<Db> {
@@ -1421,6 +1458,10 @@ pub(crate) mod tests {
                         } => sim.get_fts_index_params(keyspace, table, index, tx).await,
 
                         Db::IsValidIndex { metadata, tx } => sim.is_valid_index(metadata, tx).await,
+
+                        Db::IsValidSchema { schema_version, tx } => {
+                            sim.is_valid_schema(schema_version, tx).await
+                        }
                     }
                 }
 

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -54,7 +54,6 @@ use scylla::cluster::metadata::ColumnType;
 use scylla::cluster::metadata::NativeType;
 use scylla::cluster::metadata::Table;
 use scylla::statement::prepared::PreparedStatement;
-use scylla::value::CqlTimeuuid;
 use secrecy::ExposeSecret;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
@@ -80,7 +79,7 @@ type GetDbIndexR = anyhow::Result<(
     mpsc::Sender<DbIndex>,
     mpsc::Receiver<(DbIndexedRow, AsyncInProgress)>,
 )>;
-pub(crate) type LatestSchemaVersionR = anyhow::Result<Option<CqlTimeuuid>>;
+pub(crate) type LatestSchemaVersionR = anyhow::Result<Option<Uuid>>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;
 type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;
 type GetIndexTargetTypeR = anyhow::Result<Option<Dimensions>>;
@@ -802,10 +801,10 @@ impl Statements {
         Ok(session
             .execute_iter(self.st_latest_schema_version.clone(), &[])
             .await?
-            .rows_stream::<(CqlTimeuuid,)>()?
+            .rows_stream::<(Uuid,)>()?
             .try_next()
             .await?
-            .map(|(timeuuid,)| timeuuid))
+            .map(|(uuid,)| uuid))
     }
 
     const ST_GET_INDEXES: &str = "

--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -79,7 +79,7 @@ type GetDbIndexR = anyhow::Result<(
     mpsc::Sender<DbIndex>,
     mpsc::Receiver<(DbIndexedRow, AsyncInProgress)>,
 )>;
-pub(crate) type LatestSchemaVersionR = anyhow::Result<Option<Uuid>>;
+pub(crate) type LatestSchemaVersionR = anyhow::Result<Uuid>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;
 type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;
 type GetIndexTargetTypeR = anyhow::Result<Option<Dimensions>>;
@@ -799,12 +799,11 @@ impl Statements {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("No active session"))?;
         Ok(session
-            .execute_iter(self.st_latest_schema_version.clone(), &[])
+            .execute_unpaged(&self.st_latest_schema_version, &[])
             .await?
-            .rows_stream::<(Uuid,)>()?
-            .try_next()
-            .await?
-            .map(|(uuid,)| uuid))
+            .into_rows_result()?
+            .single_row::<(Uuid,)>()?
+            .0)
     }
 
     const ST_GET_INDEXES: &str = "

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -26,7 +26,6 @@ use crate::perf;
 use anyhow::bail;
 use futures::StreamExt;
 use futures::stream;
-use scylla::value::CqlTimeuuid;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -42,6 +41,7 @@ use tracing::debug;
 use tracing::error_span;
 use tracing::info;
 use tracing::warn;
+use uuid::Uuid;
 
 pub(crate) enum MonitorIndexes {}
 
@@ -152,8 +152,7 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
-#[derive(PartialEq)]
-struct SchemaVersion(Option<CqlTimeuuid>);
+struct SchemaVersion(Option<Uuid>);
 
 impl SchemaVersion {
     fn new() -> Self {
@@ -453,8 +452,8 @@ mod tests {
 
     #[tokio::test]
     async fn schema_version_changed() {
-        let version1 = CqlTimeuuid::from_bytes([1; 16]);
-        let version2 = CqlTimeuuid::from_bytes([2; 16]);
+        let version1 = Uuid::new_v4();
+        let version2 = Uuid::new_v4();
         let latest_schema_version: Arc<Mutex<Option<LatestSchemaVersionR>>> =
             Arc::new(Mutex::new(None));
         let set_latest_schema_version = |v| {
@@ -550,7 +549,7 @@ mod tests {
             // The indexes that the engine currently has
             engine_indexes: Arc<Mutex<IndexesT>>,
             // Schema version counter
-            schema_version: Arc<Mutex<u16>>,
+            schema_version: Arc<Mutex<Uuid>>,
             // Indexes version map
             index_versions: Arc<Mutex<HashMap<IndexName, Uuid>>>,
             // Notify to signal changes
@@ -564,7 +563,7 @@ mod tests {
                 Self {
                     db_indexes: Arc::new(Mutex::new(Vec::new())),
                     engine_indexes: Arc::new(Mutex::new(HashSet::new())),
-                    schema_version: Arc::new(Mutex::new(0)),
+                    schema_version: Arc::new(Mutex::new(Uuid::new_v4())),
                     index_versions: Arc::new(Mutex::new(HashMap::new())),
                     notify: Arc::new(Notify::new()),
                     del_calls: Arc::new(Mutex::new(HashMap::new())),
@@ -573,7 +572,7 @@ mod tests {
 
             async fn add_index(&self, index: DbCustomIndex) {
                 self.db_indexes.lock().unwrap().push(index);
-                *self.schema_version.lock().unwrap() += 1;
+                *self.schema_version.lock().unwrap() = Uuid::new_v4();
                 self.notify.notified().await;
             }
 
@@ -582,7 +581,7 @@ mod tests {
                     .lock()
                     .unwrap()
                     .retain(|idx| idx.index != index_name);
-                *self.schema_version.lock().unwrap() += 1;
+                *self.schema_version.lock().unwrap() = Uuid::new_v4();
                 self.notify.notified().await;
             }
 
@@ -647,9 +646,7 @@ mod tests {
                 let state = state.clone();
                 async move {
                     let version = *state.schema_version.lock().unwrap();
-                    let version_bytes = [version as u8; 16];
-                    tx.send(Ok(Some(CqlTimeuuid::from_bytes(version_bytes))))
-                        .unwrap();
+                    tx.send(Ok(Some(version))).unwrap();
                 }
                 .boxed()
             }

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -152,18 +152,19 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
-struct SchemaVersion(Option<Uuid>);
+struct SchemaVersion(Uuid);
 
 impl SchemaVersion {
     fn new() -> Self {
-        Self(None)
+        Self(Uuid::nil())
     }
 
     async fn has_changed(&mut self, db: &Sender<Db>) -> bool {
-        let schema_version = db.latest_schema_version().await.unwrap_or_else(|err| {
+        let Ok(schema_version) = db.latest_schema_version().await.inspect_err(|err| {
             warn!("unable to get latest schema change from db: {err}");
-            None
-        });
+        }) else {
+            return false;
+        };
         if self.0 == schema_version {
             return false;
         };
@@ -172,7 +173,7 @@ impl SchemaVersion {
     }
 
     fn reset(&mut self) {
-        self.0 = None;
+        self.0 = Uuid::nil();
     }
 }
 
@@ -486,36 +487,20 @@ mod tests {
         set_latest_schema_version(Err(anyhow!("test issue")));
         assert!(!sv.has_changed(&tx_db).await);
 
-        // step 2: None should not change the schema version
-        set_latest_schema_version(Ok(None));
-        assert!(!sv.has_changed(&tx_db).await);
-
-        // step 3: value1 should change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
+        // step 2: value1 should change the schema version
+        set_latest_schema_version(Ok(version1));
         assert!(sv.has_changed(&tx_db).await);
 
-        // step 4: Err should change the schema version
+        // step 3: Err shouldn't change the schema version
         set_latest_schema_version(Err(anyhow!("test issue")));
-        assert!(sv.has_changed(&tx_db).await);
-
-        // step 5: value1 should change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
-        assert!(sv.has_changed(&tx_db).await);
-
-        // step 6: None should change the schema version
-        set_latest_schema_version(Ok(None));
-        assert!(sv.has_changed(&tx_db).await);
-
-        // step 7: value1 should change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
-        assert!(sv.has_changed(&tx_db).await);
-
-        // step 8: value1 should not change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
         assert!(!sv.has_changed(&tx_db).await);
 
-        // step 9: value2 should change the schema version
-        set_latest_schema_version(Ok(Some(version2)));
+        // step 4: value1 shouldn't change the schema version
+        set_latest_schema_version(Ok(version1));
+        assert!(!sv.has_changed(&tx_db).await);
+
+        // step 5: value2 should change the schema version
+        set_latest_schema_version(Ok(version2));
         assert!(sv.has_changed(&tx_db).await);
     }
 
@@ -646,7 +631,7 @@ mod tests {
                 let state = state.clone();
                 async move {
                     let version = *state.schema_version.lock().unwrap();
-                    tx.send(Ok(Some(version))).unwrap();
+                    tx.send(Ok(version)).unwrap();
                 }
                 .boxed()
             }

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -82,13 +82,13 @@ pub(crate) async fn new(
                         };
 
                         // check if schema has changed from the last time
-                        if !schema_version.has_changed(&db).await {
+                        let Some(version) = schema_version.has_changed(&db).await else {
                             continue;
-                        }
+                        };
                         node_state.send_event(
                             Event::DiscoveringIndexes,
                         ).await;
-                        let Ok(new_indexes) = get_indexes(&db).await.inspect_err(|err| {
+                        let Ok(new_indexes) = get_indexes(&db, version).await.inspect_err(|err| {
                             info!("monitor_indexes: unable to get the list of indexes: {err}");
                         }) else {
                             // there was an error during retrieving indexes, reset schema version
@@ -159,17 +159,17 @@ impl SchemaVersion {
         Self(Uuid::nil())
     }
 
-    async fn has_changed(&mut self, db: &Sender<Db>) -> bool {
+    async fn has_changed(&mut self, db: &Sender<Db>) -> Option<Uuid> {
         let Ok(schema_version) = db.latest_schema_version().await.inspect_err(|err| {
             warn!("unable to get latest schema change from db: {err}");
         }) else {
-            return false;
+            return None;
         };
         if self.0 == schema_version {
-            return false;
+            return None;
         };
         self.0 = schema_version;
-        true
+        Some(schema_version)
     }
 
     fn reset(&mut self) {
@@ -177,7 +177,15 @@ impl SchemaVersion {
     }
 }
 
-async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> {
+async fn get_indexes(
+    db: &Sender<Db>,
+    schema_version: Uuid,
+) -> anyhow::Result<HashSet<IndexMetadata>> {
+    if !db.is_valid_schema(schema_version).await {
+        let msg = format!("get_indexes: not valid schema {schema_version} at the start");
+        debug!(msg);
+        bail!(msg);
+    }
     let mut indexes = HashSet::new();
     for idx in db.get_indexes().await?.into_iter() {
         let Some(version) = db
@@ -222,6 +230,11 @@ async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> 
         }
 
         indexes.insert(metadata);
+    }
+    if !db.is_valid_schema(schema_version).await {
+        let msg = format!("get_indexes: not valid schema {schema_version} at the end");
+        debug!(msg);
+        bail!(msg);
     }
     Ok(indexes)
 }
@@ -406,6 +419,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::collections::HashMap;
     use std::collections::HashSet;
+    use std::collections::VecDeque;
     use std::num::NonZeroUsize;
     use std::sync::Arc;
     use std::sync::Mutex;
@@ -485,23 +499,23 @@ mod tests {
 
         // step 1: Err should not change the schema version
         set_latest_schema_version(Err(anyhow!("test issue")));
-        assert!(!sv.has_changed(&tx_db).await);
+        assert_eq!(sv.has_changed(&tx_db).await, None);
 
         // step 2: value1 should change the schema version
         set_latest_schema_version(Ok(version1));
-        assert!(sv.has_changed(&tx_db).await);
+        assert_eq!(sv.has_changed(&tx_db).await, Some(version1));
 
         // step 3: Err shouldn't change the schema version
         set_latest_schema_version(Err(anyhow!("test issue")));
-        assert!(!sv.has_changed(&tx_db).await);
+        assert_eq!(sv.has_changed(&tx_db).await, None);
 
         // step 4: value1 shouldn't change the schema version
         set_latest_schema_version(Ok(version1));
-        assert!(!sv.has_changed(&tx_db).await);
+        assert_eq!(sv.has_changed(&tx_db).await, None);
 
         // step 5: value2 should change the schema version
         set_latest_schema_version(Ok(version2));
-        assert!(sv.has_changed(&tx_db).await);
+        assert_eq!(sv.has_changed(&tx_db).await, Some(version2));
     }
 
     #[rstest]
@@ -533,8 +547,11 @@ mod tests {
             db_indexes: Arc<Mutex<Vec<DbCustomIndex>>>,
             // The indexes that the engine currently has
             engine_indexes: Arc<Mutex<IndexesT>>,
-            // Schema version counter
+            // Schema version
             schema_version: Arc<Mutex<Uuid>>,
+            // Agreed schema versions for testing schema changes between latest schema version and
+            // get_indexes calls
+            schema_version_agreed: Arc<Mutex<VecDeque<Uuid>>>,
             // Indexes version map
             index_versions: Arc<Mutex<HashMap<IndexName, Uuid>>>,
             // Notify to signal changes
@@ -549,6 +566,7 @@ mod tests {
                     db_indexes: Arc::new(Mutex::new(Vec::new())),
                     engine_indexes: Arc::new(Mutex::new(HashSet::new())),
                     schema_version: Arc::new(Mutex::new(Uuid::new_v4())),
+                    schema_version_agreed: Arc::new(Mutex::new(VecDeque::new())),
                     index_versions: Arc::new(Mutex::new(HashMap::new())),
                     notify: Arc::new(Notify::new()),
                     del_calls: Arc::new(Mutex::new(HashMap::new())),
@@ -557,7 +575,12 @@ mod tests {
 
             async fn add_index(&self, index: DbCustomIndex) {
                 self.db_indexes.lock().unwrap().push(index);
-                *self.schema_version.lock().unwrap() = Uuid::new_v4();
+                let version = Uuid::new_v4();
+                *self.schema_version.lock().unwrap() = version;
+                self.schema_version_agreed
+                    .lock()
+                    .unwrap()
+                    .extend([version, Uuid::new_v4()]);
                 self.notify.notified().await;
             }
 
@@ -566,7 +589,12 @@ mod tests {
                     .lock()
                     .unwrap()
                     .retain(|idx| idx.index != index_name);
-                *self.schema_version.lock().unwrap() = Uuid::new_v4();
+                let version = Uuid::new_v4();
+                *self.schema_version.lock().unwrap() = version;
+                self.schema_version_agreed
+                    .lock()
+                    .unwrap()
+                    .extend([Uuid::new_v4(), version]);
                 self.notify.notified().await;
             }
 
@@ -699,11 +727,37 @@ mod tests {
             .boxed()
         });
 
+        mock_db.expect_is_valid_schema().returning({
+            let state = state.clone();
+            move |version, tx| {
+                let state = state.clone();
+                async move {
+                    let schema_version = state
+                        .schema_version_agreed
+                        .lock()
+                        .unwrap()
+                        .pop_front()
+                        .unwrap_or_else(|| *state.schema_version.lock().unwrap());
+                    tx.send(schema_version == version).unwrap();
+                }
+                .boxed()
+            }
+        });
+
         let tx_db = db::tests::new(mock_db);
         let tx_eng = engine::tests::new(mock_engine);
-        let (tx_ns, _rx_ns) = mpsc::channel(10);
 
-        let (_config_tx, config_rx) = watch::channel(Arc::new(Config::default()));
+        let (tx_ns, mut rx_ns) = mpsc::channel(10);
+        tokio::spawn(async move {
+            while let Some(_event) = rx_ns.recv().await {
+                // Just consume events for this test
+            }
+        });
+
+        let (_config_tx, config_rx) = watch::channel(Arc::new(Config {
+            monitor_indexes_interval: Some(Duration::from_millis(10)),
+            ..Config::default()
+        }));
 
         // Start the monitor
         let _monitor = new(tx_db.clone(), tx_eng.downgrade(), tx_ns.clone(), config_rx)
@@ -717,7 +771,18 @@ mod tests {
         let index2_key = index2.key();
 
         state.add_index(index1).await;
+
+        assert!(
+            state.schema_version_agreed.lock().unwrap().is_empty(),
+            "Agreed schema version should be reset"
+        );
+
         state.add_index(index2).await;
+
+        assert!(
+            state.schema_version_agreed.lock().unwrap().is_empty(),
+            "Agreed schema version should be reset"
+        );
 
         let engine_indexes = state.engine_indexes.lock().unwrap().clone();
         assert!(
@@ -733,6 +798,10 @@ mod tests {
             engine_indexes.contains(&index1_key) && !engine_indexes.contains(&index2_key),
             "Only index1 should remain"
         );
+        assert!(
+            state.schema_version_agreed.lock().unwrap().is_empty(),
+            "Agreed schema version should be reset"
+        );
 
         // Remove index1 from the list
         state.del_index(index1_key.index()).await;
@@ -741,6 +810,10 @@ mod tests {
         assert!(
             !engine_indexes.contains(&index1_key) && !engine_indexes.contains(&index2_key),
             "Both indexes should be removed"
+        );
+        assert!(
+            state.schema_version_agreed.lock().unwrap().is_empty(),
+            "Agreed schema version should be reset"
         );
 
         // Assert del_index called only once per index
@@ -835,15 +908,127 @@ mod tests {
             }
         });
 
+        mock_db.expect_is_valid_schema().returning(move |_, tx| {
+            async move {
+                tx.send(true).unwrap();
+            }
+            .boxed()
+        });
+
         let db = db::tests::new(mock_db);
 
         // all indexes are valid
         set_valid_indexes(vec![true, true, true]);
-        assert!(get_indexes(&db).await.is_ok());
+        assert!(get_indexes(&db, Uuid::new_v4()).await.is_ok());
 
         // second index is invalid
         set_valid_indexes(vec![true, false, true]);
-        assert!(get_indexes(&db).await.is_err());
+        assert!(get_indexes(&db, Uuid::new_v4()).await.is_err());
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn get_indexes_failed_while_schema_is_invalid() {
+        let valid_schemas: Arc<Mutex<Vec<Uuid>>> = Arc::new(Mutex::new(vec![]));
+        let set_valid_schemas = |v| {
+            *valid_schemas.lock().unwrap() = v;
+        };
+
+        let mut mock_db = MockSimDb::new();
+
+        mock_db.expect_get_indexes().returning({
+            move |tx| {
+                async move {
+                    let index = || DbCustomIndex {
+                        keyspace: "ks".to_string().into(),
+                        index: "idx".to_string().into(),
+                        table: "tbl".to_string().into(),
+                        primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+                        partition_key_count: NonZeroUsize::new(1).unwrap(),
+                        target_columns: NonemptyArc::new(["embedding"]).unwrap(),
+                        partitioning: DbIndexPartitioning::Global,
+                        filtering_columns: Arc::new([]),
+                        alternator_attribute_types: Arc::new(BTreeMap::new()),
+                        kind: DbIndexKind::VectorSearch,
+                    };
+                    tx.send(Ok(vec![index(), index(), index()])).unwrap();
+                }
+                .boxed()
+            }
+        });
+
+        mock_db.expect_get_index_version().returning({
+            move |_, _, _, tx| {
+                async move {
+                    tx.send(Ok(Some(Uuid::new_v4().into()))).unwrap();
+                }
+                .boxed()
+            }
+        });
+
+        mock_db
+            .expect_get_index_target_type()
+            .returning(move |_, _, _, _, tx| {
+                async move {
+                    tx.send(Ok(Some(NonZeroUsize::new(3).unwrap().into())))
+                        .unwrap();
+                }
+                .boxed()
+            });
+
+        mock_db
+            .expect_get_vs_index_params()
+            .returning(move |_, _, _, tx| {
+                async move {
+                    tx.send(Ok(Some((
+                        Default::default(),
+                        Default::default(),
+                        Default::default(),
+                        Default::default(),
+                        Default::default(),
+                    ))))
+                    .unwrap();
+                }
+                .boxed()
+            });
+
+        mock_db.expect_is_valid_index().returning({
+            move |_, tx| {
+                async move {
+                    tx.send(true).unwrap();
+                }
+                .boxed()
+            }
+        });
+
+        mock_db.expect_is_valid_schema().returning({
+            let valid_schemas = Arc::clone(&valid_schemas);
+            move |version, tx| {
+                let valid_schemas = Arc::clone(&valid_schemas);
+                async move {
+                    tx.send(valid_schemas.lock().unwrap().remove(0) == version)
+                        .unwrap();
+                }
+                .boxed()
+            }
+        });
+
+        let db = db::tests::new(mock_db);
+
+        let schema_version = Uuid::new_v4();
+
+        // all schemas are valid
+        set_valid_schemas(vec![schema_version, schema_version]);
+        assert!(get_indexes(&db, schema_version).await.is_ok());
+
+        // schema at the start is invalid
+        set_valid_schemas(vec![Uuid::new_v4(), schema_version]);
+        assert!(get_indexes(&db, schema_version).await.is_err());
+
+        // schema at the end is invalid
+        set_valid_schemas(vec![schema_version, Uuid::new_v4()]);
+        assert!(get_indexes(&db, schema_version).await.is_err());
     }
 
     #[rstest]
@@ -884,9 +1069,16 @@ mod tests {
                 .boxed()
             });
 
+        mock_db.expect_is_valid_schema().returning(move |_, tx| {
+            async move {
+                tx.send(true).unwrap();
+            }
+            .boxed()
+        });
+
         let db = db::tests::new(mock_db);
 
-        assert!(get_indexes(&db).await.is_err());
+        assert!(get_indexes(&db, Uuid::new_v4()).await.is_err());
     }
 
     fn mock_db_with_fts_index(options: Option<IndexOptionsFts>) -> MockSimDb {
@@ -936,6 +1128,13 @@ mod tests {
             .boxed()
         });
 
+        mock_db.expect_is_valid_schema().returning(move |_, tx| {
+            async move {
+                tx.send(true).unwrap();
+            }
+            .boxed()
+        });
+
         mock_db
     }
 
@@ -947,7 +1146,7 @@ mod tests {
         };
         let db = db::tests::new(mock_db_with_fts_index(Some(options)));
 
-        let result = get_indexes(&db).await.unwrap();
+        let result = get_indexes(&db, Uuid::new_v4()).await.unwrap();
 
         assert_eq!(result.len(), 1);
         let idx = result.into_iter().next().unwrap();
@@ -959,7 +1158,7 @@ mod tests {
     async fn get_indexes_defaults_fts_options_when_db_has_none() {
         let db = db::tests::new(mock_db_with_fts_index(None));
 
-        let result = get_indexes(&db).await.unwrap();
+        let result = get_indexes(&db, Uuid::new_v4()).await.unwrap();
 
         let idx = result.into_iter().next().unwrap();
         assert_eq!(idx.kind, IndexKind::Fts(IndexOptionsFts::default()));

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -8,7 +8,6 @@ use anyhow::bail;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use scylla::cluster::metadata::NativeType;
-use scylla::value::CqlTimeuuid;
 use scylla::value::CqlValue;
 use std::collections::HashMap;
 use std::iter;
@@ -208,7 +207,7 @@ impl Keyspace {
 }
 
 struct DbMock {
-    schema_version: CqlTimeuuid,
+    schema_version: Uuid,
     keyspaces: HashMap<KeyspaceName, Keyspace>,
     next_get_db_index_failed: bool,
     next_full_scan_progress: Option<Progress>,
@@ -219,14 +218,14 @@ struct DbMock {
 
 impl DbMock {
     fn create_new_schema_version(&mut self) {
-        self.schema_version = Uuid::new_v4().into();
+        self.schema_version = Uuid::new_v4();
     }
 }
 
 impl DbBasic {
     fn new(store_vectors: StoreVectors) -> Self {
         Self(Arc::new(RwLock::new(DbMock {
-            schema_version: CqlTimeuuid::from(Uuid::new_v4()),
+            schema_version: Uuid::new_v4(),
             keyspaces: HashMap::new(),
             next_get_db_index_failed: false,
             next_full_scan_progress: None,

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -380,7 +380,7 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
             .unwrap(),
 
         Db::LatestSchemaVersion { tx } => tx
-            .send(Ok(Some(db.0.read().unwrap().schema_version)))
+            .send(Ok(db.0.read().unwrap().schema_version))
             .map_err(|_| anyhow!("Db::LatestSchemaVersion: unable to send response"))
             .unwrap(),
 

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -520,6 +520,11 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
             .send(true)
             .map_err(|_| anyhow!("Db::IsValidIndex: unable to send response"))
             .unwrap(),
+
+        Db::IsValidSchema { tx, .. } => tx
+            .send(true)
+            .map_err(|_| anyhow!("Db::IsValidSchema: unable to send response"))
+            .unwrap(),
     }
 }
 


### PR DESCRIPTION
Currently, monitor_indexes reads schema version and index list in concurrent approach. Reading schema version is done using state_id from system.group0_history.  Reading indexes is done using system_schema.indexes which is guarded by checking if schema version is agreed in available nodes. So there are 3 tables, and there is some time to propagate schema changes (adding/removing index) around scylla cluster. We are using concurrent reads which can interlace. For this reason there is a possibility (and it happens in validator tests) that index list is read from the node that has no actual index list. In that case the number of indexes can be wrong up to the next schema change.

This PR removes usage of group0_history.state_id and use schema_version instead. It facilitates possibility to additional validate of index list by providing schema_version retrieved before. In db.is_valid_schema we check if agreed schema_version is equal to the previous one. If not, we will repeat reading indexes again in the next tick interval. We can read schema_version from only one node for triggering indexes check as it will be validated over agreed value further.

This PR removes guard of checking agreed schema_version in db.is_valid_index as it needs to be done in caller. Therefore, this check is done using db.is_valid_schema in monitor_indexes actor.

This PR refactors get_latest_schema_version and adds is_valid_schema messages to the db actor.

Fixes: VECTOR-905
Fixes: VECTOR-906
Fixes: VECTOR-908