### PR TITLE
ci: start siren's add-vectorstore-ver via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -278,7 +278,7 @@ jobs:
           asset_content_type: application/json
 
   # Hand the freshly built cloud images over to siren: extract the image IDs
-  # from the packer manifest and send the repository_dispatch that starts
+  # from the packer manifest and start
   # https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml,
   # which opens a versions.yaml PR in scylladb/siren. A separate job consuming
   # the manifest artifact (the push-docker pattern) keeps the dispatch
@@ -345,18 +345,39 @@ jobs:
 
       - name: Trigger the siren add-vectorstore-ver workflow
         if: steps.ga.outputs.ga == 'true'
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
-        with:
-          token: ${{ secrets.SIREN_REPO_TOKEN }}
-          repository: scylladb/siren
-          event-type: vectorstore-release
-          client-payload: |
-            {
-              "version": "${{ env.VECTOR_VERSION }}",
-              "aws_amd64_ami": "${{ steps.images.outputs.aws_amd64_ami }}",
-              "gcp_amd64_image": "${{ steps.images.outputs.gcp_amd64_image }}",
-              "aws_arm64_ami": "${{ steps.images.outputs.aws_arm64_ami }}"
-            }
+        env:
+          GH_TOKEN: ${{ secrets.SIREN_REPO_TOKEN }}
+          AWS_AMD64_AMI: ${{ steps.images.outputs.aws_amd64_ami }}
+          AWS_ARM64_AMI: ${{ steps.images.outputs.aws_arm64_ami }}
+          GCP_AMD64_IMAGE: ${{ steps.images.outputs.gcp_amd64_image }}
+        run: |
+          set -euo pipefail
+          # add-vectorstore-ver accepts both triggers with the same four
+          # values, but they are reached through different endpoints, and
+          # each endpoint checks a different permission of SIREN_REPO_TOKEN:
+          # repository_dispatch needs `Contents: write` on scylladb/siren,
+          # workflow_dispatch `Actions: write`. Use workflow_dispatch, the
+          # narrower of the two — dispatching a release must not come with
+          # the right to write siren's contents.
+          #
+          # Unlike repository_dispatch, workflow_dispatch names the ref to
+          # run on. Ask siren which one that is instead of hardcoding a
+          # branch name that only siren gets to change.
+          ref=$(gh api /repos/scylladb/siren --jq .default_branch)
+          jq -n \
+            --arg ref "${ref}" \
+            --arg version "${VECTOR_VERSION}" \
+            --arg aws_amd64_ami "${AWS_AMD64_AMI}" \
+            --arg aws_arm64_ami "${AWS_ARM64_AMI}" \
+            --arg gcp_amd64_image "${GCP_AMD64_IMAGE}" \
+            '{ref: $ref, inputs: {
+               version: $version,
+               aws_amd64_ami: $aws_amd64_ami,
+               aws_arm64_ami: $aws_arm64_ami,
+               gcp_amd64_image: $gcp_amd64_image
+             }}' \
+            | gh api --method POST --input - \
+              /repos/scylladb/siren/actions/workflows/add-vectorstore-ver.yml/dispatches
 
       - name: Log the siren workflow link
         if: steps.ga.outputs.ga == 'true'
@@ -366,10 +387,10 @@ jobs:
           GCP_AMD64_IMAGE: ${{ steps.images.outputs.gcp_amd64_image }}
         run: |
           set -euo pipefail
-          # repository_dispatch returns 204 with no run id, so the run status
+          # workflow_dispatch returns 204 with no run id, so the run status
           # cannot be reported here — link to the siren workflow page instead.
           {
-            echo "Dispatched \`vectorstore-release\` for \`${VECTOR_VERSION}\` to scylladb/siren:"
+            echo "Started \`add-vectorstore-ver\` for \`${VECTOR_VERSION}\` in scylladb/siren:"
             echo ""
             echo "- \`aws_amd64_ami\`: \`${AWS_AMD64_AMI}\`"
             echo "- \`aws_arm64_ami\`: \`${AWS_ARM64_AMI}\`"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -104,12 +104,12 @@ authenticated.
 The release workflow registers a GA release with siren automatically: after
 `build-cloud-images` uploads the packer manifest, the `trigger-siren` job
 extracts the `us-east-1` amd64/arm64 AMI IDs and the GCP image name from it
-and sends a `vectorstore-release` `repository_dispatch` to scylladb/siren.
-That starts siren's
+and hands them to siren's
 [add-vectorstore-ver](https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml)
-workflow, which opens a `feat(vectorstore): add version X.Y.Z [automation]`
-PR against siren's `info/version/versions.yaml`. No manual step is needed for
-a GA release.
+workflow as a `workflow_dispatch` against siren's default branch. That
+workflow opens a `feat(vectorstore): add version X.Y.Z [automation]` PR
+against siren's `info/version/versions.yaml`. No manual step is needed for a
+GA release.
 
 Two caveats:
 
@@ -119,15 +119,15 @@ Two caveats:
   `defaults.vectorstore` to the dispatched version. For the same reason,
   releasing a patch on an *older* series still moves `defaults.vectorstore`
   back to it — review the siren PR before merging in that case.
-- `repository_dispatch` returns no run id, so the job cannot report the siren
+- `workflow_dispatch` returns no run id, so the job cannot report the siren
   run status. It logs the dispatched image IDs and a link to the siren
   workflow page in its job summary — verify there that the run succeeded and
   the PR appeared.
 
 If the dispatch fails, or the siren run does, the cloud images do not need to
 be rebuilt: re-run just the `trigger-siren` job, which re-reads the packer
-manifest artifact of the same workflow run. To trigger siren fully by hand
-instead, start
+manifest artifact of the same workflow run. To trigger siren by hand
+instead, start the same workflow the same way:
 [add-vectorstore-ver](https://github.com/scylladb/siren/actions/workflows/add-vectorstore-ver.yml)
 via `workflow_dispatch`, copying the version, the bare `us-east-1` amd64 and
 arm64 AMI IDs, and the GCP image name from the packer manifest. For a release


### PR DESCRIPTION
## Motivation

The 1.11.0 release could not hand its cloud images to siren. The dispatch was refused ([run](https://github.com/scylladb/vector-store/actions/runs/34469090804/job/102883602170#step:5:20)):

```
Resource not accessible by personal access token
```

siren's `add-vectorstore-ver` can be started two ways, and both take the same four values — but they are reached through different endpoints, and each endpoint checks a different permission of `SIREN_REPO_TOKEN`:

| trigger | endpoint | permission |
|---|---|---|
| `repository_dispatch` (before) | `POST /repos/{owner}/{repo}/dispatches` | `Contents: write` |
| `workflow_dispatch` (after) | `POST /repos/{owner}/{repo}/actions/workflows/{id}/dispatches` | `Actions: write` |

We were using the first, so the token was being asked for write access to siren's *contents* — the right to push commits to siren — in order to start one workflow there. This asks for the narrower grant instead: announcing a release should not carry the ability to rewrite the repository being announced to.

It is also the likely repair for 1.11.0. `Actions: write` is the intuitive grant to provision for "trigger a workflow in another repository", and a `403` (rather than `404`) tells us the token does reach `scylladb/siren` but lacks what the dispatch endpoint wanted. If that is what it holds, this gets releases dispatching again with no change to the token.

## Changes

- `trigger-siren` now calls the `workflow_dispatch` endpoint with `gh`, which is preinstalled on the runners. No other action covers `workflow_dispatch`, so calling the API directly leaves nothing new to pin and audit, and drops `peter-evans/repository-dispatch`.
- The ref to run on — which `repository_dispatch` did not need — is read from siren's `default_branch` rather than hardcoded, so siren renaming its default branch cannot silently break our releases.
- The four values sent are unchanged, so the GA-only guard and the `defaults.vectorstore` caveat still hold, and a failed dispatch is still re-runnable on its own from the packer manifest artifact.
- `docs/releasing.md` and the job summary say `workflow_dispatch` where they said `repository_dispatch`.

## Needs confirming before merge

**The four `workflow_dispatch` input names are assumed to match the old `client_payload` keys** (`version`, `aws_amd64_ami`, `aws_arm64_ami`, `gcp_amd64_image`). `scylladb/siren` was not readable from the session this was written in, so its `on: workflow_dispatch: inputs:` block could not be checked. If the names differ, the API answers `422 Unexpected inputs provided` — please confirm them against siren's workflow.

## Test plan

- [x] `release.yaml` parses; the step's shell passes `bash -n`
- [x] Step executed locally against a stubbed `gh`: builds the expected body — `{"ref": "master", "inputs": {"version": "1.11.0", "aws_amd64_ami": "ami-0e8e5a026e0ae703a", "aws_arm64_ami": "ami-0fa32fd78fdc8bc56", "gcp_amd64_image": "vector-store-1-11-0-amd64-2026-09-10t01-07-04z"}}` (the real IDs from the 1.11.0 manifest)
- [x] Failure propagation: a rejected dispatch and a failed default-branch lookup each fail the step (`pipefail`), rather than passing silently
- [ ] Input names confirmed against siren's `add-vectorstore-ver.yml`
- [ ] Re-run `trigger-siren` on 1.11.0 and confirm the dispatch returns 204 and the siren PR appears

## Relationship to #600

Independent of [#600](https://github.com/scylladb/vector-store/pull/600), which leaves the call alone and only adds diagnostics and token documentation. Both edit the same region of `release.yaml`, so whichever merges second needs a rebase. If this one lands, #600's text needs `Contents: read and write` changed to `Actions: write` to match.

Refs: VECTOR-854
Refs: VECTOR-853

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPFzonL9RQCXzPo7SeHkfc

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPFzonL9RQCXzPo7SeHkfc)_