### PR TITLE
vector-store: pin the index listing to the schema-version coordinator

### DIFF
--- a/crates/vector-store/src/db.rs
+++ b/crates/vector-store/src/db.rs
@@ -53,6 +53,8 @@ use scylla::client::session_builder::SessionBuilder;
 use scylla::cluster::metadata::ColumnType;
 use scylla::cluster::metadata::NativeType;
 use scylla::cluster::metadata::Table;
+use scylla::policies::load_balancing::NodeIdentifier;
+use scylla::policies::load_balancing::SingleTargetLoadBalancingPolicy;
 use scylla::statement::prepared::PreparedStatement;
 use scylla::value::CqlTimeuuid;
 use secrecy::ExposeSecret;
@@ -80,7 +82,7 @@ type GetDbIndexR = anyhow::Result<(
     mpsc::Sender<DbIndex>,
     mpsc::Receiver<(DbIndexedRow, AsyncInProgress)>,
 )>;
-pub(crate) type LatestSchemaVersionR = anyhow::Result<Option<CqlTimeuuid>>;
+pub(crate) type LatestSchemaVersionR = anyhow::Result<SchemaVersionSnapshot>;
 type GetIndexesR = anyhow::Result<Vec<DbCustomIndex>>;
 type GetIndexVersionR = anyhow::Result<Option<IndexVersion>>;
 type GetIndexTargetTypeR = anyhow::Result<Option<Dimensions>>;
@@ -96,6 +98,18 @@ type GetVsIndexParamsR = anyhow::Result<
 type GetFtsIndexParamsR = anyhow::Result<Option<IndexOptionsFts>>;
 type IsValidIndexR = bool;
 
+/// The cluster schema version as a single node reported it.
+///
+/// `system` and `system_schema` are node-local, and a group0 command is applied
+/// on each node on its own, so the version is only meaningful together with the
+/// node that served it. `coordinator` lets a caller send its follow-up schema
+/// reads to that same node.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SchemaVersionSnapshot {
+    pub version: Option<CqlTimeuuid>,
+    pub coordinator: Option<Uuid>,
+}
+
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub enum Db {
@@ -109,6 +123,7 @@ pub enum Db {
     },
 
     GetIndexes {
+        coordinator: Option<Uuid>,
         tx: oneshot::Sender<GetIndexesR>,
     },
 
@@ -159,7 +174,7 @@ pub(crate) trait DbExt {
 
     async fn latest_schema_version(&self) -> LatestSchemaVersionR;
 
-    async fn get_indexes(&self) -> GetIndexesR;
+    async fn get_indexes(&self, coordinator: Option<Uuid>) -> GetIndexesR;
 
     async fn get_index_version(
         &self,
@@ -206,9 +221,9 @@ impl DbExt for mpsc::Sender<Db> {
         rx.await?
     }
 
-    async fn get_indexes(&self) -> GetIndexesR {
+    async fn get_indexes(&self, coordinator: Option<Uuid>) -> GetIndexesR {
         let (tx, rx) = oneshot::channel();
-        self.send(Db::GetIndexes { tx }).await?;
+        self.send(Db::GetIndexes { coordinator, tx }).await?;
         rx.await?
     }
 
@@ -411,7 +426,7 @@ fn respond_with_error(msg: Db, error: anyhow::Error) {
         Db::LatestSchemaVersion { tx } => {
             let _ = tx.send(Err(error));
         }
-        Db::GetIndexes { tx } => {
+        Db::GetIndexes { tx, .. } => {
             let _ = tx.send(Err(error));
         }
         Db::GetIndexVersion { tx, .. } => {
@@ -454,8 +469,8 @@ async fn process(
                 trace!("process: Db::LatestSchemaVersion: unable to send response")
             }),
 
-        Db::GetIndexes { tx } => tx
-            .send(statements.get_indexes().await)
+        Db::GetIndexes { coordinator, tx } => tx
+            .send(statements.get_indexes(coordinator).await)
             .unwrap_or_else(|_| trace!("process: Db::GetIndexes: unable to send response")),
 
         Db::GetIndexVersion {
@@ -799,13 +814,19 @@ impl Statements {
             .borrow()
             .clone()
             .ok_or_else(|| anyhow::anyhow!("No active session"))?;
-        Ok(session
+        let mut rows = session
             .execute_iter(self.st_latest_schema_version.clone(), &[])
             .await?
-            .rows_stream::<(CqlTimeuuid,)>()?
-            .try_next()
-            .await?
-            .map(|(timeuuid,)| timeuuid))
+            .rows_stream::<(CqlTimeuuid,)>()?;
+        let version = rows.try_next().await?.map(|(timeuuid,)| timeuuid);
+        let coordinator = rows
+            .request_coordinators()
+            .next()
+            .map(|coordinator| coordinator.node().host_id);
+        Ok(SchemaVersionSnapshot {
+            version,
+            coordinator,
+        })
     }
 
     const ST_GET_INDEXES: &str = "
@@ -815,7 +836,7 @@ impl Statements {
         ALLOW FILTERING
         ";
 
-    async fn get_indexes(&self) -> GetIndexesR {
+    async fn get_indexes(&self, coordinator: Option<Uuid>) -> GetIndexesR {
         let session = self
             .session_rx
             .borrow()
@@ -826,7 +847,7 @@ impl Statements {
         struct InvalidMetadata;
 
         let result = session
-            .execute_iter(self.st_get_indexes.clone(), &[])
+            .execute_iter(pin_to_coordinator(&self.st_get_indexes, coordinator), &[])
             .await?
             .rows_stream::<(String, String, String, BTreeMap<String, String>)>()?
             .map_err(|err| anyhow::anyhow!("Failed to fetch indexes: {}", err))
@@ -1186,6 +1207,24 @@ fn convert_legacy_target_option(
     })
 }
 
+/// Sends `statement` to `coordinator` instead of letting the driver pick a node.
+///
+/// `system` and `system_schema` are node-local, so a schema read is only
+/// comparable with another schema read served by the same node.
+fn pin_to_coordinator(
+    statement: &PreparedStatement,
+    coordinator: Option<Uuid>,
+) -> PreparedStatement {
+    let mut statement = statement.clone();
+    if let Some(host_id) = coordinator {
+        statement.set_load_balancing_policy(Some(SingleTargetLoadBalancingPolicy::new(
+            NodeIdentifier::HostId(host_id),
+            None,
+        )));
+    }
+    statement
+}
+
 fn db_index_kind_from_options(options: &mut BTreeMap<String, String>) -> Option<DbIndexKind> {
     match options.remove("class_name").as_deref() {
         Some("vector_index") | None => Some(DbIndexKind::VectorSearch),
@@ -1328,6 +1367,7 @@ pub(crate) mod tests {
 
         fn get_indexes(
             &self,
+            coordinator: Option<Uuid>,
             tx: oneshot::Sender<GetIndexesR>,
         ) -> impl Future<Output = ()> + Send + 'static;
 
@@ -1388,7 +1428,9 @@ pub(crate) mod tests {
 
                         Db::LatestSchemaVersion { tx } => sim.latest_schema_version(tx).await,
 
-                        Db::GetIndexes { tx } => sim.get_indexes(tx).await,
+                        Db::GetIndexes { coordinator, tx } => {
+                            sim.get_indexes(coordinator, tx).await
+                        }
 
                         Db::GetIndexVersion {
                             keyspace,

--- a/crates/vector-store/src/monitor_indexes.rs
+++ b/crates/vector-store/src/monitor_indexes.rs
@@ -17,6 +17,7 @@ use crate::Quantization;
 use crate::SpaceType;
 use crate::db::Db;
 use crate::db::DbExt;
+use crate::db::SchemaVersionSnapshot;
 use crate::engine::Engine;
 use crate::engine::EngineExt;
 use crate::node_state::Event;
@@ -42,6 +43,7 @@ use tracing::debug;
 use tracing::error_span;
 use tracing::info;
 use tracing::warn;
+use uuid::Uuid;
 
 pub(crate) enum MonitorIndexes {}
 
@@ -82,13 +84,13 @@ pub(crate) async fn new(
                         };
 
                         // check if schema has changed from the last time
-                        if !schema_version.has_changed(&db).await {
+                        let SchemaChange::Changed { coordinator } = schema_version.check(&db).await else {
                             continue;
-                        }
+                        };
                         node_state.send_event(
                             Event::DiscoveringIndexes,
                         ).await;
-                        let Ok(new_indexes) = get_indexes(&db).await.inspect_err(|err| {
+                        let Ok(new_indexes) = get_indexes(&db, coordinator).await.inspect_err(|err| {
                             info!("monitor_indexes: unable to get the list of indexes: {err}");
                         }) else {
                             // there was an error during retrieving indexes, reset schema version
@@ -152,6 +154,17 @@ pub(crate) async fn new(
     Ok(tx)
 }
 
+enum SchemaChange {
+    Unchanged,
+    /// The node that reported the new version. The rest of the round has to read
+    /// its schema from that same node: `system_schema` is node-local, and a
+    /// listing taken on a node whose schema is older than the reported version
+    /// silently omits the indexes that version added.
+    Changed {
+        coordinator: Option<Uuid>,
+    },
+}
+
 #[derive(PartialEq)]
 struct SchemaVersion(Option<CqlTimeuuid>);
 
@@ -160,16 +173,18 @@ impl SchemaVersion {
         Self(None)
     }
 
-    async fn has_changed(&mut self, db: &Sender<Db>) -> bool {
-        let schema_version = db.latest_schema_version().await.unwrap_or_else(|err| {
+    async fn check(&mut self, db: &Sender<Db>) -> SchemaChange {
+        let snapshot = db.latest_schema_version().await.unwrap_or_else(|err| {
             warn!("unable to get latest schema change from db: {err}");
-            None
+            SchemaVersionSnapshot::default()
         });
-        if self.0 == schema_version {
-            return false;
+        if self.0 == snapshot.version {
+            return SchemaChange::Unchanged;
         };
-        self.0 = schema_version;
-        true
+        self.0 = snapshot.version;
+        SchemaChange::Changed {
+            coordinator: snapshot.coordinator,
+        }
     }
 
     fn reset(&mut self) {
@@ -177,9 +192,12 @@ impl SchemaVersion {
     }
 }
 
-async fn get_indexes(db: &Sender<Db>) -> anyhow::Result<HashSet<IndexMetadata>> {
+async fn get_indexes(
+    db: &Sender<Db>,
+    coordinator: Option<Uuid>,
+) -> anyhow::Result<HashSet<IndexMetadata>> {
     let mut indexes = HashSet::new();
-    for idx in db.get_indexes().await?.into_iter() {
+    for idx in db.get_indexes(coordinator).await?.into_iter() {
         let Some(version) = db
             .get_index_version(idx.keyspace.clone(), idx.table.clone(), idx.index.clone())
             .await
@@ -451,6 +469,13 @@ mod tests {
         }
     }
 
+    fn snapshot(version: Option<CqlTimeuuid>) -> SchemaVersionSnapshot {
+        SchemaVersionSnapshot {
+            version,
+            coordinator: None,
+        }
+    }
+
     #[tokio::test]
     async fn schema_version_changed() {
         let version1 = CqlTimeuuid::from_bytes([1; 16]);
@@ -483,41 +508,45 @@ mod tests {
         let mut sv = SchemaVersion::new();
         let tx_db = db::tests::new(mock_db);
 
+        let has_changed = async |sv: &mut SchemaVersion| {
+            matches!(sv.check(&tx_db).await, SchemaChange::Changed { .. })
+        };
+
         // step 1: Err should not change the schema version
         set_latest_schema_version(Err(anyhow!("test issue")));
-        assert!(!sv.has_changed(&tx_db).await);
+        assert!(!has_changed(&mut sv).await);
 
         // step 2: None should not change the schema version
-        set_latest_schema_version(Ok(None));
-        assert!(!sv.has_changed(&tx_db).await);
+        set_latest_schema_version(Ok(snapshot(None)));
+        assert!(!has_changed(&mut sv).await);
 
         // step 3: value1 should change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
-        assert!(sv.has_changed(&tx_db).await);
+        set_latest_schema_version(Ok(snapshot(Some(version1))));
+        assert!(has_changed(&mut sv).await);
 
         // step 4: Err should change the schema version
         set_latest_schema_version(Err(anyhow!("test issue")));
-        assert!(sv.has_changed(&tx_db).await);
+        assert!(has_changed(&mut sv).await);
 
         // step 5: value1 should change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
-        assert!(sv.has_changed(&tx_db).await);
+        set_latest_schema_version(Ok(snapshot(Some(version1))));
+        assert!(has_changed(&mut sv).await);
 
         // step 6: None should change the schema version
-        set_latest_schema_version(Ok(None));
-        assert!(sv.has_changed(&tx_db).await);
+        set_latest_schema_version(Ok(snapshot(None)));
+        assert!(has_changed(&mut sv).await);
 
         // step 7: value1 should change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
-        assert!(sv.has_changed(&tx_db).await);
+        set_latest_schema_version(Ok(snapshot(Some(version1))));
+        assert!(has_changed(&mut sv).await);
 
         // step 8: value1 should not change the schema version
-        set_latest_schema_version(Ok(Some(version1)));
-        assert!(!sv.has_changed(&tx_db).await);
+        set_latest_schema_version(Ok(snapshot(Some(version1))));
+        assert!(!has_changed(&mut sv).await);
 
         // step 9: value2 should change the schema version
-        set_latest_schema_version(Ok(Some(version2)));
-        assert!(sv.has_changed(&tx_db).await);
+        set_latest_schema_version(Ok(snapshot(Some(version2))));
+        assert!(has_changed(&mut sv).await);
     }
 
     #[rstest]
@@ -648,7 +677,7 @@ mod tests {
                 async move {
                     let version = *state.schema_version.lock().unwrap();
                     let version_bytes = [version as u8; 16];
-                    tx.send(Ok(Some(CqlTimeuuid::from_bytes(version_bytes))))
+                    tx.send(Ok(snapshot(Some(CqlTimeuuid::from_bytes(version_bytes)))))
                         .unwrap();
                 }
                 .boxed()
@@ -657,7 +686,7 @@ mod tests {
 
         mock_db.expect_get_indexes().returning({
             let state = state.clone();
-            move |tx| {
+            move |_, tx| {
                 let state = state.clone();
                 async move {
                     let indexes = state.get_db_indexes();
@@ -787,7 +816,7 @@ mod tests {
         let mut mock_db = MockSimDb::new();
 
         mock_db.expect_get_indexes().returning({
-            move |tx| {
+            move |_, tx| {
                 async move {
                     let index = || DbCustomIndex {
                         keyspace: "ks".to_string().into(),
@@ -857,11 +886,11 @@ mod tests {
 
         // all indexes are valid
         set_valid_indexes(vec![true, true, true]);
-        assert!(get_indexes(&db).await.is_ok());
+        assert!(get_indexes(&db, None).await.is_ok());
 
         // second index is invalid
         set_valid_indexes(vec![true, false, true]);
-        assert!(get_indexes(&db).await.is_err());
+        assert!(get_indexes(&db, None).await.is_err());
     }
 
     #[rstest]
@@ -874,7 +903,7 @@ mod tests {
         // an unrelated schema change.
         let mut mock_db = MockSimDb::new();
 
-        mock_db.expect_get_indexes().returning(move |tx| {
+        mock_db.expect_get_indexes().returning(move |_, tx| {
             async move {
                 tx.send(Ok(vec![DbCustomIndex {
                     keyspace: "ks".to_string().into(),
@@ -904,13 +933,127 @@ mod tests {
 
         let db = db::tests::new(mock_db);
 
-        assert!(get_indexes(&db).await.is_err());
+        assert!(get_indexes(&db, None).await.is_err());
+    }
+
+    #[rstest]
+    #[timeout(Duration::from_secs(5))]
+    #[tokio::test]
+    async fn index_is_discovered_when_the_listing_node_lags_behind_the_version() {
+        // Two nodes. `FRESH_NODE` has applied the group0 command that created the
+        // index, `STALE_NODE` has not, and only `FRESH_NODE` reports the version
+        // that command produced. The index listing is node-local: asking
+        // `STALE_NODE` for it omits the index. A round that stores `FRESH_NODE`'s
+        // version while listing `STALE_NODE`'s schema loses the index for good,
+        // because no later tick sees the version change again.
+        const FRESH_NODE: Uuid = Uuid::from_bytes([1; 16]);
+        const STALE_NODE: Uuid = Uuid::from_bytes([2; 16]);
+
+        fn fts_index() -> DbCustomIndex {
+            DbCustomIndex {
+                keyspace: "ks".to_string().into(),
+                index: "fts_idx".to_string().into(),
+                table: "tbl".to_string().into(),
+                primary_key_columns: NonemptyArc::new(["pk"]).unwrap(),
+                partition_key_count: NonZeroUsize::new(1).unwrap(),
+                target_columns: NonemptyArc::new(["content"]).unwrap(),
+                partitioning: DbIndexPartitioning::Global,
+                filtering_columns: Arc::new([]),
+                alternator_attribute_types: Arc::new(BTreeMap::new()),
+                kind: DbIndexKind::FullTextSearch,
+            }
+        }
+        let index_key = fts_index().key();
+
+        let mut mock_db = MockSimDb::new();
+
+        mock_db.expect_latest_schema_version().returning(move |tx| {
+            async move {
+                tx.send(Ok(SchemaVersionSnapshot {
+                    version: Some(CqlTimeuuid::from_bytes([7; 16])),
+                    coordinator: Some(FRESH_NODE),
+                }))
+                .unwrap();
+            }
+            .boxed()
+        });
+
+        mock_db
+            .expect_get_indexes()
+            .returning(move |coordinator, tx| {
+                async move {
+                    let listing = match coordinator {
+                        Some(FRESH_NODE) => vec![fts_index()],
+                        Some(STALE_NODE) | None => Vec::new(),
+                        Some(other) => panic!("unexpected coordinator {other}"),
+                    };
+                    tx.send(Ok(listing)).unwrap();
+                }
+                .boxed()
+            });
+
+        mock_db
+            .expect_get_index_version()
+            .returning(move |_, _, _, tx| {
+                async move {
+                    tx.send(Ok(Some(Uuid::from_bytes([9; 16]).into()))).unwrap();
+                }
+                .boxed()
+            });
+
+        mock_db
+            .expect_get_fts_index_params()
+            .returning(move |_, _, _, tx| {
+                async move {
+                    tx.send(Ok(None)).unwrap();
+                }
+                .boxed()
+            });
+
+        mock_db.expect_is_valid_index().returning(move |_, tx| {
+            async move {
+                tx.send(true).unwrap();
+            }
+            .boxed()
+        });
+
+        let added = Arc::new(Notify::new());
+        let mut mock_engine = MockSimEngine::new();
+        mock_engine.expect_add_index().returning({
+            let added = Arc::clone(&added);
+            move |metadata, tx| {
+                let added = Arc::clone(&added);
+                let expected = index_key.clone();
+                async move {
+                    tx.send(Ok(())).unwrap();
+                    if metadata.key() == expected {
+                        added.notify_waiters();
+                    }
+                }
+                .boxed()
+            }
+        });
+        mock_engine
+            .expect_del_index()
+            .returning(move |_| async move {}.boxed());
+
+        let tx_db = db::tests::new(mock_db);
+        let tx_eng = engine::tests::new(mock_engine);
+        let (tx_ns, _rx_ns) = mpsc::channel(10);
+        let (_config_tx, config_rx) = watch::channel(Arc::new(Config::default()));
+
+        let notified = added.notified();
+        let _monitor = new(tx_db, tx_eng.downgrade(), tx_ns, config_rx)
+            .await
+            .unwrap();
+
+        notified.await;
     }
 
     fn mock_db_with_fts_index(options: Option<IndexOptionsFts>) -> MockSimDb {
         let mut mock_db = MockSimDb::new();
 
-        mock_db.expect_get_indexes().returning(move |tx| {
+        mock_db.expect_get_indexes().returning(move |_, tx| {
             async move {
                 tx.send(Ok(vec![DbCustomIndex {
                     keyspace: "ks".to_string().into(),
@@ -965,7 +1108,7 @@ mod tests {
         };
         let db = db::tests::new(mock_db_with_fts_index(Some(options)));
 
-        let result = get_indexes(&db).await.unwrap();
+        let result = get_indexes(&db, None).await.unwrap();
 
         assert_eq!(result.len(), 1);
         let idx = result.into_iter().next().unwrap();
@@ -977,7 +1120,7 @@ mod tests {
     async fn get_indexes_defaults_fts_options_when_db_has_none() {
         let db = db::tests::new(mock_db_with_fts_index(None));
 
-        let result = get_indexes(&db).await.unwrap();
+        let result = get_indexes(&db, None).await.unwrap();
 
         let idx = result.into_iter().next().unwrap();
         assert_eq!(idx.kind, IndexKind::Fts(IndexOptionsFts::default()));

--- a/crates/vector-store/tests/integration/db_basic.rs
+++ b/crates/vector-store/tests/integration/db_basic.rs
@@ -43,6 +43,7 @@ use vector_store::Timestamp;
 use vector_store::Timestamped;
 use vector_store::Vector;
 use vector_store::db::Db;
+use vector_store::db::SchemaVersionSnapshot;
 use vector_store::db_index::DbIndex;
 use vector_store::node_state::Event;
 use vector_store::node_state::NodeState;
@@ -381,11 +382,14 @@ fn process_db(db: &DbBasic, msg: Db, node_state: Sender<NodeState>) {
             .unwrap(),
 
         Db::LatestSchemaVersion { tx } => tx
-            .send(Ok(Some(db.0.read().unwrap().schema_version)))
+            .send(Ok(SchemaVersionSnapshot {
+                version: Some(db.0.read().unwrap().schema_version),
+                coordinator: None,
+            }))
             .map_err(|_| anyhow!("Db::LatestSchemaVersion: unable to send response"))
             .unwrap(),
 
-        Db::GetIndexes { tx } => {
+        Db::GetIndexes { tx, .. } => {
             if db.0.read().unwrap().simulate_endless_get_indexes_processing {
                 tokio::spawn(async move {
                     let _ = tx;


### PR DESCRIPTION
## Problem

`fts::bm25_boolean_or_query` (VECTOR-905) and `fts::bm25_stop_word_filtering`
(VECTOR-908) fail in the daily validator job with the same panic:

```
Timeout on: the index idx_5 at http://127.0.2.21:6080/api/v1 must be created
```

Both are the same bug. Counting the discovery lines each vector-store node
emits shows the index was never picked up by two of the three nodes — it was
not a slow build:

```
$ grep -ao 'creating the index ksp_[0-9]*\.idx_[0-9]*' ci.log | sort | uniq -c
      3 creating the index ksp_4.idx_4
      1 creating the index ksp_5.idx_5     <-- VECTOR-905
      3 creating the index ksp_6.idx_6
```

VECTOR-908 shows `1 creating the index ksp_9.idx_9`, otherwise identical.

## Root cause

`monitor_indexes` reads the cluster schema version once per tick and skips the
round while that version has not changed, storing the version as soon as it
reads it. The version comes from `system.group0_history`, the listing of
custom indexes from `system_schema.indexes`. Both are node-local, and the
driver routes the two reads independently, so a single round can read them
from two different coordinators.

A group0 command is applied on each node on its own. Under CI load the nodes
drift noticeably — the index-creation transaction in the VECTOR-905 run landed
234 ms apart:

```
00:10:28,396  schema_tables - Altering ksp_5.tbl_5 ...   node 1
00:10:28,401  schema_tables - Altering ksp_5.tbl_5 ...   node 2
00:10:28,630  schema_tables - Altering ksp_5.tbl_5 ...   node 3   (+234 ms)
```

(VECTOR-908: +258 ms.)

A round that reads the version from a node that has applied the `CREATE CUSTOM
INDEX` and the listing from a node that has not completes without error and
without the new index. The stored version is already the post-change one, so
no later tick reads the listing again. The fts tests issue no further DDL
between `create_fts_index` and the wait, so the index stays undiscovered for
the full 60 s timeout.

This is the same failure shape as #568 (`61b90592`, `9e01770a`), which fixed
the *per-index follow-up* reads by failing the round so the caller resets the
version and retries. The top-level listing was never guarded.

## Fix

Report the coordinator that served the schema version and send the index
listing to that same node, so a discovery round is consistent by construction
rather than detectable after the fact.

The invariant becomes: a stored version `V` implies a listing taken at `V` on
some node has been processed. A lagging node now reports its own older
version, which either equals the stored one (round skipped; a later tick finds
the change on another node) or differs from it (round runs against that node's
own consistent listing).

`SingleTargetLoadBalancingPolicy` — which the driver documents for exactly
this case, "useful for queries to node-local system tables" — has an empty
fallback plan, so a pinned node that went away fails the round; the version is
reset and the next tick picks a live node. Failover is preserved.

## Test plan

- [x] New unit test `index_is_discovered_when_the_listing_node_lags_behind_the_version`
      models a fresh/stale node pair. Verified it times out without the fix
      (by reverting the one-line change that threads the coordinator through)
      and passes with it.
- [x] `cargo test --workspace` — 306 + 102 pass, 0 failed.
- [x] `cargo fmt --all --check` and
      `cargo clippy --workspace --all-targets -- -Dwarnings` clean.
- [x] Full validator suite against `scylladb/scylla-nightly:latest` —
      166/166 passed, no timeouts, and every index in the run was discovered
      by all three nodes.

Note on reproduction: the end-to-end race could not be triggered on an
unloaded local cluster (a 40-round probe with per-node pinned sessions
observed no divergence window — schema propagates too fast there). The
diagnosis rests on the CI logs above, and the regression guard is the
deterministic unit test.

## Follow-up, not in this patch

The per-index follow-up reads (`get_index_version`, `get_index_target_type`,
`get_fts_index_params`) still go to driver-chosen nodes. They are safe today
because a missing row fails the round and retries, but pinning them to the
same coordinator would make the whole round coherent and turn those bail paths
into pure safety nets.

Fixes: VECTOR-905
Fixes: VECTOR-908

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zc5zEpHyugPXaLy6CXCXb
