### PR TITLE
docs: rewrite releasing.md around the automated release workflow

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,103 +1,163 @@
-# Releasing binaries from vector-store repositiory
+# Releasing Vector Store
 
-## Releasing vector-store
+## TL;DR — cutting a release
 
-Building an architecture other than the host's requires qemu plus docker
-support for emulated builds. See
-https://docs.docker.com/build/building/multi-platform/. You can use
-`scripts/prepare-docker-qemu` script to register qemu handlers in docker
-engine. Building only the host's native architecture doesn't need qemu.
+Almost everything is automated. For a normal GA release `X.Y.Z`:
 
-Release version is based on git annotated tags. You can create a new tag using:
+1. **Push an annotated tag** on the commit you want to release. Tag locally —
+   creating the tag from the GitHub UI produces a *lightweight* tag, which the
+   version machinery ignores (see [Versioning and tags](#versioning-and-tags)):
 
-```bash
-git tag -a X.Y.Z -m "Release version X.Y.Z"
-git push origin X.Y.Z
+   ```bash
+   git tag -a X.Y.Z -m "Release version X.Y.Z"
+   git push origin X.Y.Z
+   ```
+
+2. **Publish a GitHub Release for that existing tag**: *Releases → Draft a new
+   release*, pick `X.Y.Z` from the tag dropdown, write the release notes, leave
+   *Set as a pre-release* **unchecked**, and press *Publish release*.
+
+3. **Watch [Vector Store Release](https://github.com/scylladb/vector-store/actions/workflows/release.yaml).**
+   Publishing starts it. It runs the full validator suite on amd64 and arm64,
+   then pushes the DockerHub tags, builds the AWS/GCP cloud images, opens the
+   version PR in siren, and announces the release on Slack. No manual step is
+   needed for any of that.
+
+4. **Attach the tarballs and SBOMs to the release.** This is the one part the
+   workflow does *not* do — see [Attaching the tarballs and
+   SBOMs](#attaching-the-tarballs-and-sboms-to-the-release).
+
+That is the whole happy path. The rest of this document explains what each step
+does, and how to do any of it by hand.
+
+## Versioning and tags
+
+`Cargo.toml` carries the placeholder `version = "0.0.0-dev"`. The real version
+is derived from git at build time: `scripts/run-with-release-toolchain` runs
+`git describe --dirty` and rewrites the placeholder in a temporary `Cargo.toml`
+/ `Cargo.lock` mounted into the build container, so the source tree is never
+modified.
+
+**The tag must be annotated.** `git describe` without `--tags` only considers
+annotated tags, so a lightweight tag is invisible to it and the build versions
+itself from the *previous* annotated tag instead. This has happened before —
+`1.8.1` was tagged through the GitHub UI:
+
+```
+$ git describe 1.8.1     # lightweight tag created in the GitHub UI
+1.8.0-24-g36c47d7
+$ git describe 1.10.0    # annotated tag pushed from a local checkout
+1.10.0
 ```
 
-GitHub doesn't support creating annotated tags, so you must do them from local
-environment. You can add additional metadata to the tag, for example
-`X.Y.Z-dev` for development releases.
+GitHub cannot create annotated tags, which is why step 1 above pushes the tag
+from a local checkout and step 2 only *points* the release at it.
 
-In GitHub Actions there is a release workflow that builds the release artifacts
-and uploads them to GitHub and DockerHub. It is triggered when a GitHub Release
-is published, or manually via Run workflow with `VECTOR_VERSION`, and runs on
-both amd64 and arm64 runners. Before building artifacts it runs the full
-validator test suite.
+Additional metadata in the tag is allowed — `X.Y.Z-rc0`, `X.Y.Z-dev` — but it
+changes what the workflow does; see the trigger and siren caveats below.
 
-## Manual release
+## What the release workflow does
 
-In case you want to build the release manually, you can use the scripts in
-`scripts/` directory. The scripts are designed to be run from the root of the
-repository.
+[`.github/workflows/release.yaml`](../.github/workflows/release.yaml) — *Vector
+Store Release*.
 
-Script `scripts/run-with-release-toolchain` can create a correct version for
-the `Cargo.toml` file based on annotated tags using `git describe --dirty`.
+### Triggers
 
-To build the release you need to git clone repository and switch to the desired
-version tag. Then from the root of the repository run:
+- **`release: [released]`** — publishing a GitHub Release. Note this activity
+  type does *not* fire for a **pre-release**: publishing a release with *Set as
+  a pre-release* ticked runs nothing (un-ticking it later does fire the
+  workflow). Draft releases do not fire it either.
+- **`workflow_dispatch`** with a `VECTOR_VERSION` input (the git tag to build
+  from) — for re-runs, and for building a tag without publishing a release.
+
+Both paths set `VECTOR_VERSION`, and every job that checks out sources does so
+at that tag rather than at the branch head.
+
+### Jobs
+
+| Job | What it does |
+| --- | --- |
+| `release-get-scylla-nightly-digest` | Pins ScyllaDB to the last **known-good** `scylla-nightly` digest recorded by the Daily workflow (`use-latest-scylla-nightly: false`), not to whatever `latest` currently is. |
+| `release-build-validator`, `release-build-vector-store` | Build the validator and the `vector-store` binary with the release toolchain, natively on amd64 (`ubuntu-latest`) and arm64 (`ubuntu-24.04-arm`). |
+| `release-get-validator-test-list`, `release-run-validator-tests` | Run the full validator suite, one job per test case × architecture. **The release is gated on this** — nothing is published if it fails. |
+| `release-build-docker-archive-sbom` | Per architecture: builds the docker image, the `tar.gz`, and the Cargo + docker SBOMs, and uploads them as *workflow artifacts*. |
+| `push-docker` | Pushes `scylladb/vector-store:X.Y.Z-amd64` and `-arm64` to DockerHub and combines them into the multi-arch `scylladb/vector-store:X.Y.Z`. |
+| `build-cloud-images` | Packer-builds the AWS AMIs (amd64 + arm64) and the GCP image, and attaches the packer manifest to the release. |
+| `trigger-siren` | Dispatches the version PR to scylladb/siren (GA versions only). |
+| `announce` | Posts to the Slack `#release-announce` channel. |
+
+### What ends up where
+
+Automatically:
+
+- **DockerHub** — `scylladb/vector-store:X.Y.Z` (multi-arch) plus the
+  `X.Y.Z-amd64` / `X.Y.Z-arm64` per-arch tags.
+- **AWS / GCP** — the AMIs and the GCE image.
+- **GitHub Release assets** — only `vector-store-cloud-images-X.Y.Z.json`, the
+  packer manifest. That step is guarded on the `release` trigger, so a
+  `workflow_dispatch` run does not attach it.
+- **Workflow artifacts** on the run page — the release tarballs
+  (`vector-store-X.Y.Z-<arch>`), the SBOMs (`vector-store-sboms-X.Y.Z`), the
+  saved docker images, and the packer manifest.
+- **scylladb/siren** — the `versions.yaml` PR, for GA versions.
+- **Slack** — the `#release-announce` message.
+
+Manually, after the workflow is green:
+
+- **GitHub Release assets** — the `tar.gz` archives and the SBOM files, see
+  below.
+- **Release notes** — written by hand when drafting the release.
+
+## Attaching the tarballs and SBOMs to the release
+
+The workflow builds the tarballs and SBOMs but only keeps them as workflow
+artifacts; it never attaches them to the GitHub Release. Someone has to upload
+them.
+
+The cheapest way is to reuse what the workflow already built: from the run page
+download the `vector-store-X.Y.Z-amd64`, `vector-store-X.Y.Z-arm64` and
+`vector-store-sboms-X.Y.Z` artifacts, unpack them, and upload:
 
 ```bash
+gh release upload X.Y.Z \
+    vector-store-X.Y.Z-amd64.tar.gz \
+    vector-store-X.Y.Z-arm64.tar.gz \
+    vector-store-X.Y.Z.cdx.json \
+    vector-store-docker-X.Y.Z-amd64.cdx.json \
+    vector-store-docker-X.Y.Z-arm64.cdx.json \
+    --clobber
+```
+
+Alternatively, build the release locally and let the script find the files:
+
+```bash
+git checkout X.Y.Z
 ./scripts/build-release
-```
-
-This will create a tar.gz release in the `target/{amd64,arm64}/release`
-directories and per-architecture docker images. The script optionally accepts a subset of
-architectures to build as arguments (e.g. `./scripts/build-release arm64`).
-Building an architecture matching the host doesn't need qemu — this is how
-the release workflow builds each architecture natively on its own per-arch
-runner. Building a non-native architecture still requires qemu.
-
-No multi-platform docker image is built locally: the default docker driver
-cannot store one in the classic image store. Instead the multi-arch tag is
-assembled registry-side from the pushed per-arch images when uploading:
-
-```bash
-./scripts/upload-dockers
-```
-
-This pushes the per-arch images and then combines them into the multi-arch
-tag with `docker buildx imagetools create`, so the tag lists exactly the two
-architectures:
-
-```
-Manifests:
-  linux/amd64
-  linux/arm64
-```
-
-Two details are deliberate here. The per-arch images are combined *by the
-digest of their `linux/<arch>` manifest*, not by their tags, because buildx
-attaches a provenance attestation to each build: that makes even a
-single-platform image an index bundling the image with an extra
-`unknown/unknown` manifest, and combining the tags directly would copy those
-into the multi-arch tag as well. The attestations remain available on the
-per-arch tags (`docker buildx imagetools inspect --format '{{json
-.Provenance}}' scylladb/vector-store:{version}-amd64`), they are just not
-carried into the combined tag.
-
-The combining also uses `imagetools` rather than `docker manifest create`,
-because the latter refuses a source image that is itself an index and fails
-with `<image> is a manifest list`.
-
-The build script also generates SBOM files in CycloneDX JSON format:
-- `vector-store-{version}.cdx.json` — Cargo dependencies SBOM generated by
-  `cargo-cyclonedx`
-- `vector-store-docker-{version}-{arch}.cdx.json` — per-architecture Docker
-  image SBOM generated by `syft`, covering OS-level packages from the base
-  image (one per architecture: amd64, arm64)
-
-After building the release you ought to update the release notes in GitHub and
-upload the tar.gz files and both SBOM files to the release. You can use the
-upload script to do this:
-
-```bash
 ./scripts/upload-release
 ```
 
-This will upload all tar.gz archives and SBOM files to the GitHub release
-matching the current version tag. It requires the `gh` CLI to be installed and
-authenticated.
+`scripts/upload-release` derives the version the same way the build does
+(`git describe` on a clean tree, so check out the tag first), expects the
+tarballs under `target/<arch>/release/` and both SBOM kinds in the repository
+root, verifies each one is present, and uploads them with `gh release upload
+--clobber`. `scripts/build-release` builds both architectures, so on a single
+host this needs qemu for the non-native one — the artifact route above avoids
+that.
+
+## Re-running parts of a release
+
+Individual jobs can be re-run from the workflow run page, and the pipeline is
+split so that the expensive steps do not have to be repeated:
+
+- `push-docker` consumes the saved docker images as artifacts, so it re-runs
+  without rebuilding them.
+- `trigger-siren` re-reads the packer manifest artifact of the same run, so a
+  failed dispatch does not mean rebuilding the cloud images.
+
+To build a tag without publishing a GitHub Release — a dry run, or a `X.Y.Z-dev`
+build — start the workflow via *Run workflow* and pass the tag as
+`VECTOR_VERSION`. Remember that such a run attaches no release asset, and that
+`trigger-siren` skips any non-GA version.
 
 ## Registering the release in siren
 
@@ -138,7 +198,82 @@ started via `workflow_dispatch` uploads no release asset, so download the
 instead. In the manifest the AWS `artifact_id` is a comma-separated
 `region:ami` list — use the AMI from the `us-east-1` entry.
 
+## Building a release by hand
+
+You should not need this for a normal release — it is here for debugging the
+release pipeline, and for building artifacts outside CI.
+
+The scripts are designed to be run from the root of the repository, on a clean
+checkout of the version tag: `scripts/build-release` refuses to run with a dirty
+working tree, because `git describe --dirty` would stamp the artifacts with a
+`-dirty` version.
+
+```bash
+git checkout X.Y.Z
+./scripts/build-release
+```
+
+This builds the binaries for both architectures, then the per-architecture
+docker images (`scripts/build-dockers`), the `tar.gz` archives and the SBOMs
+(`scripts/generate-archive-sbom`). Archives land in
+`target/{amd64,arm64}/release`, SBOMs in the repository root. The script accepts
+a subset of architectures as arguments, e.g. `./scripts/build-release arm64`.
+
+Building an architecture other than the host's requires qemu plus docker support
+for emulated builds; see
+https://docs.docker.com/build/building/multi-platform/, and
+`scripts/prepare-docker-qemu` to register the qemu handlers with the docker
+engine. Building only the host's native architecture needs no qemu — that is how
+the release workflow builds each architecture, natively on its own per-arch
+runner.
+
+The SBOMs are CycloneDX JSON:
+
+- `vector-store-{version}.cdx.json` — Cargo dependencies, generated by
+  `cargo-cyclonedx`
+- `vector-store-docker-{version}-{arch}.cdx.json` — per-architecture docker
+  image SBOM generated by `syft`, covering OS-level packages from the base image
+
+### Pushing the docker images
+
+No multi-platform docker image is built locally: the default docker driver
+cannot store one in the classic image store. Instead the multi-arch tag is
+assembled registry-side from the pushed per-arch images:
+
+```bash
+./scripts/upload-dockers
+```
+
+This pushes the per-arch images and then combines them into the multi-arch
+tag with `docker buildx imagetools create`, so the tag lists exactly the two
+architectures:
+
+```
+Manifests:
+  linux/amd64
+  linux/arm64
+```
+
+Two details are deliberate here. The per-arch images are combined *by the
+digest of their `linux/<arch>` manifest*, not by their tags, because buildx
+attaches a provenance attestation to each build: that makes even a
+single-platform image an index bundling the image with an extra
+`unknown/unknown` manifest, and combining the tags directly would copy those
+into the multi-arch tag as well. The attestations remain available on the
+per-arch tags (`docker buildx imagetools inspect --format '{{json
+.Provenance}}' scylladb/vector-store:{version}-amd64`), they are just not
+carried into the combined tag.
+
+The combining also uses `imagetools` rather than `docker manifest create`,
+because the latter refuses a source image that is itself an index and fails
+with `<image> is a manifest list`.
+
+The release workflow's `push-docker` job does the same thing inline, on the
+images built by the previous job.
+
 ### Prerequisites
+
+Only needed for the manual path — CI installs its own tooling.
 
 - Docker; qemu support is needed only when building a non-native
   architecture (see `scripts/prepare-docker-qemu`)
@@ -150,3 +285,16 @@ instead. In the manifest the AWS `artifact_id` is a comma-separated
 - `cargo-cyclonedx` installed (`cargo install cargo-cyclonedx`)
 - `syft` installed (see https://github.com/anchore/syft)
 - `gh` CLI installed and authenticated (see https://cli.github.com/)
+
+A rust toolchain on the host is not required:
+`scripts/run-with-release-toolchain` runs cargo inside the
+`rust:<channel>-bookworm` image matching `rust-toolchain.toml`.
+
+## After the release
+
+- Verify the siren `versions.yaml` PR appeared and looks right, then get it
+  merged.
+- Bump the pinned `scylladb/vector-store` image in
+  `docs/examples/docker/docker-compose.yml` and
+  `docker-compose-alternator.yml`, so the quick-start examples run the current
+  release.


### PR DESCRIPTION
### Motivation

`docs/releasing.md` predated most of the release automation. It described the
whole GitHub Actions pipeline in a single paragraph and led with the manual
qemu/docker build, so the easiest way to cut a release was the hardest thing to
find in the document.

It was also wrong on one point. The doc claimed the release workflow "builds the
release artifacts and uploads them to GitHub and DockerHub" — it does not upload
them to GitHub. The tarballs and SBOMs are only kept as *workflow artifacts*;
the only asset the workflow attaches to the release is the packer manifest. On
[1.10.0](https://github.com/scylladb/vector-store/releases/tag/1.10.0) the
tarballs and SBOMs were uploaded by hand three days after the release was
published, which matches the code but not the document.

### What this does

Restructures the document so the automated path comes first, and fixes what was
inaccurate or missing:

- **Adds a TL;DR**: push an annotated tag → publish a GitHub Release for that
  existing tag → watch the workflow → attach the tarballs and SBOMs.
- **Documents the workflow itself**: both triggers, the job graph, the validator
  gate, that ScyllaDB is pinned to the last *known-good* `scylla-nightly` digest
  rather than `latest`, and a table of what lands in DockerHub, AWS/GCP, the
  release assets, the workflow artifacts, siren and Slack.
- **Separates automated from manual**, and describes both ways of attaching the
  tarballs and SBOMs: reusing the run's artifacts (no local build), or
  `build-release` + `upload-release`.
- **Notes that `release: [released]` does not fire for a pre-release** — ticking
  *Set as a pre-release* silently runs nothing.
- **Explains why the tag must be annotated**, with the concrete failure mode.
  `git describe` without `--tags` ignores lightweight tags, so the `1.8.1` tag
  created through the GitHub UI describes as `1.8.0-24-g36c47d7`:

  ```
  $ git describe 1.8.1     # lightweight tag created in the GitHub UI
  1.8.0-24-g36c47d7
  $ git describe 1.10.0    # annotated tag pushed from a local checkout
  1.10.0
  ```

  (there is also a stray `1.6.0-1-gb445d01` tag in the repo that looks like the
  same mistake)
- **Adds a section on re-running individual jobs** (`push-docker` and
  `trigger-siren` both re-run without rebuilding), and an after-the-release
  checklist (siren PR, docker-compose example pins).
- **Keeps** the manual build path, the imagetools/provenance rationale and the
  siren details — accurate as written, moved below the automated flow.

Documentation only; no code, workflow or script changes.

### Test plan

- [x] Every claim checked against `.github/workflows/release.yaml`, the reusable
      workflows it calls, and `scripts/{build,upload}-{release,dockers}`,
      `generate-archive-sbom`, `run-with-release-toolchain`
- [x] The "not attached automatically" finding verified against the 1.10.0
      release assets: the tarballs and SBOMs were uploaded by a user, only
      `vector-store-cloud-images-1.10.0.json` by `github-actions[bot]`
- [x] The `git describe` outputs in the doc reproduced against the real tags
- [ ] Reviewer sanity-check of the TL;DR against how the last release was
      actually cut

### Notes for the reviewer

- No `Fixes:`/`Refs: VECTOR-<n>` line — I don't have a ticket for this. Happy to
  add one and amend.
- Nothing in the repo links to `docs/releasing.md` (the README's docs list
  doesn't mention it). Left out of scope here, but a one-line link would help
  discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFQA9FNroY9CWe6cbSHAa2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFQA9FNroY9CWe6cbSHAa2)_