### PR TITLE
ci: improve SIREN_REPO_TOKEN validation and error messaging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -343,10 +343,33 @@ jobs:
             echo "${var}=${!var}" >> "$GITHUB_OUTPUT"
           done
 
+      - name: Check the siren token is set
+        if: steps.ga.outputs.ga == 'true'
+        env:
+          SIREN_REPO_TOKEN: ${{ secrets.SIREN_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          # An unset secret expands to the empty string and the dispatch then
+          # fails on `Bad credentials`, which reads like a broken token rather
+          # than a missing one. The usual cause is the value having been added
+          # under Settings > Secrets and variables > Actions on the
+          # *Variables* tab: `secrets.` cannot see repository variables.
+          if [[ -z "${SIREN_REPO_TOKEN:-}" ]] ; then
+            echo "::error::SIREN_REPO_TOKEN is empty — it must be an Actions secret (not a repository variable) in scylladb/vector-store; see docs/releasing.md"
+            exit 1
+          fi
+
       - name: Trigger the siren add-vectorstore-ver workflow
+        id: dispatch
         if: steps.ga.outputs.ga == 'true'
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
+          # The credential must be allowed to POST /repos/scylladb/siren/
+          # dispatches: a fine-grained PAT owned by scylladb, listing
+          # scylladb/siren among its repositories, approved by the org and
+          # granting `Contents: read and write`. Contents is what the
+          # repository-dispatch endpoint checks — `Actions: write` grants only
+          # workflow_dispatch and is rejected here. Provisioned in VECTOR-854.
           token: ${{ secrets.SIREN_REPO_TOKEN }}
           repository: scylladb/siren
           event-type: vectorstore-release
@@ -357,6 +380,27 @@ jobs:
               "gcp_amd64_image": "${{ steps.images.outputs.gcp_amd64_image }}",
               "aws_arm64_ami": "${{ steps.images.outputs.aws_arm64_ami }}"
             }
+
+      # GitHub rejects an under-privileged token with a message that names
+      # neither the repository nor the permission it wanted, so say which
+      # token is at fault and what it needs.
+      - name: Explain a rejected dispatch
+        if: failure() && steps.dispatch.conclusion == 'failure'
+        run: |
+          set -euo pipefail
+          {
+            echo "The \`vectorstore-release\` dispatch to scylladb/siren was rejected."
+            echo ""
+            echo "\`Resource not accessible by personal access token\` means the"
+            echo "\`SIREN_REPO_TOKEN\` secret reached scylladb/siren but is not allowed to"
+            echo "dispatch there: it needs the \`Contents: read and write\` repository"
+            echo "permission (not \`Actions: write\`), and a fine-grained token also needs"
+            echo "the organization to have approved it. \`Not Found\` instead means the"
+            echo "token cannot see scylladb/siren at all, and \`Bad credentials\` that it"
+            echo "has expired. None of these are fixed by re-running the job — fix the"
+            echo "token, then re-run \`trigger-siren\` alone (see docs/releasing.md)."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::The dispatch to scylladb/siren was rejected — SIREN_REPO_TOKEN lacks the rights to dispatch; see the job summary and docs/releasing.md"
 
       - name: Log the siren workflow link
         if: steps.ga.outputs.ga == 'true'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -111,6 +111,18 @@ workflow, which opens a `feat(vectorstore): add version X.Y.Z [automation]`
 PR against siren's `info/version/versions.yaml`. No manual step is needed for
 a GA release.
 
+The dispatch is authenticated with the `SIREN_REPO_TOKEN` Actions secret of
+`scylladb/vector-store` (provisioned in VECTOR-854). It must be a *secret*,
+not a repository variable of the same name — `secrets.` cannot read
+variables — and it must hold a credential allowed to
+`POST /repos/scylladb/siren/dispatches`: a fine-grained PAT owned by
+`scylladb`, listing `scylladb/siren` among its repositories, approved by the
+organization, and granting the `Contents: read and write` repository
+permission. `Contents` is the permission GitHub checks for the
+repository-dispatch endpoint; `Actions: write` grants only
+`workflow_dispatch` and is rejected. A PAT also expires, so note its expiry
+and rotate it before a release runs into it.
+
 Two caveats:
 
 - Only GA `X.Y.Z` versions are dispatched. Pre-release and dev tags
@@ -126,8 +138,21 @@ Two caveats:
 
 If the dispatch fails, or the siren run does, the cloud images do not need to
 be rebuilt: re-run just the `trigger-siren` job, which re-reads the packer
-manifest artifact of the same workflow run. To trigger siren fully by hand
-instead, start
+manifest artifact of the same workflow run. A dispatch the GitHub API
+rejects, though, is a token problem and re-running it changes nothing — the
+message says which:
+
+- `Resource not accessible by personal access token` — the token reaches
+  `scylladb/siren` but may not dispatch there: it is missing
+  `Contents: read and write`, or the organization has not approved it.
+- `Not Found` — the token does not have `scylladb/siren` among its
+  repositories at all.
+- `Bad credentials` — the token has expired, or the secret holds something
+  that is not a token.
+
+Fix the token in the organization's settings, then re-run `trigger-siren`.
+
+To trigger siren fully by hand instead, start
 [add-vectorstore-ver](https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml)
 via `workflow_dispatch`, copying the version, the bare `us-east-1` amd64 and
 arm64 AMI IDs, and the GCP image name from the packer manifest. For a release


### PR DESCRIPTION
## Motivation

The first GA release to use the automated siren handoff, 1.11.0, failed in `trigger-siren` with the GitHub API's

```
Resource not accessible by personal access token
```

([run](https://github.com/scylladb/vector-store/actions/runs/34469090804/job/102883602170#step:5:20)).

The `SIREN_REPO_TOKEN` secret is set, and it did reach scylladb/siren — a token that cannot see the repository is answered with `404`, not `403`. The token behind it simply may not dispatch there: `POST /repos/{owner}/{repo}/dispatches` is gated on the `Contents` repository permission, and `Actions: write` — the intuitive grant for "start a workflow in another repository" — covers only `workflow_dispatch`.

Repairing that is a change to the token's grant in the organization's settings, not to this repository. What this PR addresses is that nothing in the tree recorded the requirement, and that the API's message names neither the repository it was refused on nor the permission it wanted. The failure therefore reads like a missing secret, and invites a re-run that cannot succeed.

## Changes

- **Add pre-dispatch token validation**: Check that `SIREN_REPO_TOKEN` is set before attempting the dispatch, with a clear error message explaining that it must be an Actions secret (not a repository variable) and referencing the releasing documentation.

- **Add dispatch failure diagnostics**: When the repository-dispatch call fails, provide detailed explanations of what each GitHub API error message means:
  - `Resource not accessible by personal access token` — token lacks `Contents: read and write` permission or organization approval
  - `Not Found` — token doesn't have `scylladb/siren` in its repository list
  - `Bad credentials` — token has expired or is invalid

- **Update releasing documentation**: Expand `docs/releasing.md` with:
  - Detailed requirements for the `SIREN_REPO_TOKEN` credential (fine-grained PAT, ownership, permissions, organization approval)
  - Explanation of why `Contents: read and write` is required (not `Actions: write`)
  - Guidance on token expiry and rotation
  - Clarification of dispatch failure modes and how to fix them
  - Instructions to fix the token and re-run only the `trigger-siren` job

These changes make it easier to diagnose and resolve token-related issues during releases without requiring re-runs that cannot succeed. The success path is unchanged: a token that may dispatch dispatches exactly as before.

## Test plan

- [x] `release.yaml` parses; the `trigger-siren` step order and `if:` guards verified
- [x] Both new shell steps run locally: an empty token exits 1 with the actionable error, a set token passes silently, and the explainer renders the expected job summary
- [ ] Next GA release (or a re-run of `trigger-siren` on 1.11.0 once the token is fixed) dispatches successfully

Refs: VECTOR-854
Refs: VECTOR-853

https://claude.ai/code/session_01JPFzonL9RQCXzPo7SeHkfc