### PR TITLE
benchmark: add IF NOT EXISTS to CREATE

### DIFF
--- a/crates/benchmark/src/db.rs
+++ b/crates/benchmark/src/db.rs
@@ -103,7 +103,7 @@ impl Scylla {
         .query_unpaged(
             format!(
                 "
-                CREATE KEYSPACE {keyspace}
+                CREATE KEYSPACE IF NOT EXISTS {keyspace}
                 WITH replication = {{'class': 'NetworkTopologyStrategy' , 'replication_factor': '{replication_factor}'}}
                 "
             ),
@@ -117,7 +117,7 @@ impl Scylla {
             .query_unpaged(
                 format!(
                     "
-                CREATE TABLE {keyspace}.{table} (
+                CREATE TABLE IF NOT EXISTS {keyspace}.{table} (
                     {BUCKET} bigint,
                     {VECTOR_ID} bigint,
                     {VECTOR} vector<float, {dimension}>,


### PR DESCRIPTION
To check massive update scenario we need to be able to create table, run tests, update table with the same values - so we need conditional table create as we need to use the same build-table command.